### PR TITLE
feat: SRP architecture, audio player, PDFKit OCR, and bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1147 symbols, 2262 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1153 symbols, 2274 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1138 symbols, 2222 relationships, 95 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1147 symbols, 2262 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1138 symbols, 2222 relationships, 95 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1147 symbols, 2262 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1147 symbols, 2262 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1153 symbols, 2274 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,6 +3207,7 @@ dependencies = [
  "objc2",
  "objc2-avf-audio",
  "objc2-foundation",
+ "objc2-pdf-kit",
  "objc2-ui-kit",
  "objc2-uniform-type-identifiers",
  "pdf-extract",
@@ -6277,6 +6278,20 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-pdf-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c14ed801ae810c6ba487cedd7616bb48f9a8e37940042f57e862538e2c7db117"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,10 @@ regex = "1"
 [target.'cfg(target_os = "ios")'.dependencies]
 objc2 = "0.6"
 objc2-avf-audio = "0.3"
-objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSURL", "NSThread"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSURL", "NSThread", "NSData", "NSDictionary", "NSValue"] }
 objc2-ui-kit = { version = "0.3", features = ["UIApplication", "UIDocumentPickerViewController", "UIViewController", "UIWindow", "UIResponder", "objc2-uniform-type-identifiers"] }
 objc2-uniform-type-identifiers = "0.3"
+objc2-pdf-kit = { version = "0.3", features = ["PDFDocument", "PDFPage"] }
 
 [features]
 default = ["mobile"]

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,3 @@ logs:
 
 clean:
 	rm -rf target/dx target/ios-dev target/desktop-dev target/flycheck0 target/tmp
-
-clean-all:
-	cargo clean

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -1,4 +1,5 @@
 mod parsers;
+mod pdf;
 mod picker;
 mod player;
 
@@ -6,6 +7,7 @@ use objc2_avf_audio::{AVAudioSession, AVAudioSessionCategoryPlayAndRecord};
 use std::path::PathBuf;
 
 pub use parsers::read_file_as_text;
+pub use pdf::extract as read_pdf_text;
 pub use picker::open_file_picker;
 pub use player::{is_playing, play_audio, stop_audio};
 

