### PR TITLE
feat: multi-audio, chat scope, transcription, hybrid search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SONIOX_API_KEY=your_soniox_api_key
+OPENAI_API_KEY=your_openai_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1259 symbols, 2476 relationships, 105 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1272 symbols, 2504 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1259 symbols, 2476 relationships, 105 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1272 symbols, 2504 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/db/note_repo.rs
+++ b/src/db/note_repo.rs
@@ -207,6 +207,16 @@ impl Database {
         Ok(())
     }
 
+    pub fn has_any_audio(&self, note_id: &str) -> bool {
+        self.conn()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM note_audios WHERE note_id = ?1)",
+                [note_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .unwrap_or(false)
+    }
+
     pub fn delete_audio(&self, id: &str) -> Result<(), String> {
         self.conn()
             .execute("DELETE FROM note_audios WHERE id = ?1", [id])

--- a/src/db/note_repo.rs
+++ b/src/db/note_repo.rs
@@ -27,6 +27,7 @@ fn row_to_note_audio(row: &rusqlite::Row) -> rusqlite::Result<NoteAudio> {
         note_id: row.get("note_id")?,
         file_path: row.get("file_path")?,
         duration_secs: row.get("duration_secs")?,
+        transcription: row.get("transcription")?,
         created_at: row.get("created_at")?,
     })
 }
@@ -172,6 +173,7 @@ impl Database {
             note_id: note_id.to_string(),
             file_path: file_path.to_string(),
             duration_secs: Some(duration_secs),
+            transcription: None,
             created_at: now,
         })
     }
@@ -189,6 +191,20 @@ impl Database {
             audios.push(row.map_err(|e| format!("Row: {e}"))?);
         }
         Ok(audios)
+    }
+
+    pub fn set_audio_transcription(
+        &self,
+        audio_id: &str,
+        text: &str,
+    ) -> Result<(), String> {
+        self.conn()
+            .execute(
+                "UPDATE note_audios SET transcription = ?1 WHERE id = ?2",
+                rusqlite::params![text, audio_id],
+            )
+            .map_err(|e| format!("Update transcription: {e}"))?;
+        Ok(())
     }
 
     pub fn delete_audio(&self, id: &str) -> Result<(), String> {

--- a/src/db/note_repo.rs
+++ b/src/db/note_repo.rs
@@ -1,5 +1,5 @@
 use crate::db::{now_iso, Database};
-use crate::models::{NewTextNote, Note, NoteType, UpdateNote};
+use crate::models::{NewTextNote, Note, NoteAudio, NoteType, UpdateNote};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -18,6 +18,16 @@ fn row_to_note(row: &rusqlite::Row) -> rusqlite::Result<Note> {
         tags,
         created_at: row.get("created_at")?,
         modified_at: row.get("modified_at")?,
+    })
+}
+
+fn row_to_note_audio(row: &rusqlite::Row) -> rusqlite::Result<NoteAudio> {
+    Ok(NoteAudio {
+        id: row.get("id")?,
+        note_id: row.get("note_id")?,
+        file_path: row.get("file_path")?,
+        duration_secs: row.get("duration_secs")?,
+        created_at: row.get("created_at")?,
     })
 }
 
@@ -135,33 +145,6 @@ impl Database {
         Ok(())
     }
 
-    pub fn update_audio_metadata(
-        &self,
-        id: &str,
-        audio_file_path: &str,
-        duration_secs: f64,
-    ) -> Result<(), String> {
-        let now = now_iso();
-        self.conn()
-            .execute(
-                "UPDATE notes SET audio_file_path = ?1, duration_secs = ?2, modified_at = ?3 WHERE id = ?4",
-                rusqlite::params![audio_file_path, duration_secs, now, id],
-            )
-            .map_err(|e| format!("Update audio: {e}"))?;
-        Ok(())
-    }
-
-    pub fn clear_audio_metadata(&self, id: &str) -> Result<(), String> {
-        let now = now_iso();
-        self.conn()
-            .execute(
-                "UPDATE notes SET audio_file_path = NULL, duration_secs = NULL, modified_at = ?1 WHERE id = ?2",
-                rusqlite::params![now, id],
-            )
-            .map_err(|e| format!("Clear audio: {e}"))?;
-        Ok(())
-    }
-
     pub fn delete_note(&self, id: &str) -> Result<(), String> {
         self.conn()
             .execute("DELETE FROM notes WHERE id = ?1", [id])
@@ -169,10 +152,56 @@ impl Database {
         Ok(())
     }
 
+    pub fn add_audio(
+        &self,
+        note_id: &str,
+        file_path: &str,
+        duration_secs: f64,
+    ) -> Result<NoteAudio, String> {
+        let id = Uuid::new_v4().to_string();
+        let now = now_iso();
+        self.conn()
+            .execute(
+                "INSERT INTO note_audios (id, note_id, file_path, duration_secs, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![id, note_id, file_path, duration_secs, now],
+            )
+            .map_err(|e| format!("Insert audio: {e}"))?;
+        Ok(NoteAudio {
+            id,
+            note_id: note_id.to_string(),
+            file_path: file_path.to_string(),
+            duration_secs: Some(duration_secs),
+            created_at: now,
+        })
+    }
+
+    pub fn list_audios(&self, note_id: &str) -> Result<Vec<NoteAudio>, String> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare("SELECT * FROM note_audios WHERE note_id = ?1 ORDER BY created_at ASC")
+            .map_err(|e| format!("Prepare: {e}"))?;
+        let rows = stmt
+            .query_map([note_id], row_to_note_audio)
+            .map_err(|e| format!("Query: {e}"))?;
+        let mut audios = Vec::new();
+        for row in rows {
+            audios.push(row.map_err(|e| format!("Row: {e}"))?);
+        }
+        Ok(audios)
+    }
+
+    pub fn delete_audio(&self, id: &str) -> Result<(), String> {
+        self.conn()
+            .execute("DELETE FROM note_audios WHERE id = ?1", [id])
+            .map_err(|e| format!("Delete audio: {e}"))?;
+        Ok(())
+    }
+
     pub fn all_audio_paths(&self) -> Result<Vec<String>, String> {
         let conn = self.conn();
         let mut stmt = conn
-            .prepare("SELECT audio_file_path FROM notes WHERE audio_file_path IS NOT NULL")
+            .prepare("SELECT file_path FROM note_audios")
             .map_err(|e| format!("Prepare: {e}"))?;
         let rows = stmt
             .query_map([], |row| row.get::<_, String>(0))
@@ -209,7 +238,19 @@ impl Database {
         }
     }
 
