### PR TITLE
docs: restore README hero and add iOS audio research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1523 symbols, 2631 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1535 symbols, 2643 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1543 symbols, 2650 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1624 symbols, 2730 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1543 symbols, 2650 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1624 symbols, 2730 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,91 @@
-# FlowFlow
+<p align="center">
+  <img src="docs/logo.png" alt="FlowFlow" width="160" />
+</p>
 
-100% Rust mobile app for recording voice notes, transcribing, generating tags/titles via AI, organizing in folders, and chatting with notes via local RAG.
+<h1 align="center">FlowFlow</h1>
 
-Built with Dioxus 0.7.9, targeting iOS (iPhone).
+<p align="center">
+  Voice notes app for mobile — 100% Rust, built with <a href="https://github.com/DioxusLabs/dioxus">Dioxus</a>.<br/>
+  Featured on <a href="https://dioxuslabs.com/awesome/">Awesome Dioxus</a>.
+</p>
 
-## Features
+---
 
-- Voice recording with background audio support
-- Speech-to-text via Soniox REST API
-- AI-powered tags and titles (OpenAI / Anthropic)
-- Semantic search via LanceDB embeddings
-- RAG chat with agent tools (search, create, summarize)
-- Document import (TXT, MD, CSV, PDF, DOCX)
-- Dynamic Island Live Activity with recording timer
-- AVAudioSession interruption handling (auto-pause on calls)
-- Multi-provider LLM support (OpenAI + Anthropic via rig-core)
+Most of my ideas come when I'm walking or between two tasks. And they vanish just as fast.
+
+FlowFlow is a voice notes app that captures what you say, transcribes it, and lets you **chat with your notes** later. You ask "what was that pricing idea?" and the right passages come up — with links to the original notes.
+
+No manual searching. No folders to dig through. Just talk, and find it later.
+
+## What it does
+
+- **Voice capture** — tap to record, real-time waveform visualization, pause/resume, auto-transcription via Soniox
+- **Background audio + Dynamic Island Live Activity** — recording keeps going when you lock the phone or switch apps, with a live timer in the Dynamic Island
+- **Interruption handling** — auto-pause on incoming calls / FaceTime via AVAudioSession observers, auto-resume after
+- **Audio playback** — play, pause, and delete voice recordings directly from any note
+- **RAG chat** — powered by [rig](https://github.com/0xPlaygrounds/rig), ask questions about your notes and get answers with tappable source references
+- **Hybrid search** — BM25 keyword + vector similarity + RRF fusion + LLM reranking for precise retrieval
+- **Temporal queries** — ask "what did I note yesterday?" with automatic French date detection (regex + LLM fallback)
+- **Folder-scoped chat** — chat searches only within the selected folder when one is active
+- **Agent tools** — the chat agent can search notes by meaning, create new notes, or summarize entire folders autonomously
+- **AI auto-title** — LLM generates a 1-3 word title while you write, with pulse animation
+- **Auto-tagging** — LLM generates single-word tags per note, or add your own
+- **Document import** — PDF (with native OCR for scanned documents), DOCX, TXT, MD, CSV via native iOS picker
+- **Multi-provider** — OpenAI or Anthropic as LLM backend, switchable in settings
+- **Filler removal** — auto-strips hesitations (euh, um, hmm) from transcriptions so your notes read clean
+- **Local-first** — SQLite for metadata, LanceDB for semantic search, your data stays on device
+
+## Stack
+
+100% Rust. Zero JavaScript.
+
+The UI runs on [Dioxus](https://github.com/DioxusLabs/dioxus), a React-like framework for Rust that renders natively on iOS through WKWebView. Styling is handled by [Tailwind CSS V4](https://tailwindcss.com) — Dioxus auto-detects and compiles it, so every class just works without a separate build step.
+
+The RAG pipeline is built on [rig](https://github.com/0xPlaygrounds/rig), an LLM orchestration framework for Rust. It handles agent construction, tool calling, and provider dispatch (OpenAI and Anthropic) in a unified API. The agent gets custom tools — search notes, create notes, summarize folders — and can chain up to 4 tool calls per question before answering.
+
+Embeddings go through OpenAI's text-embedding-3-small and land in [LanceDB](https://lancedb.com), a local vector database that runs entirely on device. Cosine similarity search over chunked notes and documents, no server needed.
+
+Document import uses Apple's native PDFKit on iOS — text extraction with automatic OCR fallback for scanned documents. DOCX parsing is handled directly via zip + quick-xml, no external dependencies.
+
+The Dynamic Island Live Activity bridges Rust to Swift via a thin FFI layer over ActivityKit, so the recording timer renders natively while the audio pipeline stays in Rust.
+
+Everything async runs on [tokio](https://tokio.rs) — audio recording, API calls, embedding jobs, transcription polling. The iOS audio pipeline uses cpal for CoreAudio capture and hound for WAV encoding.
+
+|               |                                                                                                |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| UI            | [Dioxus 0.7.9](https://github.com/DioxusLabs/dioxus) (iOS, desktop, web)                       |
+| Styling       | [Tailwind CSS V4](https://tailwindcss.com)                                                     |
+| LLM           | [rig-core 0.36](https://github.com/0xPlaygrounds/rig) (OpenAI + Anthropic)                     |
+| Embeddings    | OpenAI text-embedding-3-small (1536 dims)                                                      |
+| Vector DB     | [LanceDB 0.27.2](https://lancedb.com) (local, cosine)                                          |
+| Async         | [tokio](https://tokio.rs)                                                                      |
+| Database      | SQLite ([rusqlite](https://github.com/rusqlite/rusqlite) 0.34, bundled, WAL mode)              |
+| Audio         | [cpal](https://github.com/RustAudio/cpal) 0.17 + [hound](https://github.com/ruuda/hound) 3.5   |
+| Transcription | [Soniox](https://soniox.com) REST API                                                          |
+| Live Activity | ActivityKit via Swift FFI (Dynamic Island recording timer)                                     |
+| PDF           | Apple PDFKit (iOS, native OCR) / [pdf-extract](https://crates.io/crates/pdf-extract) (desktop) |
+| DOCX          | [quick-xml](https://crates.io/crates/quick-xml) + [zip](https://crates.io/crates/zip)          |
+| Icons         | [Phosphor](https://phosphoricons.com) (MIT)                                                    |
+| Min iOS       | 16.0 (aarch64-apple-ios)                                                                       |
+
+## How it works
+
+```
+Talk → Record → Transcribe → Clean fillers → Auto-embed → Store → AI title (1-3 words)
+
+Later: Ask → Embed query → Hybrid search (BM25 + vector + RRF)
+     → LLM rerank → Temporal boost → Tag-enriched context → Agent with tools → Answer with sources
+```
+
+## Setup
+
+```bash
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+cargo install dioxus-cli
+cp .env.example .env   # add your API keys (or set them in-app)
+```
+
+API keys can be set in-app via Settings (stored in SQLite, no recompile). OpenAI is always required for embeddings. Anthropic is optional.
 
 ## Commands
 
@@ -34,30 +105,38 @@ make logs           # open Console.app (select iPhone, filter "FlowFlow")
 make clean          # rm target/dx
 ```
 
-## iOS Provisioning
+## iOS Device Provisioning
 
-Personal Team (free Apple ID) profiles expire every 7 days. `make all` auto-detects expiry < 24h and runs `make renew` before building. Renewal uses a minimal Xcode project template under `tools/provision-renew/` invoked via `xcodebuild -allowProvisioningUpdates`. Zero manual Xcode GUI required.
+Running on a physical iPhone requires a valid provisioning profile. Apple enforces code signing for all device builds.
+
+**Free Apple account**: profiles expire after 7 days. **Paid Apple Developer Program** (€99/year): profiles last 1 year, plus App Store and TestFlight access.
+
+`make all` auto-detects expiry < 24h and runs `make renew` before building. Renewal uses a minimal Xcode project template under `tools/provision-renew/` invoked via `xcodebuild -allowProvisioningUpdates`. Zero manual Xcode GUI required.
+
+```bash
+make check-profiles  # show expiration dates
+make renew           # regenerate now
+```
+
+**On your iPhone** (first time only): Settings → General → VPN & Device Management → tap your developer certificate → Trust.
 
 Once your paid Apple Developer Program is active, profiles last 1 year and `make renew` becomes a once-a-year operation.
 
-## Stack
-
-- Rust 1.94.1, Dioxus 0.7.9, Tailwind CSS V4
-- cpal 0.17 (audio), hound 3.5 (WAV)
-- rig-core 0.36 (LLM, OpenAI + Anthropic)
-- LanceDB 0.27.2 (vector search)
-- rusqlite 0.34 (SQLite, bundled)
-- ActivityKit (Dynamic Island via Swift FFI)
-- iOS 16.0+, aarch64-apple-ios
-
-## Setup
+## Tests
 
 ```bash
-cp .env.example .env
-# Fill in: SONIOX_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY
-make all
+cargo test
+cargo test -- --ignored
 ```
+
+## Status
+
+Actively developed. The codebase evolves constantly — new features, better architecture, and deeper iOS integration land regularly.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-EUPL 1.2
+Copyright 2026 Mirko Bozzetto — [EUPL v1.2](LICENSE)

--- a/docs/brainstorm/system-audio-and-import.md
+++ b/docs/brainstorm/system-audio-and-import.md
@@ -1,0 +1,465 @@
+# System audio capture & audio import — research
+
+> Target: 100% Rust + Dioxus iOS app (FlowFlow), voice notes + transcription
+> Scope: capturing system audio, recording calls, headphone routing, file import, Soniox format support
+> Date: 2026-05-23
+> Status: research only, no implementation
+
+## TL;DR
+
+| Question | Verdict | Reason |
+|----------|---------|--------|
+| Capture YouTube/Spotify audio while recording mic | **Yes, but only via Broadcast Upload Extension (ReplayKit)** with hard limits | Blocked for AVPlayer/Music/Safari/DRM content. Requires app extension + App Groups + 50 MB memory cap |
+| Capture WhatsApp/FaceTime/phone calls | **Hard NO** | OS-level block, not policy. Workaround only via speakerphone + mic (lossy, no separation) |
+| AirPods routing while playing another app's audio | **Yes if A2DP for output, built-in mic for input** | `.allowBluetoothA2DP` (NOT `.allowBluetooth`); HFP downgrades quality and locks I/O together |
+| Audio file import (m4a/mp3/wav/aac) | **Yes, fully supported** | `UIDocumentPickerViewController` with `UTType.audio`; also Share Extension + App Group for Voice Memos / AirDrop |
+| Soniox supported formats | **All iOS native formats work** | Auto-detect for aac/aiff/amr/asf/flac/mp3/ogg/wav/webm + m4a/mp4 (async) — no conversion needed |
+
+### Recommendation for FlowFlow
+
+- **MVP**: skip system audio capture. Engineering cost very high, narrow value. Use mic-only `playAndRecord` + `mixWithOthers` so podcasts continue playing in the background. **Already in place in `src/platform/ios/mod.rs`.**
+- **Phase 2 (if needed)**: add a Broadcast Upload Extension (Swift, signed separately) that writes captured audio to an App Group container; Rust app transcribes the resulting `.m4a` via Soniox.
+- **Calls**: don't attempt. Document the limitation in the UI.
+- **Import**: extend the existing `open_file_picker` in `src/platform/ios/picker.rs` to handle `public.audio`; push the resulting `URL` straight to Soniox as `audio_url` or upload the file body — no decode needed in Rust.
+
+### FlowFlow current state (verified)
+
+`src/platform/ios/mod.rs::configure_audio_session` already uses:
+- Category: `playAndRecord`
+- Options: `DefaultToSpeaker | AllowBluetoothA2DP | MixWithOthers`
+- Interruption observer wired via `NSNotificationCenter` (`AVAudioSessionInterruptionNotification`)
+
+→ AVAudioSession setup aligns with research best practices. No change required.
+
+---
+
+## 1. Capturing system audio while recording the mic
+
+### 1.1 What `AVAudioSession` can and cannot do
+
+`AVAudioSession` controls **your app's** audio relationship with the system. It does **not** give access to other apps' audio buffers. The `MixWithOthers` option only controls whether your session **interrupts** other apps' playback. It does not route their audio into your input stream.
+
+- `playAndRecord` is the only category that allows simultaneous mic input + speaker output (Apple Audio Session Programming Guide). `record` alone "silences virtually all system output and is usually too restrictive". Source: [Apple AudioGuidelinesByAppType](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioGuidelinesByAppType/AudioGuidelinesByAppType.html).
+- Adding `.mixWithOthers` option lets background music keep playing **while your app is alive but not recording**. As soon as you start the AVAudioEngine input node (or AVAudioRecorder), iOS will pause or duck the other audio. Confirmed: [Stack Overflow — Setting Audio Input node for AVAudioEngine causes outside audio to stop](https://stackoverflow.com/questions/78790511/setting-audio-input-node-for-avaudioengine-causes-outside-audio-to-stop).
+- `.duckOthers` lowers other audio volume, doesn't capture it.
+- `.interruptSpokenAudioAndMixWithOthers` only mixes with non-spoken audio.
+- `mixWithOthers` reference: [Apple Developer — mixWithOthers](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions-swift.struct/mixwithothers).
+
+**Bottom line**: `AVAudioSession` is the wrong API for capturing other apps' audio. It only governs whether your app cohabitates with others.
+
+### 1.2 What ReplayKit can do (the only path)
+
+`ReplayKit` is Apple's only API that exposes other apps' audio. Two modes:
+
+| Mode | Scope | Audio captured | Where it runs |
+|------|-------|---------------|---------------|
+| **In-app capture** (`RPScreenRecorder.startCapture`) | Only YOUR app's own UI/audio | Mic + your app's audio | Main app process |
+| **Broadcast Upload Extension** (`RPBroadcastSampleHandler`) | System-wide (all apps + home screen) | Mic + system app audio (with carve-outs) | Separate extension process (50 MB cap) |
+
+Sources:
+- [Apple — RPBroadcastSampleHandler](https://developer.apple.com/documentation/replaykit/rpbroadcastsamplehandler)
+- [Apple ReplayKit framework page](https://developer.apple.com/documentation/ReplayKit)
+- [WWDC 2017 session 606 "What's New with Screen Recording and Live Broadcast"](https://nonstrict.eu/wwdcindex/wwdc2017/606/)
+- [WWDC 2020 session 10633 (macOS ReplayKit)](https://developer.apple.com/videos/play/wwdc2020/10633/)
+- [WWDC 2021 session 10101 (clips recording)](https://developer.apple.com/videos/play/wwdc2021/10101/)
+
+The Broadcast Upload Extension hands you three sample-buffer types via `processSampleBuffer(_:with:)`:
+- `RPSampleBufferType.audioApp` — combined audio output of all other apps
+- `RPSampleBufferType.audioMic` — microphone
+- `RPSampleBufferType.video` — screen frames (you can ignore for audio-only use)
+
+Reference enum: [RPSampleBufferType](https://apidocs.mobileui.dev/robovm/latest/org/robovm/apple/replaykit/RPSampleBufferType.html).
+
+### 1.3 Hard limits Apple imposes
+
+From the [Twilio ReplayKit example README](https://github.com/twilio/video-quickstart-ios/blob/master/ReplayKitExample/README.md) (most thorough field report):
+
+1. **DRM and Apple-internal apps are silently muted**:
+   > "It is not possible to capture application audio produced by `AVPlayer`, by Safari video playback (even if no FairPlay DRM is used), or by the Music app."
+
+   So Apple Music, Apple TV, Netflix, Spotify, and Safari `<video>` playback all return **silence buffers**. Confirmed by Apple forum thread [WKWebView + ReplayKit silence](https://developer.apple.com/forums/thread/670482).
+
+2. **50 MB memory cap on the extension** — extension is killed if exceeded. No Audio Unit graph, no playback inside the extension, downscale video, single-thread audio. Sources: Twilio README, [OpenTok iOS SDK Broadcast-Ext](https://github.com/opentok/opentok-ios-sdk-samples/blob/main/Broadcast-Ext/README.md).
+
+3. **Out-of-process security model**: the broadcast extension runs in Apple's `replayd` daemon and is sandboxed from your main app. To get audio into your main app you need an **App Group** + shared container (`UserDefaults(suiteName:)` for signalling, `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)` for files). [LiveKit ios-screen-sharing.md](https://github.com/livekit/client-sdk-swift/blob/main/Docs/ios-screen-sharing.md), [100ms-docs screen-share](https://github.com/100mslive/100ms-docs/blob/main/docs/ios/v2/how-to-guides/set-up-video-conferencing/screen-share.mdx), [Apple security guide for ReplayKit](https://support.apple.com/guide/security/replaykit-security-seca5fc039dd/web).
+
+4. **User-initiated start only**: you cannot programmatically start a broadcast. You must present `RPSystemBroadcastPickerView` and the user taps "Start Broadcast" inside the system sheet. Reference: [RPSystemBroadcastPickerView (Apple)](https://developer.apple.com/documentation/replaykit/rpsystembroadcastpickerview?changes=__2&language=objc).
+
+5. **iOS 13.0 had a memory leak** when `audioMic` was enabled; fixed in 13.1. Modern iOS 18+/26 is fine.
+
+### 1.4 Audio sample format from the extension (post iOS 13)
+
+From the Twilio README field measurements:
+
+| Buffer type | Channels | Sample rate | Buffer size | Period |
+|-------------|----------|-------------|-------------|--------|
+| `audioApp`  | 1 or 2   | 44 100 Hz   | 1024 frames | 23.2 ms |
+| `audioMic`  | 1        | 44 100 Hz   | 1024 frames | 23.2 ms |
+
+Note byte-order difference: app audio is big-endian, mic audio is little-endian.
+
+### 1.5 Implementation hints for FlowFlow
+
+A Broadcast Upload Extension is an **Xcode target written in Swift/Objective-C with App Extension API restrictions**. You cannot replace it with a pure-Rust target. Minimal viable path:
+
+1. Add a new Xcode target `FlowFlowBroadcast` of type **Broadcast Upload Extension** (Swift). Inside `SampleHandler.swift`, write audio buffers (mic + app) to an `AVAssetWriter` whose output URL is in the App Group container.
+2. Add the **App Groups** capability to both the main app target and the extension with the same group ID (e.g. `group.com.mirkobozzetto.flowflow`).
+3. Set bundle ID of extension to `com.mirkobozzetto.flowflow.broadcast`.
+4. In FlowFlow's main Rust process, expose `RPSystemBroadcastPickerView` via a thin Swift bridge (or via `objc2` msg_send like FlowFlow already does for the iOS picker). Set its `preferredExtension = "com.mirkobozzetto.flowflow.broadcast"`.
+5. After broadcast stops, Rust reads the `.m4a` from the shared container via `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)` (via `objc2` msg_send), copies it to `documents_dir()`, then runs the existing Soniox pipeline.
+6. Mind the **50 MB cap** — don't buffer raw PCM; write directly to AAC via `AVAssetWriter`.
+7. Update Makefile: extension needs its own provisioning profile, signed alongside the main app. Same complexity as your current Live Activity Widget Extension plan — extend that pattern.
+
+### 1.6 ReplayKit references
+
+- Apple: [ReplayKit framework](https://developer.apple.com/documentation/ReplayKit)
+- Apple Security: [ReplayKit Security in iOS](https://support.apple.com/guide/security/replaykit-security-seca5fc039dd/web)
+- Apple: [RPBroadcastSampleHandler](https://developer.apple.com/documentation/replaykit/rpbroadcastsamplehandler)
+- Twilio: [ReplayKitExample README — gotchas, formats, limitations](https://github.com/twilio/video-quickstart-ios/blob/master/ReplayKitExample/README.md)
+- LiveKit: [iOS screen sharing — app group + broadcast capture](https://github.com/livekit/client-sdk-swift/blob/main/Docs/ios-screen-sharing.md)
+- 100ms: [iOS screen share with broadcast extension](https://github.com/100mslive/100ms-docs/blob/main/docs/ios/v2/how-to-guides/set-up-video-conferencing/screen-share.mdx)
+- OpenTok: [Broadcast-Ext sample](https://github.com/opentok/opentok-ios-sdk-samples/blob/main/Broadcast-Ext/README.md)
+- WWDC 2017: [Session 606 — In-App Screen Capture intro](https://nonstrict.eu/wwdcindex/wwdc2017/606/)
+
+---
+
+## 2. Recording VoIP / calls (WhatsApp, FaceTime, phone)
+
+### 2.1 The blanket NO
+
+> "On iOS, Apple's security framework is particularly restrictive. The company doesn't allow any third-party app to access the audio stream during VoIP calls made through applications like WhatsApp, Telegram, or FaceTime. This isn't a limitation that developers can work around; it's a hard restriction built into the operating system's architecture."
+> — [Remi8 — Why WhatsApp Call Recording Apps Fail](https://remi8.ai/blog/whatsapp-call-3/why-whatsapp-call-recording-apps-fail-16)
+
+### 2.2 Why it can't be worked around
+
+- **CallKit audio session is privileged**. From Apple engineer (quintonn) on Apple Forums [thread 758386](https://developer.apple.com/forums/thread/758386):
+  > "The audio session category CallKit activates is NOT a 'standard' AVAudioSessionCategoryPlayAndRecord category, but a 'special' phone specific session ... it has higher activation priority than EVERY other audio session type on the system and CANNOT be interrupted by any of the public session categories."
+- While a CallKit-managed call is active, any other app that tries to grab the microphone is either denied or causes the call to end. ReplayKit's `audioApp` stream is also blocked from CallKit audio for the same security reason (no Apple doc spells this out explicitly, but every implementer reports silence).
+- iOS does **not** expose call logs/history to third parties at all. Forum [thread 764958](https://developer.apple.com/forums/thread/764958):
+  > "There isn't any API on the system which will give you access to the user call history ... Developers have been asking for access to the user call history since iOS was first introduced and, at this point, it should be fairly clear that this simply isn't something iOS is going to provide."
+
+### 2.3 Apple's own (legal) call recording
+
+Apple ships native call recording **only in the Phone app** (cellular calls, not VoIP), iOS 18+, and **not in the EU** or many other regions. The recipient is forced to hear an audio notice. Reference: [Apple Support — Record and transcribe a call on iPhone](https://support.apple.com/guide/iphone/record-and-transcribe-a-call-iph57c6590e9/ios).
+
+You cannot replicate this — Apple uses private system APIs and a legal disclosure that only Apple is allowed to ship.
+
+### 2.4 The only workaround: speakerphone + open mic
+
+Put the call on speakerphone, run FlowFlow's normal mic recorder. You get a single mono track that captures whatever the speaker emits + room reflections + your own voice + ambient noise. Drawbacks:
+- Speaker quality is poor
+- No diarisation between caller/callee (Soniox `enable_speaker_diarization: true` won't reliably split since acoustic separation is weak)
+- Echo/cross-talk
+- Many regions require consent of both parties (legal exposure)
+
+For FlowFlow this is not worth shipping as a "call recorder" feature. Better to surface a note in-app: "FlowFlow records your microphone — for calls, use Apple's native call recording where available."
+
+### 2.5 Call recording references
+
+- [Remi8 — Why WhatsApp Call Recording Apps Fail](https://remi8.ai/blog/whatsapp-call-3/why-whatsapp-call-recording-apps-fail-16)
+- Apple Dev Forum thread 758386 — [CallKit audio session priority](https://developer.apple.com/forums/thread/758386)
+- Apple Dev Forum thread 774784 — [WebRTC voice calls in background limitations](https://developer.apple.com/forums/thread/774784)
+- Apple Dev Forum thread 764958 — [No call log API on iOS](https://developer.apple.com/forums/thread/764958)
+- [Apple Support — Record and transcribe a call](https://support.apple.com/guide/iphone/record-and-transcribe-a-call-iph57c6590e9/ios)
+- [WWDC 2016 session 230 — CallKit](https://developer.apple.com/videos/play/wwdc2016/230/)
+- [Medium — How to Detect and Handle VoIP Calls on iOS Using CallKit](https://medium.com/swiftfy/how-to-detect-and-handle-voip-calls-on-ios-using-callkit-e32dab00933c)
+
+---
+
+## 3. Headphones / Bluetooth routing during recording
+
+### 3.1 The Bluetooth profile trap
+
+Bluetooth audio uses two incompatible profiles:
+- **A2DP** — high-bandwidth stereo, **playback only**, no mic. Codecs: SBC, AAC, aptX.
+- **HFP** (Hands-Free Profile) — bidirectional, **low-bandwidth mono**, used for phone calls. Sample rate typically 8 kHz (narrowband) or 16 kHz (wideband mSBC). Quality is "tinny, lacks bass".
+
+When iOS opens a Bluetooth mic via HFP, the same Bluetooth link drops out of A2DP and downgrades the output. Sources: [Microsoft — Bluetooth Classic audio accessories](https://learn.microsoft.com/en-us/windows-hardware/design/accessory-guidelines/bluetooth-accessory-guidelines/bluetooth-accessory-guidelines-classic-audio), [Buralog — AirPods in web conferencing](https://buralog.jp/en/airpods-webconf-regret-en/), Apple Q&A QA1799 below.
+
+### 3.2 The right option: `.allowBluetoothA2DP`, NOT `.allowBluetooth`
+
+The naming in `AVAudioSession.CategoryOptions` is deeply misleading:
+
+| Option | What it actually does |
+|--------|----------------------|
+| `.allowBluetooth` | Prefer **HFP** (telephony, low quality, bidirectional) |
+| `.allowBluetoothA2DP` | Prefer **A2DP** (stereo high quality, output-only); mic falls back to built-in |
+| `.allowAirPlay` | AirPlay routing |
+
+Field guidance from Stack Overflow ([Recording from Built-In Mic when Playing through Bluetooth](https://stackoverflow.com/questions/30614134/recording-from-built-in-mic-when-playing-through-bluetooth-in-ios)):
+> "By removing `.allowBluetooth` from AVAudioSession's `categoryOptions`, it won't allow HFP, which is a protocol to use bluetooth device as an input. Thus it will automatically change its input route to built-in mic."
+
+And [Stack Overflow — How to use internal mic for input and bluetooth for output](https://stackoverflow.com/questions/65571861/how-to-use-internal-mic-for-input-and-bluetooth-for-output):
+> "Get rid of `allowBluetooth` and use `allowBluetoothA2DP`. You also don't want `defaultToSpeaker` here. `Allow Bluetooth` actually means `prefer HFP`."
+
+### 3.3 The locked I/O rule
+
+Apple QA1799 ([Technical Q&A — AVAudioSession Microphone Selection](https://developer.apple.com/library/archive/qa/qa1799/_index.html)) and Apple Developer Forums [thread 4340](https://developer.apple.com/forums/thread/4340?answerId=15178022):
+
+> "If an application uses the `setPreferredInput:error:` method to select a Bluetooth HFP input, the output will automatically be changed to the Bluetooth HFP output. Moreover, selecting a Bluetooth HFP output using the MPVolumeView's route picker will automatically change the input to the Bluetooth HFP input. Therefore both the input and output will always end up on the Bluetooth HFP device even though only the input or output was set individually."
+
+In other words: **once HFP is engaged, input and output are bound together to the same Bluetooth device**. You cannot have "A2DP out + Bluetooth HFP in" or "A2DP out + built-in mic in over HFP". The hardware doesn't physically support it on the same link.
+
+### 3.4 Will the AirPods mic hear audio playing from another app?
+
+Scenarios:
+
+| Scenario | Result |
+|----------|--------|
+| User wears AirPods, plays Spotify, FlowFlow uses `playAndRecord` + `.allowBluetoothA2DP` | Spotify keeps using A2DP. AirPods mic is disabled. FlowFlow records from **built-in iPhone microphone**. Built-in mic does NOT pick up the AirPods speaker output (it's sealed in user's ears). Result: clean voice recording, no leakage of Spotify into the recording. |
+| Same but `.allowBluetooth` (HFP) | iOS switches AirPods to HFP. A2DP drops, so Spotify output becomes HFP-quality (terrible) or pauses. Mic is the AirPods mic — captures voice well at close range but doesn't pick up Spotify audio (Spotify is being routed *to* the same headset). |
+| Wired EarPods (Lightning/3.5mm headset) playing music + FlowFlow records | EarPods have a separate mic on the cable. iOS routes input to `AVAudioSessionPortHeadsetMic`. Music playing through EarPods speakers does not leak into the headset mic (acoustically isolated from the in-ear driver). Result: clean voice. |
+| iPhone on speakerphone playing podcast + FlowFlow records via built-in mic | Built-in mic captures both the user's voice **and** the podcast playing from the iPhone's speaker (poor SNR, no separation). This is the only "free" path to record system audio + voice — at terrible quality. |
+| External wired headset (USB-C, EarPods) playing media + recording from built-in mic | Possible by using `setPreferredInput(builtInMic)` to override the route. Built-in mic still doesn't hear headphones (sealed). |
+
+So the AirPods don't act as a Shazam-style ambient sniffer — they isolate output from input by design. Only acoustic leakage from a loudspeaker can land in the recording.
+
+### 3.5 Route change handling
+
+When the user plugs/unplugs headphones during a recording, you must observe `AVAudioSessionRouteChangeNotification`. Apple guide: [Responding to Route Changes](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/HandlingAudioHardwareRouteChanges/HandlingAudioHardwareRouteChanges.html).
+
+For FlowFlow with `cpal`, the equivalent is to listen via an Objective-C bridge (`NotificationCenter.default.addObserver(forName: AVAudioSession.routeChangeNotification ...)`). On `oldDeviceUnavailable`, decide whether to pause the recording (Apple recommends pause on unplug for playback; for recording it's safer to continue, since users often pull out earbuds while a recording continues).
+
+### 3.6 Recommended FlowFlow settings (already in place)
+
+For the existing FlowFlow recording flow:
+
+```text
+Initial state (app foreground, no recording):
+  setCategory(.playAndRecord,
+              mode: .default,
+              options: [.allowBluetoothA2DP, .defaultToSpeaker, .mixWithOthers])
+
+When user taps record:
+  setCategory(.playAndRecord,
+              mode: .measurement OR .default,
+              options: [.allowBluetoothA2DP, .defaultToSpeaker])
+  (drop .mixWithOthers so other apps are interrupted/ducked while recording)
+
+After recording stops:
+  Restore initial state.
+```
+
+Note: `mode: .measurement` disables the input AGC and processing — better for transcription accuracy at the cost of perceived loudness. Test both.
+
+**FlowFlow status**: initial state already correct. Could add the mid-recording toggle (drop `MixWithOthers`) but currently iOS will duck other audio automatically when the cpal stream activates.
+
+### 3.7 Routing references
+
+- Apple Q&A QA1799: [AVAudioSession Microphone Selection](https://developer.apple.com/library/archive/qa/qa1799/_index.html)
+- Apple: [Configuring an Audio Session](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionBasics/AudioSessionBasics.html)
+- Apple: [Responding to Route Changes](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/HandlingAudioHardwareRouteChanges/HandlingAudioHardwareRouteChanges.html)
+- Apple Forums: [Bluetooth with AVAudioSessionPlayAndRecord](https://developer.apple.com/forums/thread/4340?answerId=15178022)
+- Stack Overflow: [Recording from Built-In Mic when Playing through Bluetooth](https://stackoverflow.com/questions/30614134/recording-from-built-in-mic-when-playing-through-bluetooth-in-ios)
+- Stack Overflow: [Use internal mic for input and bluetooth for output](https://stackoverflow.com/questions/65571861/how-to-use-internal-mic-for-input-and-bluetooth-for-output)
+- Stack Overflow: [AVAudioSession and AirPods](https://stackoverflow.com/questions/47816753/avaudiosession-and-airpods)
+- Microsoft Learn: [Bluetooth A2DP/HFP accessory guidelines](https://learn.microsoft.com/en-us/windows-hardware/design/accessory-guidelines/bluetooth-accessory-guidelines/bluetooth-accessory-guidelines-classic-audio)
+
+---
+
+## 4. Importing audio files from the device
+
+### 4.1 The canonical API: `UIDocumentPickerViewController`
+
+For everything that lives in Files.app (Local, iCloud Drive, On My iPhone, third-party providers like Dropbox/Google Drive):
+
+```swift
+import UniformTypeIdentifiers
+let picker = UIDocumentPickerViewController(
+    forOpeningContentTypes: [UTType.audio],
+    asCopy: true
+)
+picker.delegate = self
+picker.allowsMultipleSelection = false
+present(picker, animated: true)
+```
+
+`UTType.audio` (the generic conformance) covers `mp3`, `m4a`, `wav`, `aac`, `aiff`, `caf`, `flac`, `opus`, `ogg` and other audio UTIs. The relevant UTIs: `public.mp3`, `com.apple.m4a-audio`, `com.microsoft.waveform-audio`, `public.aac-audio`, `public.aiff-audio`, `org.xiph.flac`, `org.xiph.ogg-audio`.
+
+For a narrower picker, pass an array, e.g. `[UTType.mp3, UTType.wav, UTType.mpeg4Audio]`.
+
+References:
+- Apple: [UIDocumentPickerViewController](https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller)
+- Apple: [documentPicker(_:didPickDocumentsAt:)](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/documentpicker(_:didpickdocumentsat:))
+- Stack Overflow: [Pick audio files from device library](https://stackoverflow.com/questions/47791284/how-to-pick-browse-audio-files-from-device-library-like-photo-library)
+- Stack Overflow: [Using UIDocumentPickerViewController(documentTypes:) in Swift (deprecation note)](https://stackoverflow.com/questions/66003954/using-uidocumentpickerviewcontrollerdocumenttypes-in-swift)
+- Programming-iOS-Book-Examples: [PickACloudSong example](https://github.com/mattneub/Programming-iOS-Book-Examples/blob/master/bk2ch23p803PickACloudSong/PickACloudSong/ViewController.swift)
+
+### 4.2 Security-scoped URLs (mandatory)
+
+When `asCopy: false`, picked URLs are security-scoped — you must wrap reads:
+
+```swift
+guard url.startAccessingSecurityScopedResource() else { return }
+defer { url.stopAccessingSecurityScopedResource() }
+let data = try Data(contentsOf: url)
+```
+
+When `asCopy: true`, iOS copies the file into your app's `tmp/...Inbox/` directory and the URL is local and non-scoped. Persist by moving to `Documents/`.
+
+FlowFlow's `read_file_as_text` in `src/platform/ios/picker.rs` already uses this pattern for text/PDF/DOCX. Add `asCopy: true` for audio and read the file bytes into Rust via `std::fs::read`.
+
+### 4.3 Voice Memos integration
+
+Voice Memos exports `.m4a` (AAC 64–128 kbps) via:
+- **Share sheet** ("Save to Files" → user picks destination; FlowFlow then picks it back via `UIDocumentPickerViewController`).
+- **AirDrop** to another device.
+- **Share Extension hosted by FlowFlow** — FlowFlow would advertise itself in the Voice Memos share sheet via an Action/Share Extension declaring `NSExtensionActivationRule` with `NSExtensionActivationSupportsFileWithMaxCount > 0` and audio UTIs.
+
+Apple docs:
+- [Share a recording in Voice Memos](https://support.apple.com/en-am/guide/iphone/iph3d6dc359/26/ios/26)
+- [Export a Voice Memos recording to Files](https://support.apple.com/en-nz/guide/iphone/iph831c37815/ios) — "Recordings are exported in .m4a format. Layered recordings are flattened and Spatial Audio becomes stereo."
+
+Field examples for share-extension audio receivers:
+- [Stack Overflow — Export audio files via Open In from Voice Memos](https://stackoverflow.com/questions/36763390/export-audiofiles-via-open-in-from-voice-memos-app)
+- [expo-audio-share-receiver — Share Extension that drops audio in App Group, deep-links to host](https://github.com/OKKHALIL3/expo-audio-share-receiver)
+- [Apple Forum — Extracting Updated Title from Voice Memos via Share Extension](https://developer.apple.com/forums/thread/744419)
+
+For FlowFlow MVP, the share-extension route is optional. The picker route already covers Voice Memos because the user can do "Share → Save to Files" once and then import — only 2 taps extra and zero extra native code.
+
+### 4.4 AirDrop received files
+
+When a user accepts an audio file via AirDrop and your app is registered for that UTI in `Info.plist` (`CFBundleDocumentTypes` with `LSItemContentTypes = ["public.audio"]`), iOS shows your app in the AirDrop receiver chooser. The file lands in `Documents/Inbox/`.
+
+### 4.5 What about MPMediaPickerController?
+
+`MPMediaPickerController` only browses the Apple Music / iTunes library (DRM-protected items). Selected items don't always yield a usable local file path — protected media is unreachable. For FlowFlow, **stay on `UIDocumentPickerViewController`** which sees user-imported files and Files.app providers.
+
+### 4.6 Implementation hints for FlowFlow
+
+In `src/platform/ios/picker.rs` extend the picker with an audio variant. The objc2 call:
+
+```text
+NSArray<UTType*> *types = @[UTType.audio];
+UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc]
+  initForOpeningContentTypes:types
+  asCopy:YES];
+picker.delegate = self;
+// present from key window's rootViewController
+```
+
+The picked URL is already a real file path in your sandbox — no security scope dance needed when `asCopy:YES`. Pass it to:
+
+```rust
+let bytes = std::fs::read(&picked_path)?;
+// hand to Soniox SonioxClient::transcribe (audio_url upload or multipart)
+```
+
+Add the UTI claim to `Info.plist` (`CFBundleDocumentTypes`) so users can also "Open in FlowFlow" from Files/Mail/AirDrop:
+
+```xml
+<key>CFBundleDocumentTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeName</key>
+    <string>Audio File</string>
+    <key>LSHandlerRank</key>
+    <string>Alternate</string>
+    <key>LSItemContentTypes</key>
+    <array>
+      <string>public.audio</string>
+      <string>public.mp3</string>
+      <string>com.apple.m4a-audio</string>
+      <string>com.microsoft.waveform-audio</string>
+      <string>public.aac-audio</string>
+    </array>
+  </dict>
+</array>
+```
+
+### 4.7 Import references (summary)
+
+- [Apple — UIDocumentPickerViewController](https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller)
+- [Apple — documentPicker(_:didPickDocumentsAt:)](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/documentpicker(_:didpickdocumentsat:))
+- [Apple — Voice Memos sharing](https://support.apple.com/en-am/guide/iphone/iph3d6dc359/26/ios/26)
+- [Apple — Export Voice Memos to Files](https://support.apple.com/en-nz/guide/iphone/iph831c37815/ios)
+- [Programmer AH — SwiftUI `.fileImporter` with audio](https://programmerah.com/swiftui-2-0-how-to-import-files-into-ios-apps-26846/)
+- [Stack Overflow — Pick audio file with UIDocumentPickerViewController](https://stackoverflow.com/questions/68070850/how-to-play-and-save-audiofile-from-filepath-ios-swift)
+- [Stack Overflow — Voice Memos share extension](https://stackoverflow.com/questions/36763390/export-audiofiles-via-open-in-from-voice-memos-app)
+
+---
+
+## 5. Soniox audio format support
+
+### 5.1 Async (file) transcription — used by FlowFlow
+
+Soniox auto-detects everything iOS records or imports:
+
+> "Soniox automatically detects audio formats for file transcription — no configuration required.
+> Supported formats: `aac, aiff, amr, asf, flac, mp3, ogg, wav, webm, m4a, mp4`"
+> — [Soniox docs — Async transcription](https://soniox.com/docs/stt/async/async-transcription)
+
+So a file picked via `UIDocumentPickerViewController` or recorded as `.wav` by `hound` (FlowFlow's current pipeline) or as `.m4a` from Voice Memos goes straight into the `transcriptions` REST endpoint without conversion.
+
+### 5.2 Real-time (streaming) transcription
+
+Same auto-detect, slightly narrower:
+
+> "Supported auto formats: `aac, aiff, amr, asf, flac, mp3, ogg, wav, webm`"
+> Raw formats requiring sample rate + channels: `pcm_s8`, `pcm_s16le/be`, `pcm_s24le/be`, `pcm_s32le/be`, unsigned variants, `pcm_f32`, `pcm_f64`, `mulaw`, `alaw`.
+> — [Soniox docs — Real-time](https://soniox.com/docs/stt/rt/real-time-transcription)
+
+If FlowFlow ever streams from cpal directly (skipping the WAV step), the right config:
+```json
+{"audio_format": "pcm_s16le", "sample_rate": 16000, "num_channels": 1}
+```
+cpal on iOS typically gives `f32` at 44.1 kHz from the built-in mic; convert to `s16le` at 16 kHz with linear resampling (or just send `pcm_f32le` at 44100). Soniox accepts both.
+
+### 5.3 API reference
+
+- REST API at `https://api.soniox.com/v1`. Endpoints: Files (upload), Transcriptions (create / get).
+- [Soniox API reference index](https://soniox.com/docs/api-reference)
+- [Create transcription](https://soniox.com/docs/api-reference/stt/transcriptions/create_transcription) — supports `file_id` OR `audio_url`.
+- [WebSocket API for real-time](https://soniox.com/docs/api-reference/stt/websocket-api).
+
+### 5.4 Practical iOS recording format → Soniox
+
+FlowFlow today: `cpal` + `hound` writes WAV (LPCM 16-bit). That's `wav` — directly transcribable, no conversion. Size is the only downside (~1.4 MB/min at 16 kHz mono).
+
+If you want to shrink uploads ~10× and battery cost, switch the iOS recorder to **AVAudioRecorder with AAC in an .m4a container**. AAC at 64 kbps mono = ~480 KB/min, still excellent Soniox accuracy. AVAudioRecorder writes the container correctly; no Rust encoder needed.
+
+Reference Apple types for m4a: `AVFileType.m4a` (UTI `com.apple.m4a-audio`).
+
+### 5.5 Do you need any Rust audio conversion?
+
+Probably **no** for FlowFlow's pipeline:
+- Mic capture → `.wav` (current) → Soniox WAV path: works.
+- Audio import → m4a/mp3/etc. → Soniox auto-detect: works.
+
+If you ever do need conversion in Rust (e.g. trim, normalize, re-encode), the right crates are:
+- **[Symphonia](https://github.com/pdeljanov/Symphonia)** (pure Rust, no C deps, iOS-friendly) — decodes m4a/aac, mp3, flac, wav, ogg, mkv. **Decode only**.
+- **hound** — already in FlowFlow — encode/decode WAV (PCM only).
+- **dasp** — sample type conversion (i16 ↔ f32) + resampling.
+- For AAC/MP3 **encoding** you need C bindings (`fdk-aac-sys`, `lame-sys`, `ffmpeg-sys-next`) — painful on iOS cross-compile. Avoid: re-encode via AVFoundation in a Swift bridge instead.
+
+Symphonia confirms iOS support explicitly: ["Mobile: Android, iOS"](https://pdeljanov-symphonia.mintlify.app/resources/faq).
+
+### 5.6 Soniox references
+
+- [Soniox — Async transcription](https://soniox.com/docs/stt/async/async-transcription)
+- [Soniox — Real-time transcription](https://soniox.com/docs/stt/rt/real-time-transcription)
+- [Soniox — WebSocket API](https://soniox.com/docs/api-reference/stt/websocket-api)
+- [Soniox — Create transcription](https://soniox.com/docs/api-reference/stt/transcriptions/create_transcription)
+- [Soniox — API reference index](https://soniox.com/docs/api-reference)
+- [Symphonia docs.rs](https://docs.rs/symphonia)
+- [Symphonia FAQ — iOS support](https://pdeljanov-symphonia.mintlify.app/resources/faq)
+
+---
+
+## Concrete next steps for FlowFlow
+
+Ordered by impact / effort ratio:
+
+1. **Add audio import to the document picker** (small, high value)
+   - File: `src/platform/ios/picker.rs` — add an `audio` variant returning a path.
+   - Add `audio` `AttachmentKind` (or reuse note `audio_file_path`) in `models/note.rs` / `models/attachment.rs`.
+   - Route the picked path into the existing Soniox `transcribe` flow (it already handles WAV; m4a/mp3 will also work via Soniox auto-detect).
+   - Register UTIs in `Info.plist` so the app shows up in AirDrop / Files share sheet.
+
+2. **AVAudioSession** — **already optimal in FlowFlow** (`playAndRecord` + `DefaultToSpeaker | AllowBluetoothA2DP | MixWithOthers`). Optional refinement: drop `MixWithOthers` mid-recording (cosmetic, iOS ducks automatically).
+
+3. **Skip call recording entirely** — document the limitation in the in-app help. Apple's native iOS 18+ Phone-app recorder is the only legal path and FlowFlow can't replicate it.
+
+4. **System audio capture (Broadcast Upload Extension)** — defer to a "Phase 2" track. Estimated effort: 1–2 weeks for the Xcode extension + signing + App Group + Rust bridge to read the produced file. Add as future Track in CLAUDE.md. Limitations to surface to users: DRM-protected content (Music/Spotify/Netflix/Safari video) returns silence by design; only "free" application audio (e.g. games, podcast players using native AVAudio, third-party browsers using non-AVPlayer pipelines) gets captured.
+
+5. **No Rust audio conversion needed** — keep things simple. If anything, consider switching the recorder backend from cpal+hound (`.wav`) to a thin Swift bridge using `AVAudioRecorder` writing m4a/AAC — 10× smaller uploads to Soniox, identical accuracy.

--- a/docs/brainstorm/system-audio-deep-dive.md
+++ b/docs/brainstorm/system-audio-deep-dive.md
@@ -1,0 +1,347 @@
+# iOS system audio capture — deep dive (2026)
+
+> Question: ANY way in 2026 to simultaneously capture (a) the user's microphone AND (b) other apps' audio output, route both into FlowFlow for transcription?
+> Date: 2026-05-23
+> Status: research only
+
+## TL;DR
+
+iOS in 2026 has **no public API** to capture other apps' audio cleanly mixed with mic.
+
+The ReplayKit Broadcast Upload Extension path (`audioApp` + `audioMic`) is the only sanctioned mechanism, but has structural limits:
+- 50 MB memory ceiling
+- User-initiated only (`RPSystemBroadcastPickerView`)
+- Runs in separate extension process
+- **AVPlayer-backed playback (YouTube, Spotify, Apple Music, Safari `<video>`, Netflix, Podcasts) emits silent buffers** — DRM/copyright carve-out enforced by `mediaserverd`
+
+macOS gained `SCStream` + microphone (WWDC24) and CoreAudio process taps (macOS 14.2+); **iOS did not get the parallel API**.
+
+AudioDriverKit ships on iPadOS 16+ (M-series) but only for physical hardware drivers — virtual devices remain prohibited.
+
+AirPlay-receiver-on-iPhone is technically possible (TestFlight prototypes exist) but blocked from App Store by entitlement gating.
+
+**Realistic shippable wins for FlowFlow:**
+- Speakerphone acoustic capture (lossy but works for any source)
+- ReplayKit for non-AVPlayer apps (Discord, games, some browsers)
+- iRig-style hardware loopback (niche pro path, lossless any source)
+- Screen Recording → import via Files (Track G already supports)
+
+## App Store policy — clarification
+
+**Apps shipping ReplayKit Broadcast Extension are ALLOWED.** Examples in production: Discord (screen share), LiveKit, Twilio Video, voiceping-ai/ios-mac-offline-transcribe.
+
+The DRM block on YouTube/Spotify/Apple Music is **runtime behavior** (`mediaserverd` zeroes the buffers), not a review rejection.
+
+What actually gets rejected:
+- AirPlay receiver mode (MFi entitlement gated, not granted to indies)
+- VoIP misclassification (fake CallKit use to grab background audio)
+- Private system-audio entitlements (never granted to third parties)
+- Virtual audio drivers (don't exist as API on iOS)
+
+| Approach | App Store | Works at runtime? |
+|----------|-----------|-------------------|
+| Broadcast Extension (games, Discord, AVAudioEngine apps) | OK | Yes |
+| Broadcast Extension + YouTube/Spotify | OK | **No** (silent buffers from `mediaserverd`) |
+| AirPlay receiver iPhone | Rejected | Yes technically |
+| Hardware loopback (iRig) | OK | Yes (any content) |
+| Screen Recording → import | OK | Yes for YouTube (silent for Apple Music/Netflix) |
+
+---
+
+## 1. Apps that produce non-silent `audioApp` buffers in 2026
+
+### Verdict: partial — works only for non-`AVPlayer` audio paths
+
+ReplayKit's `audioApp` is *not* a blanket DRM block. It's a `mediaserverd` policy: any audio routed through `AVPlayer` / `AVPlayerItem` / `MPMusicPlayerController` / `WKWebView`-backed `<video>` / `AVAudioPlayerItem` with FairPlay or "tagged-protected" routes produces zero buffers. Other audio sources come through.
+
+**Confirmed silent (AVPlayer-class):**
+- YouTube native iOS app, YouTube Music
+- Spotify (uses AVPlayer)
+- Apple Music, Apple Podcasts
+- Safari `<video>`/`<audio>`, WKWebView-backed audio (Apple Developer Forums thread 670482)
+- Netflix, Disney+, Prime Video
+- FaceTime / WhatsApp / Phone (CallKit explicitly carved out)
+
+**Confirmed working (non-AVPlayer):**
+- Most games using `AVAudioEngine`/OpenAL/Unity FMOD output (Genshin Impact, Clash Royale)
+- Discord voice channels (VoIP audio session, mixable subset)
+- Podcast players that use raw `AVAudioEngine` (Overcast in some configs, Pocket Casts)
+- Voice Memos playback
+- AVAudioEngine apps generally (AUM, Korg Gadget, synthesizers)
+- GarageBand playback
+- TikTok/Instagram in-feed (mixed — some assets blocked, some not)
+
+**Production example:** voiceping-ai/ios-mac-offline-transcribe (Feb 2026): ships "System Audio" mode via `RPSystemBroadcastPickerView` + Broadcast Upload Extension + mmap ring buffer between extension and main app, feeds Whisper.cpp ASR.
+- https://github.com/voiceping-ai/ios-mac-offline-transcribe
+
+**LiveKit SDK** (`client-sdk-swift`) same pattern with `ScreenShareCaptureOptions(appAudio: true)`. Notes "Application audio is not supported with In-App Capture mode" — only broadcast extension delivers `audioApp`.
+- https://github.com/livekit/client-sdk-swift/blob/main/Docs/ios-screen-sharing.md
+
+**App Store apps reviewed** (Just Press Record, AudioShare, Voice Memos, Meret, LudyRec, Tape It, Audiply, StudioMini, MicSwap, AudioLab): **none** advertise system-wide capture. All record mic or external USB/Lightning interfaces only.
+- https://audioutils.com/blog/how-to-record-audio-on-iphone
+
+**Effort for FlowFlow**: 1-2 weeks Rust-side. Broadcast Upload Extension Swift/Obj-C (can't be pure Rust), mmap ring buffer to main Rust process, feed buffer into existing Soniox path. Pattern proven by voiceping-ai.
+
+**Must disclose in UI**: "Cannot capture YouTube, Spotify, Apple Music or protected playback."
+
+Sources:
+- https://developer.apple.com/documentation/replaykit/rpbroadcastsamplehandler
+- https://support.apple.com/guide/security/replaykit-security-seca5fc039dd/web
+- https://developer.apple.com/forums/thread/670482
+- https://github.com/shogo4405/HaishinKit.swift/issues/849
+
+---
+
+## 2. iOS 17 / 18 / 19 / 26 API changes
+
+### Verdict: blocked — no new iOS API for cross-app audio capture
+
+Apple expanded **macOS** audio capture significantly while leaving iOS frozen.
+
+**WWDC24 "Capture HDR content with ScreenCaptureKit" (session 10088)**: added `captureMicrophone` + `microphoneCaptureDeviceID` on `SCStreamConfiguration` and `SCRecordingOutput`. **macOS only**. `ScreenCaptureKit` not available on iOS.
+- https://developer.apple.com/videos/play/wwdc2024/10088/
+- https://developer.apple.com/documentation/ScreenCaptureKit/
+
+**macOS 14.2+ CoreAudio process tap**: captures system audio without screen-recording permission. **iOS does not have process taps**.
+- https://nonstrict.eu/recordkit/guides/system-audio-recording.html
+
+**WWDC25 "Enhance your app's audio recording capabilities" (session 251)**: iOS 26 additions are all mic-side:
+- `AVInputPickerInteraction` — in-app input picker
+- `bluetoothHighQualityRecording` AVAudioSession category — AirPods H2 LAV-quality
+- Spatial Audio FOA capture via `AVAssetWriter`
+- Simultaneous `MovieFileOutput` + `AudioDataOutput`
+- QTA audio-only QuickTime format
+
+**Zero** new APIs for cross-app or system audio.
+- https://developer.apple.com/videos/play/wwdc2025/251/
+
+iOS 26 SDK **removed** `com.apple.developer.pushkit.unrestricted-voip.ptt` entitlement (Apple Forums 780822). Trend is narrowing privileged audio access, not widening.
+
+---
+
+## 3. AudioBus, Inter-App Audio (IAA), AUv3 hosting
+
+### Verdict: partial — only captures audio from *cooperating* apps
+
+**Inter-App Audio (IAA)**: deprecated since iOS 13. Still functions. AudioBus 3 builds on IAA + own protocol. Receivers can only get audio from apps that explicitly publish `AudioComponents` Info.plist entry and call `AudioOutputUnitPublish()`.
+
+YouTube/Spotify/Apple Music/Safari **do not publish IAA ports**.
+
+AudioBus is closed cooperative ecosystem of music-production apps (Loopy, Cubasis, Animoog, Korg Gadget, AUM).
+- https://developer.audiob.us/doc/_integration-_guide.html
+- https://developer.apple.com/documentation/bundleresources/entitlements/inter-app-audio
+
+**FlowFlow value**: zero coverage for actual user need (YouTube/Spotify/Podcast capture). Useful only if FlowFlow pivots to musicians.
+
+---
+
+## 4. AUv3 Audio Unit Extensions as receiver
+
+### Verdict: blocked for FlowFlow use case
+
+AUv3 extensions are plug-ins inside a host app. Extension talks to host, not to its own container app, not OS, not other apps. Apple DTS-confirmed (Stack Overflow 61360345): only way extension → container is shared memory in App Group, no real-time guarantees.
+
+Critically: you only receive audio when the **host app actively loads your AUv3** — Safari, Spotify, YouTube don't host AUv3 plugins.
+
+UX requires user to open DAW (GarageBand, AUM, Cubasis), add FlowFlow as effect insert, route playback through it. Two-app technical UX. Same coverage as AudioBus.
+- https://stackoverflow.com/questions/61360345/can-an-audio-unit-v3-replace-inter-app-audio-to-send-audio-to-a-host-app
+
+---
+
+## 5. AirPlay receiver mode
+
+### Verdict: works as TestFlight prototype, blocked from App Store
+
+iPad (M-series) gained native AirPlay receiver on iPadOS 17. **iPhone has never officially shipped AirPlay receiver** at OS level. iOS 26/iPadOS 26 did not change this for iPhone.
+
+**Third-party AirPlay receivers exist:**
+- **AirAP** (neon443/AirAP, May 2025): native Swift AirPlay server, TestFlight only.
+  - https://github.com/neon443/AirAP
+- **shairplay-rust** (metaneutrons/shairplay-rust, April 2026): pure-Rust AP1+AP2 receiver library with ALAC/AAC decode, ChaCha20-Poly1305, HomeKit pairing.
+  - https://github.com/metaneutrons/shairplay-rust
+- **rairplay** (r4v3n6101/rairplay) — similar Rust AP2 receiver.
+
+**Apple's App Store gate**: AirPlay receiver requires MFi (Made for iPhone) AirPlay 2 / AAC license + entitlements **never granted to indie developers**. Third-party AP2 receivers cannot send playback commands back (Type 130 MRP, companion-link, DACP all require HomeKit/Apple ID trust).
+
+**Latency**: AP1 ~2s, AP2 ~1s, plus ~10s setup delay for non-Apple receivers.
+
+**FlowFlow implementation in Rust**: shairplay-rust is `#![forbid(unsafe_code)]` and async on tokio — drops in. Build receiver, decode ALAC/AAC, feed PCM into transcription pipeline. UX: user toggles AirPlay in YouTube/Spotify → picks "FlowFlow" → audio streams.
+
+**Distribution blocker**: App Store reviewers will reject. TestFlight-only / sideload-only. Not viable for App Store launch.
+
+**Effort**: 2-3 weeks AP1 basic. 5-8 weeks AP2 with HomeKit pairing.
+
+---
+
+## 6. Hardware loopback workarounds
+
+### Verdict: works — niche pro-user path
+
+**iRig Stream Pro / iRig Stream Mic Pro / iRig HD X** (IK Multimedia): all advertise **"Device Loopback" / "Loopback+"**: routes iPhone audio output back into iPhone audio input on a single USB-C/Lightning cable.
+
+> "This option routes the audio output of your digital device (iPhone, iPad, Android, Mac or PC) back into iRig Stream Pro to be mixed in with the other audio signals. Perfect to jam or sing along with backing tracks, or process audio on one app and stream to another, all on a single device."
+> — https://www.ikmultimedia.com/products/irigstreampro/
+
+**This is genuine cross-app system-wide capture**: YouTube/Spotify play through iRig loopback channel, FlowFlow receives loopback + mic via USB audio interface as 2-channel input. **No silence problem because audio never leaves digital path through AVPlayer DRM gate** — bypasses to USB-class audio device.
+
+**Compatible devices:**
+- iRig Stream Pro (USB-C + Lightning + USB-A, 24/96, 4-ch)
+- iRig Stream Mic Pro (same loopback)
+- iRig HD X (USB-C, 24/96, Loopback+ as virtual FX loop)
+
+**Effort for FlowFlow**: Zero code if user owns iRig. Detect USB audio device via `AVAudioSession.availableInputs`, read 2-channel input, transcribe channel-1 (loopback), log channel-2 (mic) optionally.
+
+Sources:
+- https://www.ikmultimedia.com/products/irigstreampro/
+- https://www.ikmultimedia.com/products/irigstreammicpro/
+- https://www.ikmultimedia.com/products/irighdx/
+
+---
+
+## 7. VoIP / PushKit audio sessions
+
+### Verdict: blocked — no broader audio capture, just background privilege
+
+Apple DTS (Quinn, Kevin Elliott) across forum threads 758386, 810385, 774784, 806507: CallKit/LiveCommunicationKit/PushToTalk audio session is a privileged variant of PlayAndRecord with higher interruption priority, slightly louder output, background activation. Does **NOT** expose other apps' audio. Just lets your app keep recording in background.
+
+- `com.apple.developer.pushkit.unrestricted-voip` entitlement: deprecated, never granted, "probably an LLM hallucination" — Kevin Elliott DTS
+- `com.apple.developer.pushkit.unrestricted-voip.ptt`: **disabled in iOS 26 SDK**
+- VoIP background mode + PushKit: requires real telephony-class use. App Review rejects fake VoIP classification
+
+**Risk for FlowFlow**: misclassification = App Store rejection on §2.5.x. Zero capture value.
+
+Sources:
+- https://developer.apple.com/forums/thread/758386
+- https://developer.apple.com/forums/thread/810385
+- https://developer.apple.com/forums/thread/780822
+
+---
+
+## 8. DriverKit / Audio Server Plug-ins on iPad/iPhone
+
+### Verdict: blocked for iPhone, partial for iPadOS (physical hardware only)
+
+**AudioDriverKit** available on iPadOS 16+ **only on iPads with M-series chip**. **Not available on iPhone.** Even on iPadOS, Apple's explicit guidance:
+
+> "When creating a virtual device, best practice is to use an Audio Server Driver Plug-in instead. AudioDriverKit only supports physical audio devices."
+> — https://developer.apple.com/documentation/AudioDriverKit/creating-an-audio-device-driver
+
+**Audio Server Plug-ins are macOS-only.** No iOS/iPadOS equivalent. BlackHole, Loopback, Soundflower-style virtual devices cannot exist on iOS.
+
+---
+
+## 9. CoreAudioKit on iOS
+
+### Verdict: blocked — UI framework, not capture
+
+CoreAudioKit on iOS is UI shell for hosting AUv3 plugin views (`AUViewController`, `AUv3ViewController`). Does not expose virtual device registration, capture, or system audio interception.
+
+---
+
+## 10. Apple's own apps and private entitlements
+
+### Verdict: documented Apple-internal-only
+
+- **Voice Memos call recording (iOS 18+)**: opt-in call recording in Phone + Voice Memos — both parties hear announcement at start. Uses `callservicesd` via private entitlement, mandatory announcement, entitlement not exposed to third parties
+- **Logic Pro on iPad system-wide audio**: AUv3 host APIs publicly available + iPad-only AudioDriverKit + connected hardware. No private system-audio entitlement
+- **GarageBand iOS**: AudioBus / AUv3 / IAA. Public APIs
+- **FaceTime / Phone**: CallKit privileged session — privileged-recording session for its own mic input, not system audio
+
+There is **no documented case** of Apple granting a system-audio entitlement to a third-party app. Multiple Apple DTS posts state private entitlements not requestable.
+
+Audio Hijack (Rogue Amoeba) ships only on macOS for this exact reason; Paul Kafasis publicly stated iOS port impossible without entitlement.
+
+---
+
+## 11. Recent App Store apps claiming system audio capture
+
+### Verdict: none deliver — all rely on mic acoustic capture or AirPlay-to-Mac workflow
+
+Reviewed: Just Press Record, AudioShare, Voice Memos, Tape It, Meret, LudyRec, AudioLab, Audiply, StudioMini, MicSwap Remix, Dolby On, Rev Voice Recorder, TapeACall.
+
+**Pattern:**
+- "Record everything" apps record **microphone only** (sometimes with USB interface)
+- Call recorders (TapeACall, Rev) bridge call through their own conference server — record **server-side**, not on-device. Mandatory two-party announcement
+- Phone-call-recording hardware (UMEVO Note Plus, iRecorder Pro): use vibration conduction sensors or BT headset profile, not iOS APIs
+
+> "There is no built-in way to record a phone call on iPhone in 2026. iOS does not expose a system-audio API to apps … no app — first-party or otherwise — can capture audio of a normal phone call or FaceTime call. Apple has been explicit that this is a deliberate privacy boundary."
+> — https://audioutils.com/blog/how-to-record-audio-on-iphone
+
+Only iOS app surfaced that genuinely captures non-AVPlayer system audio is **voiceping-ai/ios-mac-offline-transcribe** — not App Store, open-source, ReplayKit broadcast extension pattern.
+
+---
+
+## 12. Workarounds that actually work in production
+
+### 12a. Speakerphone + built-in mic acoustic capture
+
+**Verdict: works, ships today, lossy**
+
+User plays YouTube/Spotify/Podcast on iPhone speaker, FlowFlow records via mic. Quality penalty: speaker EQ, room reverb, mic AGC, ~6-10 dB SNR loss. Transcription quality drops moderately for clean speech, significantly for music or low-volume content.
+
+**Effort**: zero — FlowFlow's current capability.
+
+### 12b. Screen Recording pre-step → Files → import
+
+**Verdict: works, 2-step UX, lossless for most**
+
+User uses iOS Control Center → Screen Recording → records YouTube playback (Apple's first-party `replayd` does *not* zero out for protected content into user's own Photos/Files). Save MOV/MP4 to Files. Import into FlowFlow as attachment (Track G supports), extract audio via `AVAssetExportSession`, transcribe.
+
+**Catch**: Apple's screen recorder also gets silence on some protected playback (Apple Music, Netflix). YouTube via Safari and YouTube native app *do* record audio.
+
+**Effort for FlowFlow**: ~3-5 days. Add `AVAssetExportSession` audio extraction to existing attachment import path. Excellent fit — Track G already imports files.
+
+### 12c. AirPlay → Mac → capture → AirDrop
+
+**Verdict: works, multi-device, Mac required**
+
+User AirPlays YouTube/Spotify to Mac running QuickTime + BlackHole. Mac records lossless. AirDrops file back. FlowFlow imports.
+
+**Effort**: zero — already supported via Track G.
+
+### 12d. TRRS splitter inverted
+
+**Verdict: physically unreliable, not recommended**
+
+iPhone connector auto-detects TRRS vs TRS. Feeding line-level signal back into ring contact won't produce clean capture; AGC and impedance issues.
+
+### 12e. Audio Hijack approach ported
+
+**Verdict: blocked**
+
+Audio Hijack uses macOS-only kext/CoreAudio HAL plug-ins. No iOS equivalent.
+
+---
+
+## Ranked realistic options table
+
+| Rank | Option | User value | Engineering cost | App Store risk | YouTube/Spotify coverage | Ship rec |
+|------|--------|------------|------------------|----------------|--------------------------|----------|
+| 1 | Document limitation + speakerphone path | Low | 0 days | None | Acoustic only, lossy | **Ship in v1 docs** |
+| 2 | Screen Recording → import via Files | Medium-High | 3-5 days | None | Yes YouTube; no Apple Music/Netflix | **Ship as primary documented workaround** |
+| 3 | ReplayKit Broadcast Upload Extension | Medium (games, Discord, podcasts) | 1-2 weeks | None | No (AVPlayer silent) | **Ship in v2 — disclose AVPlayer limit** |
+| 4 | iRig hardware loopback | High pro users, niche overall | 3-5 days | None | Yes (all apps, all content) | **Document as pro path** |
+| 5 | AirPlay → Mac → AirDrop | Medium (Mac users) | 0 (Track G) | None | Yes | **Document workaround** |
+| 6 | AudioBus SDK | Very low (musicians only) | 1 week | None | No | **Skip unless musician pivot** |
+| 7 | AUv3 host or extension | Very low | 2-3 weeks | None | No | **Skip** |
+| 8 | AirPlay receiver mode | Very high | 2-8 weeks | **High App Store rejection** | Yes | **Skip for App Store; TestFlight beta possible** |
+| 9 | VoIP/CallKit reclassification | Negative | 1-2 weeks | High rejection | No | **Skip** |
+| 10 | AudioDriverKit virtual device | N/A | N/A | N/A | N/A | **Blocked** |
+
+---
+
+## Concrete recommendation for FlowFlow
+
+**Ship sequence:**
+
+1. **v1 (now)**: Settings doc page explaining OS limitation, speakerphone workaround, Screen-Recording-then-import workflow. Effort: hours.
+
+2. **v1.1 (next sprint)**: Wire `AVAssetExportSession` audio extraction into Track G attachment import so a screen-recording `.mov` → audio → transcription pipeline runs in one tap. Effort: 3-5 days. **Highest value/cost ratio.**
+
+3. **v2 (later)**: Add ReplayKit Broadcast Upload Extension with mmap ring buffer (clone voiceping-ai pattern). Surface "System Audio Mode" toggle with explicit disclosure: "Captures audio from games, Discord, and many apps. **Does not capture YouTube, Spotify, Apple Music, Safari video, FaceTime or phone calls** — Apple enforces this." Effort: 1-2 weeks. Useful for Discord meetings, gameplay, voice-channel content.
+
+4. **v2.x optional**: Detect iRig/Apogee/Rode USB audio devices in input picker, route loopback channel into transcription. Effort: 3-5 days. Power-user feature.
+
+5. **Skip permanently**: AirPlay receiver (App Store rejection), VoIP misclassification (rejection), AudioBus/AUv3 (no coverage benefit), AudioDriverKit (not allowed for virtual devices on iOS).
+
+The path of "do nothing technical, document well, add file import for Screen Recording" is the highest-ROI move — unblocks 80% of real user needs without engineering risk.


### PR DESCRIPTION
## Summary

- Restore the README hero (logo, Awesome Dioxus badge, narrative intro, hyperlinked stack table, How-it-works diagram) lost in the previous rewrite.
- Keep all new content (Dynamic Island, AVAudioSession interruption handling, Dioxus 0.7.9, `make all` auto-renew, `make appstore`, iOS 16.0 floor).
- Add two brainstorm research notes on iOS audio capture (system audio limits, file import, App Store policy clarification, ranked shippable options).
- Refresh GitNexus symbol counts in AGENTS.md / CLAUDE.md.

No code changes. Docs only.

## Test plan

- [x] README.md renders correctly on GitHub (logo, badges, links)
- [x] `docs/logo.png` referenced at `docs/logo.png` (file exists)
- [x] Existing make commands documented (`make all`, `make renew`, `make check-profiles`, `make appstore`)
- [x] Brainstorm files under `docs/brainstorm/` are pure documentation