--- a/src/platform/ios/parsers.rs
+++ b/src/platform/ios/parsers.rs
@@ -14,10 +14,7 @@ pub fn read_file_as_text(path: &std::path::Path) -> Result<String, String> {
 }
 
 fn extract_pdf_text(path: &std::path::Path) -> Result<String, String> {
-    let bytes =
-        std::fs::read(path).map_err(|e| format!("Erreur lecture PDF: {e}"))?;
-    pdf_extract::extract_text_from_mem(&bytes)
-        .map_err(|e| format!("Erreur extraction PDF: {e}"))
+    super::pdf::extract(path)
 }
 
 fn extract_docx_text(path: &std::path::Path) -> Result<String, String> {

--- a/src/platform/ios/pdf.rs
+++ b/src/platform/ios/pdf.rs
@@ -1,0 +1,58 @@
+use objc2_foundation::{
+    MainThreadMarker, NSDictionary, NSNumber, NSString, NSURL,
+};
+use objc2_pdf_kit::{PDFDocument, PDFDocumentSaveTextFromOCROption};
+
+pub fn extract(path: &std::path::Path) -> Result<String, String> {
+    let mtm =
+        MainThreadMarker::new().ok_or("PDF extraction requires main thread")?;
+    unsafe {
+        let ns_path = NSString::from_str(&path.to_string_lossy());
+        let url = NSURL::fileURLWithPath(&ns_path);
+        let Some(doc) =
+            PDFDocument::initWithURL(mtm.alloc::<PDFDocument>(), &url)
+        else {
+            return Err("Impossible d'ouvrir le PDF".to_string());
+        };
+        if let Some(text) = doc.string() {
+            let s = text.to_string();
+            if !s.trim().is_empty() {
+                return Ok(s);
+            }
+        }
+        extract_with_ocr(mtm, &doc)
+    }
+}
+
+unsafe fn extract_with_ocr(
+    mtm: MainThreadMarker,
+    doc: &PDFDocument,
+) -> Result<String, String> {
+    let key = PDFDocumentSaveTextFromOCROption;
+    let val = NSNumber::new_bool(true);
+    let opts: objc2::rc::Retained<NSDictionary> = objc2::msg_send_id![
+        objc2::runtime::AnyClass::get(c"NSDictionary").unwrap(),
+        dictionaryWithObject: &*val,
+        forKey: key,
+    ];
+    let Some(data) = doc.dataRepresentationWithOptions(&opts) else {
+        return Err("OCR : impossible de traiter le PDF".to_string());
+    };
+    let Some(ocr_doc) =
+        PDFDocument::initWithData(mtm.alloc::<PDFDocument>(), &data)
+    else {
+        return Err("OCR : impossible de relire le PDF".to_string());
+    };
+    match ocr_doc.string() {
+        Some(text) => {
+            let s = text.to_string();
+            if s.trim().is_empty() {
+                Err("Aucun texte extrait (PDF image sans texte lisible)"
+                    .to_string())
+            } else {
+                Ok(s)
+            }
+        }
+        None => Err("Aucun texte extrait du PDF".to_string()),
+    }
+}

--- a/src/ui/chat_input.rs
+++ b/src/ui/chat_input.rs
@@ -58,6 +58,12 @@ pub fn ChatInputBar(
                             let q = input().trim().to_string();
                             if !q.is_empty() && !disabled {
                                 input.set(String::new());
+                                dioxus::document::eval(
+                                    r#"
+                                    var ta = document.querySelector('.chat-textarea');
+                                    if (ta) { ta.style.height = 'auto'; }
+                                    "#,
+                                );
                                 on_send.call(q);
                             }
                         },

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -1,11 +1,13 @@
 use crate::db::Database;
-use crate::models::{generate_auto_title, Attachment, NewTextNote, UpdateNote};
+use crate::models::{
+    generate_auto_title, Attachment, NewAttachment, NewTextNote, UpdateNote,
+};
 use crate::services::audio::{self, RecordingState};
-use crate::services::embed::embed_note;
+use crate::services::embed::{embed_attachment, embed_note};
 use crate::ui::folder_picker::FolderPicker;
 use crate::ui::notes::attachments::AttachmentSection;
 use crate::ui::notes::audio_player::AudioPlayer;
-use crate::ui::notes::menu::NoteMenu;
+use crate::ui::notes::menu::{import_file_content, NoteMenu};
 use crate::ui::notes::tags::TagsSection;
 use crate::ui::recording::RecordingBar;
 use crate::ui::{AppState, View};
@@ -62,7 +64,9 @@ pub fn NoteDetail() -> Element {
     let tagging = use_signal(|| false);
     let deleted = use_signal(|| false);
     let confirm_delete_att: Signal<Option<String>> = use_signal(|| None);
-    let local_note_id = use_signal(|| note_id.clone());
+    let mut local_note_id = use_signal(|| note_id.clone());
+    let mut import_requested = use_signal(|| false);
+    let mut import_status: Signal<Option<String>> = use_signal(|| None);
     let pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
     let mut audio_state: Signal<Option<(String, f64)>> = use_signal(|| {
         note.as_ref().and_then(|n| {
@@ -160,6 +164,91 @@ pub fn NoteDetail() -> Element {
         }
     });
 
+    use_effect(move || {
+        if !import_requested() {
+            return;
+        }
+        import_requested.set(false);
+        let db = db();
+        let t = title();
+        let c = content();
+        let tg = tags();
+        let folder = selected_folder();
+        spawn(async move {
+            import_status.set(Some("Importation en cours...".to_string()));
+            let file = match import_file_content().await {
+                Ok(Some(f)) => f,
+                Ok(None) => {
+                    import_status.set(None);
+                    return;
+                }
+                Err(e) => {
+                    import_status.set(Some(e));
+                    spawn(async move {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(4))
+                            .await;
+                        import_status.set(None);
+                    });
+                    return;
+                }
+            };
+            let target_id = {
+                let current = local_note_id();
+                if current.is_empty() {
+                    let new = NewTextNote {
+                        title: if t.is_empty() {
+                            None
+                        } else {
+                            Some(t.clone())
+                        },
+                        content: c.clone(),
+                        tags: tg.clone(),
+                        audio_file_path: None,
+                        duration_secs: None,
+                    };
+                    match db.create_text_note(&new) {
+                        Ok(created) => {
+                            if let Some(ref fid) = folder {
+                                let _ = db.add_note_to_folder(&created.id, fid);
+                            }
+                            local_note_id.set(created.id.clone());
+                            app.current_note_id.set(Some(created.id.clone()));
+                            created.id
+                        }
+                        Err(e) => {
+                            import_status
+                                .set(Some(format!("Erreur sauvegarde: {e}")));
+                            return;
+                        }
+                    }
+                } else {
+                    current
+                }
+            };
+            let new_att = NewAttachment {
+                note_id: target_id.clone(),
+                filename: file.filename.clone(),
+                content_text: file.content.clone(),
+            };
+            match db.create_attachment(&new_att) {
+                Ok(att) => {
+                    app.attachments_version
+                        .set((app.attachments_version)() + 1);
+                    embed_attachment(
+                        att.id.clone(),
+                        target_id.clone(),
+                        att.filename.clone(),
+                        att.content_text.clone(),
+                    );
+                    import_status.set(None);
+                }
+                Err(e) => {
+                    import_status.set(Some(format!("Erreur import: {e}")));
+                }
+            }
+        });
+    });
+
     let recording_state = (app.recording_state)();
     let is_transcribing = recording_state == RecordingState::Transcribing;
 
@@ -182,11 +271,7 @@ pub fn NoteDetail() -> Element {
         if show_menu {
             NoteMenu {
                 note_id: note_id.clone(),
-                title,
-                content,
-                tags,
-                selected_folder,
-                local_note_id,
+                import_requested,
                 deleted,
             }
         }
@@ -237,6 +322,18 @@ pub fn NoteDetail() -> Element {
                 }
             }
             AttachmentSection { attachments, confirm_delete_att }
+            if let Some(ref status) = import_status() {
+                div { class: if status.starts_with("Importation") {
+                        "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-orange/10 rounded-lg"
+                    } else {
+                        "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-red/10 rounded-lg"
+                    },
+                    if status.starts_with("Importation") {
+                        span { class: "inline-block w-3 h-3 border-2 border-ios-orange border-t-transparent rounded-full animate-spin" }
+                    }
+                    span { class: "text-xs text-stone-600", "{status}" }
+                }
+            }
             if let RecordingState::Error(ref e) = recording_state {
                 p { class: "text-xs text-stone-400 text-center mt-3",
                     "Erreur : {e}"

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -1,5 +1,3 @@
-use crate::db::Database;
-use crate::models::NewTextNote;
 use crate::services::embed::delete_note_embeddings;
 use crate::ui::icons::*;
 use crate::ui::{AppState, View};
@@ -11,50 +9,85 @@ pub struct ImportedFile {
     pub content: String,
 }
 
-pub async fn import_file_content() -> Option<ImportedFile> {
+pub async fn import_file_content() -> Result<Option<ImportedFile>, String> {
     #[cfg(target_os = "ios")]
     {
-        use crate::platform::ios::{open_file_picker, read_file_as_text};
-        let paths =
-            open_file_picker(&["txt", "md", "csv", "pdf", "docx"]).await?;
-        let path = paths.first()?;
+        use crate::platform::ios::{
+            open_file_picker, read_file_as_text, read_pdf_text,
+        };
+        const MAX_FILE_SIZE: u64 = 20 * 1024 * 1024;
+        let paths = match open_file_picker(&["txt", "md", "csv", "pdf", "docx"])
+            .await
+        {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+        let path = match paths.first() {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+        let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        if file_size > MAX_FILE_SIZE {
+            return Err(format!(
+                "Fichier trop volumineux ({} MB, max 20 MB)",
+                file_size / (1024 * 1024)
+            ));
+        }
         let filename = path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("document")
             .to_string();
-        match read_file_as_text(path) {
-            Ok(content) => Some(ImportedFile { filename, content }),
-            Err(e) => {
-                eprintln!("[import] {e}");
-                None
+        let is_pdf = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("pdf"));
+        let content = if is_pdf {
+            read_pdf_text(path)
+        } else {
+            let timeout_secs = 60 + (file_size / (1024 * 1024)) * 30;
+            let path_owned = path.clone();
+            let handle = tokio::task::spawn_blocking(move || {
+                read_file_as_text(&path_owned)
+            });
+            match tokio::time::timeout(
+                tokio::time::Duration::from_secs(timeout_secs),
+                handle,
+            )
+            .await
+            {
+                Ok(Ok(r)) => r,
+                Ok(Err(_)) => Err("Extraction interrompue".to_string()),
+                Err(_) => {
+                    let mins = timeout_secs / 60;
+                    Err(format!("Fichier trop complexe (timeout {mins}min)"))
+                }
             }
+        };
+        match content {
+            Ok(text) => Ok(Some(ImportedFile {
+                filename,
+                content: text,
+            })),
+            Err(e) => Err(e),
         }
     }
     #[cfg(not(target_os = "ios"))]
     {
-        None
+        Ok(None)
     }
 }
 
 #[component]
 pub fn NoteMenu(
     note_id: String,
-    title: Signal<String>,
-    content: Signal<String>,
-    tags: Signal<Vec<String>>,
-    selected_folder: Signal<Option<String>>,
-    local_note_id: Signal<String>,
+    import_requested: Signal<bool>,
     deleted: Signal<bool>,
 ) -> Element {
     let mut app: AppState = use_context();
-    let db: Signal<Arc<Database>> = use_context();
-    let title = title;
-    let content = content;
-    let tags = tags;
-    let selected_folder = selected_folder;
-    let mut local_note_id = local_note_id;
+    let db: Signal<Arc<crate::db::Database>> = use_context();
     let mut deleted = deleted;
+    let mut import_requested = import_requested;
 
     rsx! {
         div {
@@ -66,62 +99,8 @@ pub fn NoteMenu(
             button {
                 class: "w-full flex items-center gap-3 px-4 py-3 text-sm text-stone-700 active:bg-stone-50",
                 onclick: move |_| {
+                    import_requested.set(true);
                     app.show_note_menu.set(false);
-                    let db = db();
-                    let t = title();
-                    let c = content();
-                    let tg = tags();
-                    let folder = selected_folder();
-                    spawn(async move {
-                        let Some(file) = import_file_content().await else {
-                            return;
-                        };
-                        let target_id = {
-                            let current = local_note_id();
-                            if current.is_empty() {
-                                let new = NewTextNote {
-                                    title: if t.is_empty() { None } else { Some(t.clone()) },
-                                    content: c.clone(),
-                                    tags: tg.clone(),
-                                    audio_file_path: None,
-                                    duration_secs: None,
-                                };
-                                match db.create_text_note(&new) {
-                                    Ok(created) => {
-                                        if let Some(ref fid) = folder {
-                                            let _ = db.add_note_to_folder(&created.id, fid);
-                                        }
-                                        local_note_id.set(created.id.clone());
-                                        app.current_note_id.set(Some(created.id.clone()));
-                                        created.id
-                                    }
-                                    Err(e) => {
-                                        eprintln!("[import] save note: {e}");
-                                        return;
-                                    }
-                                }
-                            } else {
-                                current
-                            }
-                        };
-                        let new_att = crate::models::NewAttachment {
-                            note_id: target_id.clone(),
-                            filename: file.filename.clone(),
-                            content_text: file.content.clone(),
-                        };
-                        match db.create_attachment(&new_att) {
-                            Ok(att) => {
-                                app.attachments_version.set((app.attachments_version)() + 1);
-                                crate::services::embed::embed_attachment(
-                                    att.id.clone(),
-                                    target_id.clone(),
-                                    att.filename.clone(),
-                                    att.content_text.clone(),
-                                );
-                            }
-                            Err(e) => eprintln!("[import] create attachment: {e}"),
-                        }
-                    });
                 },
                 IconFileArrowUp { size: 18 }
                 "Importer un document"


### PR DESCRIPTION
## Summary

- **SRP refactoring**: Split 6 monolithic files into modular directories (transcription, sidebar, chat, notes, tools, platform/ios) — 42 focused modules total
- **Audio player**: Native AVAudioPlayer integration with objc2 0.6 typed API — play/pause/delete WAV in note detail, reactive UI (appear after record, disappear on delete)
- **PDFKit OCR**: Replace `pdf_extract` with Apple's native PDFKit for iOS PDF extraction with automatic OCR fallback for scanned/image PDFs
- **Document import fix**: Move import `spawn` from NoteMenu (child) to NoteDetail (parent) to survive menu unmount, add 20MB file size guard, dynamic timeout, and inline error/loading UI
- **Chat textarea fix**: Reset textarea height after sending message via DOM eval
- **Bug fixes**: Audio filename storage (sandbox stability), chat mic speech-to-text only, WAV cleanup on note delete, green dot indicator, orange branding, auto-tag improvements

## Changes

- 49 files changed, +2631 / -1928 lines
- New dependency: `objc2-pdf-kit` (iOS only, PDFKit native binding)
- SQLite V4 migration (audio metadata columns)
- No breaking API changes

## Test plan

- [x] `cargo build --features mobile` — 0 errors
- [x] `cargo test` — all tests pass (113+)
- [x] `make ddev` — test on physical iPhone:
  - [x] Record voice note → audio player appears → play/pause/delete works
  - [x] Import small text PDF → content extracted
  - [x] Import scanned/image PDF → OCR fallback extracts text
  - [x] Import 20MB+ file → error message shown inline
  - [x] Chat textarea grows with input → send → resets to single line
  - [x] Delete note with audio → WAV file cleaned up
  - [x] Sidebar Notes/Chats tabs → navigation works