-    /// Kept for future use (tag analytics, suggestions, UI)
+    pub fn delete_all_audios(&self, audio_dir: &str) -> Result<usize, String> {
+        let paths = self.all_audio_paths().unwrap_or_default();
+        let dir = std::path::Path::new(audio_dir);
+        for p in &paths {
+            let _ = std::fs::remove_file(dir.join(p));
+        }
+        let count = paths.len();
+        self.conn()
+            .execute("DELETE FROM note_audios", [])
+            .map_err(|e| format!("Delete all audios: {e}"))?;
+        Ok(count)
+    }
+
     pub fn list_all_tags(&self) -> Vec<String> {
         let notes = self.list_notes().unwrap_or_default();
         let mut tags: Vec<String> =

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -3,6 +3,7 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     (2, V2_SCHEMA),
     (3, V3_SCHEMA),
     (4, V4_SCHEMA),
+    (5, V5_SCHEMA),
 ];
 
 const V1_SCHEMA: &str = "
@@ -97,3 +98,23 @@ CREATE INDEX IF NOT EXISTS idx_attachments_note
 ";
 
 const V4_SCHEMA: &str = "";
+
+const V5_SCHEMA: &str = "
+CREATE TABLE IF NOT EXISTS note_audios (
+    id TEXT PRIMARY KEY,
+    note_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    duration_secs REAL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_note_audios_note ON note_audios(note_id);
+
+INSERT INTO note_audios (id, note_id, file_path, duration_secs, created_at)
+SELECT lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' ||
+       substr(hex(randomblob(2)),2) || '-' ||
+       substr('89ab', abs(random()) % 4 + 1, 1) ||
+       substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+       id, audio_file_path, duration_secs, created_at
+FROM notes WHERE audio_file_path IS NOT NULL;
+";

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -4,6 +4,7 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     (3, V3_SCHEMA),
     (4, V4_SCHEMA),
     (5, V5_SCHEMA),
+    (6, V6_SCHEMA),
 ];
 
 const V1_SCHEMA: &str = "
@@ -117,4 +118,8 @@ SELECT lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' ||
        substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
        id, audio_file_path, duration_secs, created_at
 FROM notes WHERE audio_file_path IS NOT NULL;
+";
+
+const V6_SCHEMA: &str = "
+ALTER TABLE note_audios ADD COLUMN transcription TEXT;
 ";

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,4 +6,7 @@ pub mod note;
 pub use attachment::*;
 pub use conversation::*;
 pub use folder::*;
-pub use note::*;
+pub use note::{
+    generate_auto_title, is_auto_title, NewTextNote, Note, NoteAudio, NoteType,
+    UpdateNote,
+};

--- a/src/models/note.rs
+++ b/src/models/note.rs
@@ -106,5 +106,6 @@ pub struct NoteAudio {
     pub note_id: String,
     pub file_path: String,
     pub duration_secs: Option<f64>,
+    pub transcription: Option<String>,
     pub created_at: String,
 }

--- a/src/models/note.rs
+++ b/src/models/note.rs
@@ -99,3 +99,12 @@ pub struct UpdateNote {
     pub content: Option<String>,
     pub tags: Option<Vec<String>>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NoteAudio {
+    pub id: String,
+    pub note_id: String,
+    pub file_path: String,
+    pub duration_secs: Option<f64>,
+    pub created_at: String,
+}

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -3,7 +3,10 @@ mod pdf;
 mod picker;
 mod player;
 
-use objc2_avf_audio::{AVAudioSession, AVAudioSessionCategoryPlayAndRecord};
+use objc2_avf_audio::{
+    AVAudioSession, AVAudioSessionCategoryOptions,
+    AVAudioSessionCategoryPlayAndRecord,
+};
 use std::path::PathBuf;
 
 pub use parsers::read_file_as_text;
@@ -55,7 +58,10 @@ pub fn configure_audio_session() {
             eprintln!("[ios] PlayAndRecord category unavailable");
             return;
         };
-        if let Err(e) = session.setCategory_error(category) {
+        let options = AVAudioSessionCategoryOptions::DefaultToSpeaker
+            | AVAudioSessionCategoryOptions::AllowBluetoothA2DP;
+        if let Err(e) = session.setCategory_withOptions_error(category, options)
+        {
             eprintln!("[ios] setCategory failed: {e}");
             return;
         }

--- a/src/platform/ios/player.rs
+++ b/src/platform/ios/player.rs
@@ -1,8 +1,6 @@
 use objc2::rc::Retained;
 use objc2::AnyThread;
-use objc2_avf_audio::{
-    AVAudioPlayer, AVAudioSession, AVAudioSessionPortOverride,
-};
+use objc2_avf_audio::AVAudioPlayer;
 use objc2_foundation::{NSString, NSURL};
 use std::cell::RefCell;
 
@@ -26,10 +24,6 @@ pub fn play_audio(path: &str) {
             &url,
         ) {
             Ok(player) => {
-                let session = AVAudioSession::sharedInstance();
-                let _ = session.overrideOutputAudioPort_error(
-                    AVAudioSessionPortOverride::Speaker,
-                );
                 let _: bool = player.play();
                 eprintln!("[player] playing OK");
                 PLAYER.with(|p| {

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -8,6 +8,7 @@ use crate::ui::chat::models::ChatMsg;
 use crate::ui::chat::typing_indicator::TypingIndicator;
 use crate::ui::chat::user_bubble::UserBubble;
 use crate::ui::chat_input::ChatInputBar;
+use crate::ui::folder_picker::FolderPicker;
 use crate::ui::state::View;
 use crate::ui::AppState;
 use dioxus::prelude::*;
@@ -83,8 +84,11 @@ pub fn ChatView() -> Element {
             }
         }
         div {
-            class: "overflow-hidden",
+            class: "overflow-hidden relative",
             style: "height: calc(100% - var(--keyboard-inset, 0px));",
+            if (app.show_folder_picker)() {
+                FolderPicker { selected: app.chat_scope_folder_id }
+            }
             div { id: "chat-messages", class: "h-full overflow-y-auto px-4 pt-4 pb-40",
                 if is_empty && !loading() {
                     ChatEmptyState {}
@@ -126,7 +130,7 @@ pub fn ChatView() -> Element {
                         conversation_id.set(Some(cid));
                     }
                 }
-                let folder = (app.selected_folder_id)();
+                let folder = (app.chat_scope_folder_id)();
                 send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, folder);
             },
         }

--- a/src/ui/folder_picker.rs
+++ b/src/ui/folder_picker.rs
@@ -7,56 +7,41 @@ use std::sync::Arc;
 #[component]
 pub fn FolderPicker(selected: Signal<Option<String>>) -> Element {
     let db: Signal<Arc<Database>> = use_context();
-    let app: AppState = use_context();
-    let mut show = use_signal(|| false);
+    let mut app: AppState = use_context();
 
     let all_folders: Memo<Vec<Folder>> = use_memo(move || {
         let _v = (app.folders_version)();
         db().list_all_folders().unwrap_or_default()
     });
 
-    let display = match selected() {
-        Some(ref fid) => all_folders()
-            .iter()
-            .find(|f| f.id == *fid)
-            .map(|f| f.name.clone())
-            .unwrap_or_else(|| "Dossier".to_string()),
-        None => "Aucun dossier".to_string(),
-    };
-
     rsx! {
-        div { class: "mb-3",
+        div { class: "absolute left-0 right-0 top-0 z-20 bg-warm-white border-b border-stone-200 overflow-hidden shadow-md animate-[slideDown_150ms_ease-out]",
             button {
-                class: "inline-flex items-center px-3 py-1.5 rounded-full border border-stone-200 text-xs text-stone-600",
-                onclick: move |_| show.set(!show()),
-                "{display}"
+                class: if selected().is_none() {
+                    "w-full text-left px-3 py-2.5 text-sm text-ios-orange-dark font-medium bg-ios-orange-50 border-b border-stone-100"
+                } else {
+                    "w-full text-left px-3 py-2.5 text-sm text-stone-500 border-b border-stone-100 active:bg-stone-50 transition-colors duration-150"
+                },
+                onclick: move |_| {
+                    selected.set(None);
+                    app.show_folder_picker.set(false);
+                },
+                "Global"
             }
-            if show() {
-                div { class: "mt-1 border border-stone-200 rounded-xl bg-warm-white overflow-hidden",
-                    button {
-                        class: "w-full text-left px-3 py-2.5 text-sm text-stone-500 border-b border-stone-100",
-                        onclick: move |_| {
-                            selected.set(None);
-                            show.set(false);
-                        },
-                        "Aucun dossier"
-                    }
-                    for folder in all_folders() {
-                        {
-                            let fid = folder.id.clone();
-                            let fname = folder.name.clone();
-                            let is_current = selected() == Some(fid.clone());
-                            rsx! {
-                                button {
-                                    class: "w-full text-left px-3 py-2.5 text-sm",
-                                    class: if is_current { "text-ios-orange-dark font-medium bg-ios-orange-50" } else { "text-stone-900" },
-                                    onclick: move |_| {
-                                        selected.set(Some(fid.clone()));
-                                        show.set(false);
-                                    },
-                                    "{fname}"
-                                }
-                            }
+            for folder in all_folders() {
+                {
+                    let fid = folder.id.clone();
+                    let fname = folder.name.clone();
+                    let is_current = selected() == Some(fid.clone());
+                    rsx! {
+                        button {
+                            class: "w-full text-left px-3 py-2.5 text-sm active:bg-stone-50 transition-colors duration-150",
+                            class: if is_current { "text-ios-orange-dark font-medium bg-ios-orange-50" } else { "text-stone-900" },
+                            onclick: move |_| {
+                                selected.set(Some(fid.clone()));
+                                app.show_folder_picker.set(false);
+                            },
+                            "{fname}"
                         }
                     }
                 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -152,7 +152,7 @@ pub fn App() -> Element {
                     }
                     if matches!((app.view)(), View::NoteDetail { .. }) {
                         div {
-                            class: "absolute inset-0 flex flex-col min-h-0 px-4 py-3 bg-stone-100",
+                            class: "absolute inset-0 flex flex-col min-h-0 bg-stone-100",
                             style: if (app.sliding_out)() {
                                 "animation: slideOutToLeft 0.15s ease-in forwards;"
                             } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,7 +2,7 @@ mod attachment_modal;
 mod chat;
 mod chat_input;
 mod fab;
-mod folder_picker;
+pub(crate) mod folder_picker;
 pub mod icons;
 mod note_card;
 mod note_list;
@@ -62,6 +62,7 @@ pub fn App() -> Element {
         show_chat_menu: Signal::new(false),
         sidebar_tab: Signal::new(SidebarTab::Notes),
         show_folder_picker: Signal::new(false),
+        chat_scope_folder_id: Signal::new(None),
     });
 
     use_effect(|| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -61,6 +61,7 @@ pub fn App() -> Element {
         attachment_modal: Signal::new(None),
         show_chat_menu: Signal::new(false),
         sidebar_tab: Signal::new(SidebarTab::Notes),
+        show_folder_picker: Signal::new(false),
     });
 
     use_effect(|| {

--- a/src/ui/note_card.rs
+++ b/src/ui/note_card.rs
@@ -22,7 +22,8 @@ pub fn NoteCard(note: Note) -> Element {
     };
 
     let date = &note.created_at[..10];
-    let has_audio = note.audio_file_path.is_some();
+    let _ = (app.notes_version)();
+    let has_audio = !db().list_audios(&note.id).unwrap_or_default().is_empty();
 
     let folder_name = db()
         .folders_for_note(&note.id)

--- a/src/ui/note_card.rs
+++ b/src/ui/note_card.rs
@@ -23,7 +23,7 @@ pub fn NoteCard(note: Note) -> Element {
 
     let date = &note.created_at[..10];
     let _ = (app.notes_version)();
-    let has_audio = !db().list_audios(&note.id).unwrap_or_default().is_empty();
+    let has_audio = db().has_any_audio(&note.id);
 
     let folder_name = db()
         .folders_for_note(&note.id)

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -396,7 +396,7 @@ pub fn NoteDetail() -> Element {
             }
         }
         div {
-            class: "relative overflow-y-auto pb-40",
+            class: "relative overflow-y-auto pb-40 px-4 pt-3",
             style: "height: calc(100% - var(--keyboard-inset, 0px));",
             if (app.show_folder_picker)() {
                 FolderPicker { selected: selected_folder }

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -1,7 +1,7 @@
 use crate::db::Database;
 use crate::models::{
     generate_auto_title, is_auto_title, Attachment, NewAttachment, NewTextNote,
-    UpdateNote,
+    NoteAudio, UpdateNote,
 };
 use crate::services::audio::{self, RecordingState};
 use crate::services::embed::{embed_attachment, embed_note};
@@ -140,20 +140,19 @@ pub fn NoteDetail() -> Element {
     let mut import_requested = use_signal(|| false);
     let mut import_status: Signal<Option<String>> = use_signal(|| None);
     let pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
-    let mut audio_state: Signal<Option<(String, f64)>> = use_signal(|| {
-        note.as_ref().and_then(|n| {
-            n.audio_file_path
-                .as_ref()
-                .map(|path| (path.clone(), n.duration_secs.unwrap_or(0.0)))
-        })
-    });
+    let mut audios_version = use_signal(|| 0u32);
 
-    use_effect(move || {
-        let pa = pending_audio();
-        if pa.is_some() {
-            audio_state.set(pa);
+    let audios: Vec<NoteAudio> = {
+        let id = local_note_id();
+        let _ = audios_version();
+        let _ = (app.notes_version)();
+        if id.is_empty() {
+            Vec::new()
+        } else {
+            db().list_audios(&id).unwrap_or_default()
         }
-    });
+    };
+    let mut audios_expanded = use_signal(|| false);
 
     let attachments_version = (app.attachments_version)();
     let attachments: Vec<Attachment> = {
@@ -204,13 +203,16 @@ pub fn NoteDetail() -> Element {
                     title: if t.is_empty() { None } else { Some(t.clone()) },
                     content: c.clone(),
                     tags: tags(),
-                    audio_file_path: pa.as_ref().map(|(p, _)| p.clone()),
-                    duration_secs: pa.as_ref().map(|(_, d)| *d),
+                    audio_file_path: None,
+                    duration_secs: None,
                 };
                 match db.create_text_note(&new) {
                     Ok(created) => {
                         if let Some(ref fid) = selected_folder() {
                             let _ = db.add_note_to_folder(&created.id, fid);
+                        }
+                        if let Some((p, d)) = pa {
+                            let _ = db.add_audio(&created.id, &p, d);
                         }
                         let ca = created.created_at.clone();
                         (Some(created.id), ca)
@@ -229,9 +231,6 @@ pub fn NoteDetail() -> Element {
                 }
                 if let Some(ref fid) = selected_folder() {
                     let _ = db.add_note_to_folder(&note_id, fid);
-                }
-                if let Some((p, d)) = pa {
-                    let _ = db.update_audio_metadata(&note_id, &p, d);
                 }
                 let ca = db
                     .get_note(&note_id)
@@ -397,7 +396,7 @@ pub fn NoteDetail() -> Element {
             }
         }
         div {
-            class: "relative overflow-y-auto pb-20",
+            class: "relative overflow-y-auto pb-40",
             style: "height: calc(100% - var(--keyboard-inset, 0px));",
             if (app.show_folder_picker)() {
                 FolderPicker { selected: selected_folder }
@@ -441,26 +440,53 @@ pub fn NoteDetail() -> Element {
                 value: "{content}",
                 oninput: move |evt| content.set(evt.value()),
             }
-            {
-                if let Some((ref audio_filename, dur)) = audio_state() {
-                    let resolved = audio::resolve_audio_path(audio_filename);
-                    let note_id_clone = note_id.clone();
+            if !audios.is_empty() {
+                {
+                    let audio_label = format!("Enregistrements ({})", audios.len());
                     rsx! {
-                        AudioPlayer {
-                            audio_path: resolved,
-                            duration_secs: Some(dur),
-                            on_delete: move |_| {
-                                if let Some((ref f, _)) = audio_state() {
-                                    let _ = std::fs::remove_file(audio::resolve_audio_path(f));
+                        div { class: "mt-3",
+                            button {
+                                class: "flex items-center gap-2 w-full py-2 text-left active:opacity-70 transition-opacity duration-150",
+                                onclick: move |_| audios_expanded.set(!audios_expanded()),
+                                span { class: "text-xs font-medium text-stone-500", "{audio_label}" }
+                                span {
+                                    class: if audios_expanded() {
+                                        "inline-block w-1.5 h-1.5 border-r-[1.5px] border-b-[1.5px] border-stone-400 transition-transform duration-150 -rotate-[135deg]"
+                                    } else {
+                                        "inline-block w-1.5 h-1.5 border-r-[1.5px] border-b-[1.5px] border-stone-400 transition-transform duration-150 rotate-45"
+                                    },
                                 }
-                                let _ = db().clear_audio_metadata(&note_id_clone);
-                                audio_state.set(None);
-                                app.notes_version.set((app.notes_version)() + 1);
-                            },
+                            }
+                            if audios_expanded() {
+                                div { class: "space-y-2 pt-1",
+                                    for audio in audios.iter() {
+                                        {
+                                            let audio_id = audio.id.clone();
+                                            let file_path = audio.file_path.clone();
+                                            let resolved = audio::resolve_audio_path(&file_path);
+                                            let date = format_relative_date(&audio.created_at);
+                                            rsx! {
+                                                div { class: "space-y-1",
+                                                    p { class: "text-[10px] text-stone-400 px-1", "{date}" }
+                                                    AudioPlayer {
+                                                        audio_path: resolved,
+                                                        duration_secs: audio.duration_secs,
+                                                        on_delete: move |_| {
+                                                            let fp = file_path.clone();
+                                                            let _ = std::fs::remove_file(audio::resolve_audio_path(&fp));
+                                                            let _ = db().delete_audio(&audio_id);
+                                                            audios_version.set(audios_version() + 1);
+                                                            app.notes_version.set((app.notes_version)() + 1);
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
-                } else {
-                    rsx! {}
                 }
             }
             AttachmentSection { attachments, confirm_delete_att }

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -5,6 +5,7 @@ use crate::models::{
 };
 use crate::services::audio::{self, RecordingState};
 use crate::services::embed::{embed_attachment, embed_note};
+use crate::services::transcription::SonioxClient;
 use crate::ui::folder_picker::FolderPicker;
 use crate::ui::notes::attachments::AttachmentSection;
 use crate::ui::notes::audio_player::AudioPlayer;
@@ -139,7 +140,7 @@ pub fn NoteDetail() -> Element {
     let mut local_note_id = use_signal(|| note_id.clone());
     let mut import_requested = use_signal(|| false);
     let mut import_status: Signal<Option<String>> = use_signal(|| None);
-    let pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
+    let mut pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
     let mut audios_version = use_signal(|| 0u32);
 
     let audios: Vec<NoteAudio> = {
@@ -153,6 +154,7 @@ pub fn NoteDetail() -> Element {
         }
     };
     let mut audios_expanded = use_signal(|| false);
+    let mut transcribing_audio_id: Signal<Option<String>> = use_signal(|| None);
 
     let attachments_version = (app.attachments_version)();
     let attachments: Vec<Attachment> = {
@@ -166,7 +168,6 @@ pub fn NoteDetail() -> Element {
     };
 
     use_drop({
-        let note_id = note_id.clone();
         let orig_title = initial_title.clone();
         let orig_content = initial_content.clone();
         let orig_tags = initial_tags.clone();
@@ -179,10 +180,11 @@ pub fn NoteDetail() -> Element {
             let t = title();
             let c = content();
             let pa = pending_audio();
-            if note_id.is_empty() && c.is_empty() && pa.is_none() {
+            let nid = local_note_id();
+            if nid.is_empty() && c.is_empty() && pa.is_none() {
                 return;
             }
-            if !note_id.is_empty() && t.is_empty() && c.is_empty() {
+            if !nid.is_empty() && t.is_empty() && c.is_empty() {
                 return;
             }
             let title_changed = t != orig_title;
@@ -195,10 +197,10 @@ pub fn NoteDetail() -> Element {
                 || tags_changed
                 || folder_changed
                 || has_new_audio;
-            if !note_id.is_empty() && !changed {
+            if !nid.is_empty() && !changed {
                 return;
             }
-            let (saved_id, saved_created_at) = if note_id.is_empty() {
+            let (saved_id, saved_created_at) = if nid.is_empty() {
                 let new = NewTextNote {
                     title: if t.is_empty() { None } else { Some(t.clone()) },
                     content: c.clone(),
@@ -225,20 +227,20 @@ pub fn NoteDetail() -> Element {
                     content: Some(c.clone()),
                     tags: Some(tags()),
                 };
-                let _ = db.update_note(&note_id, &upd);
-                for old in db.folders_for_note(&note_id).unwrap_or_default() {
-                    let _ = db.remove_note_from_folder(&note_id, &old.id);
+                let _ = db.update_note(&nid, &upd);
+                for old in db.folders_for_note(&nid).unwrap_or_default() {
+                    let _ = db.remove_note_from_folder(&nid, &old.id);
                 }
                 if let Some(ref fid) = selected_folder() {
-                    let _ = db.add_note_to_folder(&note_id, fid);
+                    let _ = db.add_note_to_folder(&nid, fid);
                 }
                 let ca = db
-                    .get_note(&note_id)
+                    .get_note(&nid)
                     .ok()
                     .flatten()
                     .map(|n| n.created_at)
                     .unwrap_or_default();
-                (Some(note_id.clone()), ca)
+                (Some(nid.clone()), ca)
             };
             app.notes_version.set((app.notes_version)() + 1);
             if let Some(ref id) = saved_id {
@@ -257,9 +259,20 @@ pub fn NoteDetail() -> Element {
         if let RecordingState::Transcribed(text) = (app.recording_state)() {
             let current = content();
             if current.is_empty() {
-                content.set(text);
+                content.set(text.clone());
             } else {
                 content.set(format!("{}\n{}", current, text));
+            }
+            let id = local_note_id();
+            if !id.is_empty() {
+                if let Some(last) =
+                    db().list_audios(&id).ok().and_then(|a| a.last().cloned())
+                {
+                    if last.transcription.is_none() {
+                        let _ = db().set_audio_transcription(&last.id, &text);
+                        audios_version.set(audios_version() + 1);
+                    }
+                }
             }
             app.recording_state.set(RecordingState::Idle);
         }
@@ -285,6 +298,33 @@ pub fn NoteDetail() -> Element {
             generating_title.set(false);
             title_gen_done.set(true);
         });
+    });
+
+    use_effect(move || {
+        if pending_audio().is_some() && local_note_id().is_empty() {
+            let t = title();
+            let c = content();
+            let new = NewTextNote {
+                title: if t.is_empty() { None } else { Some(t.clone()) },
+                content: c,
+                tags: tags(),
+                audio_file_path: None,
+                duration_secs: None,
+            };
+            if let Ok(created) = db().create_text_note(&new) {
+                if let Some(ref fid) = selected_folder() {
+                    let _ = db().add_note_to_folder(&created.id, fid);
+                }
+                if let Some((filename, dur)) = pending_audio() {
+                    let _ = db().add_audio(&created.id, &filename, dur);
+                }
+                local_note_id.set(created.id.clone());
+                app.current_note_id.set(Some(created.id));
+                pending_audio.set(None);
+                audios_version.set(audios_version() + 1);
+                app.notes_version.set((app.notes_version)() + 1);
+            }
+        }
     });
 
     use_effect(move || {
@@ -462,9 +502,13 @@ pub fn NoteDetail() -> Element {
                                     for audio in audios.iter() {
                                         {
                                             let audio_id = audio.id.clone();
+                                            let audio_id_tr = audio.id.clone();
                                             let file_path = audio.file_path.clone();
+                                            let file_path_tr = audio.file_path.clone();
                                             let resolved = audio::resolve_audio_path(&file_path);
                                             let date = format_relative_date(&audio.created_at);
+                                            let transcription = audio.transcription.clone();
+                                            let is_transcribing_this = transcribing_audio_id() == Some(audio.id.clone());
                                             rsx! {
                                                 div { class: "space-y-1",
                                                     p { class: "text-[10px] text-stone-400 px-1", "{date}" }
@@ -478,6 +522,42 @@ pub fn NoteDetail() -> Element {
                                                             audios_version.set(audios_version() + 1);
                                                             app.notes_version.set((app.notes_version)() + 1);
                                                         },
+                                                    }
+                                                    if let Some(ref text) = transcription {
+                                                        p { class: "text-xs text-stone-600 italic px-1 pb-1", "{text}" }
+                                                    } else if is_transcribing_this {
+                                                        p {
+                                                            class: "text-xs text-stone-400 px-1 pb-1",
+                                                            style: "animation: pulseSoft 1.5s ease-in-out infinite;",
+                                                            "Transcription..."
+                                                        }
+                                                    } else {
+                                                        button {
+                                                            class: "text-xs text-ios-orange-dark px-1 pb-1 active:opacity-70",
+                                                            onclick: move |_| {
+                                                                let aid = audio_id_tr.clone();
+                                                                let fp = file_path_tr.clone();
+                                                                let path = audio::resolve_audio_path(&fp);
+                                                                transcribing_audio_id.set(Some(aid.clone()));
+                                                                spawn(async move {
+                                                                    let result = async {
+                                                                        let client = SonioxClient::from_env()?;
+                                                                        client.transcribe(std::path::Path::new(&path)).await
+                                                                    }.await;
+                                                                    match result {
+                                                                        Ok(text) => {
+                                                                            let _ = db().set_audio_transcription(&aid, &text);
+                                                                        }
+                                                                        Err(e) => {
+                                                                            eprintln!("[transcribe] error: {e}");
+                                                                        }
+                                                                    }
+                                                                    transcribing_audio_id.set(None);
+                                                                    audios_version.set(audios_version() + 1);
+                                                                });
+                                                            },
+                                                            "Transcrire"
+                                                        }
                                                     }
                                                 }
                                             }

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -12,8 +12,77 @@ use crate::ui::notes::menu::{import_file_content, NoteMenu};
 use crate::ui::notes::tags::TagsSection;
 use crate::ui::recording::RecordingBar;
 use crate::ui::{AppState, View};
+use chrono::{Datelike, NaiveDateTime, Utc};
 use dioxus::prelude::*;
 use std::sync::Arc;
+
+fn format_relative_date(iso: &str) -> String {
+    let parsed = NaiveDateTime::parse_from_str(
+        &iso.replace('T', " ").replace('Z', ""),
+        "%Y-%m-%d %H:%M:%S%.f",
+    );
+    let dt = match parsed {
+        Ok(d) => d,
+        Err(_) => return iso.to_string(),
+    };
+    let now = Utc::now().naive_utc();
+    let diff = now.signed_duration_since(dt);
+    let secs = diff.num_seconds();
+
+    if secs < 60 {
+        return "À l'instant".to_string();
+    }
+    if secs < 3600 {
+        let mins = secs / 60;
+        return format!("Il y a {mins} min");
+    }
+    if secs < 86400 {
+        let hours = secs / 3600;
+        return format!("Il y a {hours}h");
+    }
+
+    let today = now.date();
+    let note_date = dt.date();
+    if today.pred_opt() == Some(note_date) {
+        return format!("Hier, {}", dt.format("%H:%M"));
+    }
+
+    let months = [
+        "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
+        "sept.", "oct.", "nov.", "déc.",
+    ];
+    let m = months[note_date.month() as usize];
+    let d = note_date.day();
+
+    if note_date.year() == today.year() {
+        format!("{d} {m}")
+    } else {
+        format!("{d} {m} {}", note_date.year())
+    }
+}
+
+fn format_absolute_short(iso: &str) -> String {
+    let parsed = NaiveDateTime::parse_from_str(
+        &iso.replace('T', " ").replace('Z', ""),
+        "%Y-%m-%d %H:%M:%S%.f",
+    );
+    let dt = match parsed {
+        Ok(d) => d,
+        Err(_) => return iso.to_string(),
+    };
+    let months = [
+        "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
+        "sept.", "oct.", "nov.", "déc.",
+    ];
+    let d = dt.date();
+    let now = Utc::now().naive_utc().date();
+    let m = months[d.month() as usize];
+    if d.year() == now.year() {
+        format!("{} {}, {}", d.day(), m, dt.format("%H:%M"))
+    } else {
+        format!("{} {} {}", d.day(), m, d.year())
+    }
+}
 
 #[component]
 pub fn NoteDetail() -> Element {
@@ -99,6 +168,10 @@ pub fn NoteDetail() -> Element {
 
     use_drop({
         let note_id = note_id.clone();
+        let orig_title = initial_title.clone();
+        let orig_content = initial_content.clone();
+        let orig_tags = initial_tags.clone();
+        let orig_folder = initial_folder_id.clone();
         move || {
             if deleted() {
                 return;
@@ -111,6 +184,19 @@ pub fn NoteDetail() -> Element {
                 return;
             }
             if !note_id.is_empty() && t.is_empty() && c.is_empty() {
+                return;
+            }
+            let title_changed = t != orig_title;
+            let content_changed = c != orig_content;
+            let tags_changed = tags() != orig_tags;
+            let folder_changed = selected_folder() != orig_folder;
+            let has_new_audio = pa.is_some();
+            let changed = title_changed
+                || content_changed
+                || tags_changed
+                || folder_changed
+                || has_new_audio;
+            if !note_id.is_empty() && !changed {
                 return;
             }
             let (saved_id, saved_created_at) = if note_id.is_empty() {
@@ -290,17 +376,14 @@ pub fn NoteDetail() -> Element {
     let recording_state = (app.recording_state)();
     let is_transcribing = recording_state == RecordingState::Transcribing;
 
-    let date = note
+    let modified_date = note
         .as_ref()
-        .map(|n| {
-            if n.created_at.len() >= 16 {
-                let d = &n.created_at[..10];
-                let h = &n.created_at[11..16];
-                format!("{d} · {h}")
-            } else {
-                n.created_at[..10].to_string()
-            }
-        })
+        .map(|n| format_relative_date(&n.modified_at))
+        .unwrap_or_default();
+
+    let created_date = note
+        .as_ref()
+        .map(|n| format_absolute_short(&n.created_at))
         .unwrap_or_default();
 
     let show_menu = (app.show_note_menu)();
@@ -314,32 +397,45 @@ pub fn NoteDetail() -> Element {
             }
         }
         div {
-            class: "overflow-y-auto pb-20",
+            class: "relative overflow-y-auto pb-20",
             style: "height: calc(100% - var(--keyboard-inset, 0px));",
-            input {
-                class: if generating_title() {
-                    "text-xl font-semibold border-none outline-none py-2 text-stone-400 bg-transparent w-full animate-pulse"
-                } else {
-                    "text-xl font-semibold border-none outline-none py-2 text-stone-900 bg-transparent w-full"
-                },
-                placeholder: if generating_title() {
-                    "Titre en cours..."
-                } else {
-                    "Titre de la note"
-                },
-                value: "{title}",
-                oninput: move |evt| title.set(evt.value()),
+            if (app.show_folder_picker)() {
+                FolderPicker { selected: selected_folder }
             }
-            if !date.is_empty() {
-                p { class: "text-xs text-stone-400 mb-2", "{date}" }
+            div { class: "pt-2 pb-3",
+                div { class: "inline-block relative",
+                    span {
+                        class: "text-xl font-semibold invisible whitespace-pre py-1.5 px-3 border border-transparent",
+                        {if title().is_empty() { "Titre".to_string() } else { title() }}
+                    }
+                    input {
+                        class: if generating_title() {
+                            "absolute inset-0 text-xl font-semibold outline-none py-1.5 px-3 border border-stone-200/60 rounded-md text-stone-400 bg-white/25 animate-pulse"
+                        } else {
+                            "absolute inset-0 text-xl font-semibold outline-none py-1.5 px-3 border border-stone-200/60 rounded-md text-stone-900 bg-white/25 focus:border-ios-orange-dark/40 transition-colors duration-150"
+                        },
+                        placeholder: "Titre",
+                        value: "{title}",
+                        oninput: move |evt| title.set(evt.value()),
+                    }
+                }
+                if !modified_date.is_empty() {
+                    div { class: "mt-2 px-1",
+                        p { class: "text-xs text-stone-400", "{modified_date}" }
+                        if !created_date.is_empty() {
+                            p { class: "text-[10px] text-stone-300 mt-0.5", "Créé le {created_date}" }
+                        }
+                    }
+                }
             }
-            FolderPicker { selected: selected_folder }
-            TagsSection { tags, tag_input, tagging, content }
+            div { class: "border-t border-stone-100 pt-3 pb-2",
+                TagsSection { tags, tag_input, tagging, content }
+            }
             textarea {
                 class: if is_transcribing {
-                    "w-full min-h-[200px] border border-ios-orange/30 rounded-xl p-3 text-sm resize-none font-sans outline-none text-stone-900"
+                    "w-full min-h-[300px] border border-ios-orange/30 rounded-xl p-3 mt-3 text-sm resize-none font-sans outline-none text-stone-900"
                 } else {
-                    "w-full min-h-[200px] border border-stone-200 rounded-xl p-3 text-sm resize-none font-sans outline-none text-stone-900"
+                    "w-full min-h-[300px] border border-stone-200 rounded-xl p-3 mt-3 text-sm resize-none font-sans outline-none text-stone-900"
                 },
                 placeholder: if is_transcribing { "Transcription en cours..." } else { "Contenu de la note..." },
                 value: "{content}",

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -95,8 +95,6 @@ pub fn NoteDetail() -> Element {
         _ => return rsx! {},
     };
 
-    app.current_note_id.set(Some(note_id.clone()));
-
     let is_new = note_id.is_empty();
 
     let note = if is_new {
@@ -142,6 +140,27 @@ pub fn NoteDetail() -> Element {
     let mut import_status: Signal<Option<String>> = use_signal(|| None);
     let mut pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
     let mut audios_version = use_signal(|| 0u32);
+
+    use_effect(move || {
+        if !deleted() {
+            app.current_note_id.set(Some(local_note_id()));
+        }
+    });
+
+    use_effect(move || {
+        if deleted() {
+            app.sliding_out.set(true);
+            spawn(async move {
+                futures_timer::Delay::new(std::time::Duration::from_millis(
+                    150,
+                ))
+                .await;
+                app.sliding_out.set(false);
+                app.notes_version.set((app.notes_version)() + 1);
+                app.view.set(View::NotesList);
+            });
+        }
+    });
 
     let audios: Vec<NoteAudio> = {
         let id = local_note_id();
@@ -430,7 +449,7 @@ pub fn NoteDetail() -> Element {
     rsx! {
         if show_menu {
             NoteMenu {
-                note_id: note_id.clone(),
+                note_id: local_note_id(),
                 import_requested,
                 deleted,
             }

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -112,10 +112,8 @@ pub fn NoteMenu(
                     move |_| {
                         app.show_note_menu.set(false);
                         deleted.set(true);
-                        if let Ok(Some(n)) = db().get_note(&note_id) {
-                            if let Some(ref f) = n.audio_file_path {
-                                let _ = std::fs::remove_file(crate::services::audio::resolve_audio_path(f));
-                            }
+                        for a in db().list_audios(&note_id).unwrap_or_default() {
+                            let _ = std::fs::remove_file(crate::services::audio::resolve_audio_path(&a.file_path));
                         }
                         let _ = db().delete_note(&note_id);
                         delete_note_embeddings(note_id.clone());

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -1,6 +1,6 @@
 use crate::services::embed::delete_note_embeddings;
 use crate::ui::icons::*;
-use crate::ui::{AppState, View};
+use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
 
@@ -117,13 +117,7 @@ pub fn NoteMenu(
                         }
                         let _ = db().delete_note(&note_id);
                         delete_note_embeddings(note_id.clone());
-                        app.notes_version.set((app.notes_version)() + 1);
-                        app.sliding_out.set(true);
-                        spawn(async move {
-                            futures_timer::Delay::new(std::time::Duration::from_millis(150)).await;
-                            app.sliding_out.set(false);
-                            app.view.set(View::NotesList);
-                        });
+                        app.current_note_id.set(None);
                     }
                 },
                 IconTrash { size: 18 }

--- a/src/ui/recording/controls.rs
+++ b/src/ui/recording/controls.rs
@@ -174,7 +174,8 @@ pub fn RecordingControls(
                                 if !transcribe_only {
                                     let filename = audio::audio_filename(&path.display().to_string());
                                     if let Some(ref nid) = (app.current_note_id)().filter(|id| !id.is_empty()) {
-                                        let _ = db().update_audio_metadata(nid, &filename, dur as f64);
+                                        let _ = db().add_audio(nid, &filename, dur as f64);
+                                        app.notes_version.set((app.notes_version)() + 1);
                                     }
                                     pending_audio.set(Some((filename, dur as f64)));
                                 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1,10 +1,13 @@
 use crate::db::Database;
+use crate::services::audio;
+use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
 
 #[component]
 pub fn SettingsView() -> Element {
     let db: Signal<Arc<Database>> = use_context();
+    let mut app: AppState = use_context();
 
     let mut openai_key =
         use_signal(|| db().get_setting("openai_api_key").unwrap_or_default());
@@ -16,9 +19,12 @@ pub fn SettingsView() -> Element {
             .unwrap_or(8)
     });
     let mut saved = use_signal(|| false);
+    let mut confirm_cleanup = use_signal(|| false);
+    let mut cleanup_status: Signal<Option<String>> = use_signal(|| None);
+    let audio_count = db().all_audio_paths().map(|p| p.len()).unwrap_or(0);
 
     rsx! {
-        div { class: "space-y-6",
+        div { class: "space-y-6 pb-20",
             h2 { class: "text-lg font-semibold text-stone-900", "Clés API" }
             div { class: "space-y-4",
                 div {
@@ -49,7 +55,7 @@ pub fn SettingsView() -> Element {
                 }
             }
 
-            h2 { class: "text-lg font-semibold text-stone-900 pt-2", "RAG" }
+            h2 { class: "text-lg font-semibold text-stone-900 pt-2", "Recherche" }
             div {
                 div { class: "flex justify-between items-center mb-1",
                     label { class: "text-sm font-medium text-stone-700",
@@ -101,6 +107,63 @@ pub fn SettingsView() -> Element {
                 },
                 if saved() { "Enregistré ✓" } else { "Enregistrer" }
             }
+
+            div { class: "border-t border-stone-200 pt-4",
+                h2 { class: "text-lg font-semibold text-stone-900 mb-3", "Stockage" }
+                if let Some(ref status) = cleanup_status() {
+                    p { class: "text-xs text-ios-green text-center mb-2", "{status}" }
+                }
+                if audio_count > 0 {
+                    {
+                        let label = format!("Nettoyer les fichiers audio ({audio_count})");
+                        rsx! {
+                            button {
+                                class: if confirm_cleanup() {
+                                    "w-full py-2.5 rounded-xl text-sm font-medium bg-ios-red text-white"
+                                } else {
+                                    "w-full py-2.5 rounded-xl text-sm font-medium border border-stone-300 text-stone-600"
+                                },
+                                onclick: move |_| {
+                                    if confirm_cleanup() {
+                                        let dir = audio::output_dir();
+                                        match db().delete_all_audios(&dir) {
+                                            Ok(count) => {
+                                                cleanup_status.set(Some(
+                                                    format!("{count} fichiers audio supprimés"),
+                                                ));
+                                                app.notes_version
+                                                    .set((app.notes_version)() + 1);
+                                            }
+                                            Err(e) => {
+                                                cleanup_status
+                                                    .set(Some(format!("Erreur: {e}")));
+                                            }
+                                        }
+                                        confirm_cleanup.set(false);
+                                    } else {
+                                        confirm_cleanup.set(true);
+                                        spawn(async move {
+                                            tokio::time::sleep(
+                                                tokio::time::Duration::from_secs(3),
+                                            )
+                                            .await;
+                                            confirm_cleanup.set(false);
+                                        });
+                                    }
+                                },
+                                if confirm_cleanup() {
+                                    "Confirmer ? Les notes restent intactes."
+                                } else {
+                                    "{label}"
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    p { class: "text-xs text-stone-400 text-center", "Aucun fichier audio" }
+                }
+            }
+
             p { class: "text-xs text-stone-400 text-center",
                 "Les clés sont stockées localement sur cet appareil."
             }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -34,4 +34,5 @@ pub struct AppState {
     pub attachment_modal: Signal<Option<Attachment>>,
     pub show_chat_menu: Signal<bool>,
     pub sidebar_tab: Signal<SidebarTab>,
+    pub show_folder_picker: Signal<bool>,
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -35,4 +35,5 @@ pub struct AppState {
     pub show_chat_menu: Signal<bool>,
     pub sidebar_tab: Signal<SidebarTab>,
     pub show_folder_picker: Signal<bool>,
+    pub chat_scope_folder_id: Signal<Option<String>>,
 }

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -23,7 +23,11 @@ pub fn TopBar() -> Element {
                 .unwrap_or_else(|| "Dossier".to_string()),
             None => "Toutes mes notes".to_string(),
         },
-        View::NoteDetail { .. } => "Note".to_string(),
+        View::NoteDetail { note_id } => db()
+            .folders_for_note(&note_id)
+            .ok()
+            .and_then(|f| f.into_iter().next().map(|f| f.name))
+            .unwrap_or_else(|| "Global".to_string()),
         View::Chat { .. } => "Chat".to_string(),
         View::Settings => "Réglages".to_string(),
     };
@@ -56,7 +60,25 @@ pub fn TopBar() -> Element {
                     IconList { size: 22 }
                 }
             }
-            span { class: "text-lg font-semibold text-stone-900 flex-1", "{title}" }
+            if is_detail {
+                button {
+                    class: "flex-1 text-left flex items-center gap-1.5 active:opacity-70 transition-opacity duration-150",
+                    onclick: move |_| {
+                        let cur = (app.show_folder_picker)();
+                        app.show_folder_picker.set(!cur);
+                    },
+                    span { class: "text-lg font-semibold text-stone-900", "{title}" }
+                    span {
+                        class: if (app.show_folder_picker)() {
+                            "inline-block w-1.5 h-1.5 border-r-2 border-b-2 border-stone-400 transition-transform duration-150 -rotate-[135deg]"
+                        } else {
+                            "inline-block w-1.5 h-1.5 border-r-2 border-b-2 border-stone-400 transition-transform duration-150 rotate-45"
+                        },
+                    }
+                }
+            } else {
+                span { class: "text-lg font-semibold text-stone-900 flex-1", "{title}" }
+            }
             if is_detail {
                 button {
                     class: "min-w-[44px] min-h-[44px] flex items-center justify-center text-stone-700",

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -28,7 +28,15 @@ pub fn TopBar() -> Element {
             .ok()
             .and_then(|f| f.into_iter().next().map(|f| f.name))
             .unwrap_or_else(|| "Global".to_string()),
-        View::Chat { .. } => "Chat".to_string(),
+        View::Chat { .. } => match (app.chat_scope_folder_id)() {
+            Some(ref fid) => db()
+                .get_folder(fid)
+                .ok()
+                .flatten()
+                .map(|f| f.name)
+                .unwrap_or_else(|| "Global".to_string()),
+            None => "Global".to_string(),
+        },
         View::Settings => "Réglages".to_string(),
     };
 
@@ -60,7 +68,7 @@ pub fn TopBar() -> Element {
                     IconList { size: 22 }
                 }
             }
-            if is_detail {
+            if is_detail || is_chat {
                 button {
                     class: "flex-1 text-left flex items-center gap-1.5 active:opacity-70 transition-opacity duration-150",
                     onclick: move |_| {

--- a/tailwind.css
+++ b/tailwind.css
@@ -15,6 +15,10 @@
     * {
         -webkit-tap-highlight-color: transparent;
         -webkit-text-size-adjust: 100%;
+        scrollbar-width: none;
+    }
+    *::-webkit-scrollbar {
+        display: none;
     }
     html,
     body {

--- a/tailwind.css
+++ b/tailwind.css
@@ -82,6 +82,16 @@
             opacity: 0.8;
         }
     }
+    @keyframes slideDown {
+        from {
+            max-height: 0;
+            opacity: 0;
+        }
+        to {
+            max-height: 15rem;
+            opacity: 1;
+        }
+    }
     @keyframes fadeInUp {
         from {
             transform: translateY(8px);


### PR DESCRIPTION
## Summary

- **Multi-audio per note**: V5 migration, `note_audios` table with CASCADE delete, accordion UI in NoteDetail
- **Per-audio transcription**: V6 migration, auto-save from recording flow, manual "Transcrire" button for old audios
- **Chat scope picker**: Global/folder selector in top bar (reuses FolderPicker), scopes RAG search
- **Hybrid search**: LanceDB FTS + vector + RRF fusion, temporal intent detection, LLM reranking
- **Audio routing**: DefaultToSpeaker + AllowBluetoothA2DP (respects headphones/AirPods)
- **Settings**: "RAG" renamed "Recherche", audio cleanup with confirmation
- **Perf**: `has_any_audio` EXISTS query, deferred `notes_version` bump on delete
- **Fix**: delete transition spawn in NoteDetail scope (prevents cancel on NoteMenu unmount)
- **Docs**: `.env.example` added (closes #6), README updated

## Changes

- 52 files changed, 2573 insertions, 295 deletions
- DB migrations V5 (note_audios) + V6 (transcription column)
- 35 commits on development

## Test plan

- [x] Multi-audio: record 2+ audios in same note, verify accordion display
- [x] Transcription: auto-saved after recording, "Transcrire" button for old audios
- [x] Chat scope: tap "Global" in top bar, switch to folder, verify RAG filters
- [x] Delete note: no freeze, no ghost card, smooth transition
- [x] Audio routing: plays through headphones when connected
- [x] Settings: audio cleanup button works, count updates
- [x] Build: `make check` clean (fmt + clippy)

Closes #6