### PR TITLE
feat(i18n): full FR/EN localization with system detection + picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1763 symbols, 2883 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1762 symbols, 2884 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1762 symbols, 2884 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1825 symbols, 3158 relationships, 147 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1763 symbols, 2883 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1762 symbols, 2884 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1762 symbols, 2884 relationships, 108 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1825 symbols, 3158 relationships, 147 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,6 +3201,8 @@ dependencies = [
  "cpal",
  "dioxus",
  "dotenvy",
+ "fluent-bundle",
+ "fluent-langneg",
  "futures",
  "futures-timer",
  "hound",
@@ -3222,8 +3224,43 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "unic-langid",
  "uuid",
  "zip",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4363,6 +4400,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
 ]
 
 [[package]]
@@ -6980,7 +7036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6999,7 +7055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7922,6 +7978,21 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.2.2",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -8897,6 +8968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -9303,6 +9375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "type1-encoding-parser"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9316,6 +9397,24 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -10505,6 +10604,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ pdf-extract = "0.10"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 quick-xml = "0.36"
 regex = "1"
+fluent-bundle = "0.15"
+fluent-langneg = "0.13"
+unic-langid = "0.9"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc2 = "0.6"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,32 @@ Once your paid Apple Developer Program is active, profiles last 1 year and `make
 
 End-to-end submission walkthrough: [docs/deploy/02-app-store-submission.md](docs/deploy/02-app-store-submission.md). Sequential execution plan: [docs/deploy/03-execution-plan.md](docs/deploy/03-execution-plan.md).
 
+### Glossary
+
+- **IPA** — iOS App Archive. A signed `.ipa` is the zipped, signed bundle Apple accepts. `make appstore` builds it.
+- **ASC** — [App Store Connect](https://appstoreconnect.apple.com). Apple's web dashboard to upload builds, fill metadata, attach screenshots, and submit for review.
+- **Transporter** — [free Mac app](https://apps.apple.com/app/transporter/id1450874784) to upload an `.ipa` to ASC.
+- **Provisioning profile** — Apple signed file that authorizes your bundle ID + cert combo. Generated once at [developer.apple.com](https://developer.apple.com/account/resources/profiles/list).
+- **CFBundleVersion / CFBundleShortVersionString** — build number (must increment every upload) and user-visible version (e.g. `1.0.0`).
+- **Bundle ID** — unique app identifier (`com.mirkobozzetto.flowflow`). Tied to the provisioning profile.
+
+### Push an update (continuous releases)
+
+Workflow once the app is live on the Store:
+
+1. Bump `CFBundleVersion` in `Makefile` (line 74) by `+1`. ASC rejects duplicate build numbers. Bump `CFBundleShortVersionString` only on user-visible releases (e.g. `1.0.0` → `1.0.1`).
+2. `make appstore` → fresh signed `FlowFlow.ipa`.
+3. Open Transporter → drag the `.ipa` → Deliver. Apple processes the build (5–30 min).
+4. ASC → your app → **TestFlight or App Store tab** → attach the new build to the current version, or create a new version (`+ Version` button) if you bumped the short version string.
+5. Update locale-specific metadata (description, keywords, screenshots) if needed — see *Multilingual releases* below.
+6. **Submit for Review**. Apple usually answers within 24h.
+
+### Multilingual releases
+
+The app auto-detects the iPhone system language at boot (NSLocale) and falls back to English. Users can switch language any time via Settings → Langue / Language. Supported locales: `en`, `fr`.
+
+For ASC: add **English (U.S.)** and **French (France)** under App Information → Localizations. Each locale needs its own screenshots (iPhone 6.9", 1320×2868), description, and keywords. Upload locale screenshots separately in each language tab.
+
 ## Tests
 
 ```bash

--- a/src/db/settings_repo.rs
+++ b/src/db/settings_repo.rs
@@ -1,5 +1,7 @@
 use crate::db::Database;
 
+pub const LANGUAGE_KEY: &str = "language";
+
 impl Database {
     pub fn get_setting(&self, key: &str) -> Option<String> {
         let conn = self.conn();

--- a/src/models/note.rs
+++ b/src/models/note.rs
@@ -1,32 +1,5 @@
-use chrono::{Datelike, Timelike};
+use chrono::Datelike;
 use serde::{Deserialize, Serialize};
-
-pub fn generate_auto_title() -> String {
-    let now = chrono::Local::now();
-    let months = [
-        "janvier",
-        "février",
-        "mars",
-        "avril",
-        "mai",
-        "juin",
-        "juillet",
-        "août",
-        "septembre",
-        "octobre",
-        "novembre",
-        "décembre",
-    ];
-    let month = months[now.month0() as usize];
-    format!(
-        "{} {} {}, {:02}:{:02}",
-        now.day(),
-        month,
-        now.year(),
-        now.hour(),
-        now.minute()
-    )
-}
 
 const FR_MONTHS: [&str; 12] = [
     "janvier",
@@ -43,6 +16,33 @@ const FR_MONTHS: [&str; 12] = [
     "décembre",
 ];
 
+const EN_MONTHS: [&str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
+pub fn generate_auto_title(lang: &str) -> String {
+    let now = chrono::Local::now();
+    let months = if lang == "fr" { &FR_MONTHS } else { &EN_MONTHS };
+    let month = months[now.month0() as usize];
+    let time = if lang == "fr" {
+        now.format("%H:%M").to_string()
+    } else {
+        now.format("%-I:%M %p").to_string()
+    };
+    format!("{} {} {}, {}", now.day(), month, now.year(), time)
+}
+
 pub fn is_auto_title(title: &str) -> bool {
     let parts: Vec<&str> = title.splitn(2, ',').collect();
     if parts.len() != 2 {
@@ -54,6 +54,7 @@ pub fn is_auto_title(title: &str) -> bool {
         return false;
     }
     FR_MONTHS.iter().any(|m| date_part.contains(m))
+        || EN_MONTHS.iter().any(|m| date_part.contains(m))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -118,6 +118,32 @@ pub fn hide_keyboard_accessory() {
     }
 }
 
+pub fn detect_system_language() -> String {
+    let result = std::panic::catch_unwind(|| unsafe {
+        let cls = objc2::ffi::objc_getClass(c"NSLocale".as_ptr());
+        if cls.is_null() {
+            return None;
+        }
+        let locale: *mut objc2::runtime::AnyObject = objc2::msg_send![
+            cls as *const objc2::runtime::AnyClass,
+            currentLocale
+        ];
+        if locale.is_null() {
+            return None;
+        }
+        let lang: *const objc2_foundation::NSString =
+            objc2::msg_send![&*locale, languageCode];
+        if lang.is_null() {
+            return None;
+        }
+        Some((*lang).to_string())
+    });
+    match result {
+        Ok(Some(code)) if code.starts_with("fr") => "fr".to_string(),
+        _ => "en".to_string(),
+    }
+}
+
 pub fn documents_dir() -> PathBuf {
     let home = std::env::var("HOME").expect("HOME not set on iOS");
     PathBuf::from(home).join("Documents")

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,2 +1,12 @@
 #[cfg(target_os = "ios")]
 pub mod ios;
+
+#[cfg(target_os = "ios")]
+pub fn detect_system_language() -> String {
+    ios::detect_system_language()
+}
+
+#[cfg(not(target_os = "ios"))]
+pub fn detect_system_language() -> String {
+    "en".to_string()
+}

--- a/src/services/i18n/locales/en.ftl
+++ b/src/services/i18n/locales/en.ftl
@@ -1,0 +1,117 @@
+consent-title = Ready to never forget anything?
+consent-description = Capture your thoughts by voice, organize them by theme, import your documents, chat with your notes, develop your ideas and much more with AI!
+consent-cta = Let's go!
+consent-disclaimer = By continuing, you agree that your data will be processed by third-party AI services through your API keys.
+
+settings-api-keys-title = API Keys
+settings-openai-label = OpenAI API Key
+settings-soniox-label = Soniox API Key
+settings-soniox-placeholder = Soniox key
+sources-one = 1 source
+sources-many = { $count } sources
+settings-search-title = Search
+settings-max-sources = Max sources
+settings-save = Save
+settings-saved = Saved ✓
+settings-storage-title = Storage
+settings-cleanup-audio = Clean up audio files
+settings-cleanup-confirm = Confirm? Notes stay intact.
+settings-cleanup-done = audio files removed
+settings-cleanup-error = Error
+settings-no-audio = No audio file
+settings-keys-stored-locally = Keys are stored locally on this device.
+settings-ai-services-title = AI Services
+settings-ai-services-description = Soniox, OpenAI and Anthropic are used for transcription, semantic search and chat.
+settings-revoke-consent = Revoke consent
+
+sidebar-new-conversation = New conversation
+sidebar-no-conversations = No conversation
+sidebar-untitled = Untitled
+sidebar-delete-confirm = Delete?
+sidebar-yes = Yes
+sidebar-no = No
+sidebar-folders-title = Themes
+sidebar-folder-placeholder = Theme name
+sidebar-no-folders = No theme
+sidebar-subfolder-placeholder = Subtheme
+
+note-list-search-placeholder = Search my notes...
+note-list-no-results = No result
+note-list-no-results-hint = Try another term
+note-list-welcome = Welcome
+note-list-first-note-hint = Tap + for your first note
+
+chat-menu-rename = Rename
+chat-menu-cancel = Cancel
+chat-menu-ok = OK
+chat-menu-delete-title = Delete this chat?
+chat-menu-delete-warning = This action is irreversible.
+chat-menu-delete = Delete
+chat-menu-rename-action = Rename
+chat-menu-delete-chat = Delete chat
+
+chat-empty-title = Chat with your notes
+chat-empty-hint = Ask a question, I'll search your notes.
+
+chat-tool-search = Searching notes...
+chat-tool-create = Creating note...
+chat-tool-summarize = Summarizing folder...
+chat-tool-working = Agent working...
+chat-error = Error
+
+recording-dictate = Dictate
+
+folder-picker-all = All notes
+
+settings-language-section = Language
+language-en = English
+language-fr = French
+
+sidebar-tab-notes = Notes
+sidebar-tab-chats = Chats
+sidebar-all-notes = All my notes
+sidebar-settings = Settings
+
+top-bar-folder-fallback = Theme
+top-bar-all-notes = All notes
+
+note-title-placeholder = Title
+note-created-on = Created on { $date }
+note-content-placeholder = Note content...
+note-transcribing-placeholder = Transcribing...
+note-transcribing-short = Transcribing...
+note-transcribe-action = Transcribe
+note-audios-label = Recordings ({ $count })
+note-recording-error = Error: { $message }
+
+note-card-untitled = Untitled
+
+note-menu-import = Import a document
+note-menu-delete = Delete note
+
+note-extract-interrupted = Extraction interrupted
+note-file-too-large = File too large ({ $size } MB, max 20 MB)
+note-file-too-complex = File too complex (timeout { $mins }min)
+note-import-in-progress = Importing...
+note-import-save-error = Save error: { $error }
+note-import-error = Import error: { $error }
+
+attachment-confirm-delete = Delete?
+attachment-cancel = Cancel
+attachment-delete = Delete
+
+audio-confirm-delete = Delete?
+
+tag-add-placeholder = + tag
+tag-auto-action = Auto-tag
+
+chat-input-placeholder = Ask a question...
+
+recording-cancel-hint = double-tap to cancel
+recording-pause-label = Paused
+recording-transcribing = Transcribing...
+
+date-just-now = Just now
+date-mins-ago = { $mins } min ago
+date-hours-ago = { $hours }h ago
+date-yesterday = Yesterday, { $time }

--- a/src/services/i18n/locales/fr.ftl
+++ b/src/services/i18n/locales/fr.ftl
@@ -1,0 +1,117 @@
+consent-title = Prêt à ne plus rien oublier ?
+consent-description = Capturez vos pensées à la voix, organisez-les par thèmes, importez vos documents, discutez avec vos notes, développez vos idées et bien plus grâce à l'IA !
+consent-cta = C'est parti !
+consent-disclaimer = En continuant, vous acceptez que vos données soient traitées par des services d'IA tiers via vos clés API.
+
+settings-api-keys-title = Clés API
+settings-openai-label = Clé API OpenAI
+settings-soniox-label = Clé API Soniox
+settings-soniox-placeholder = Clé Soniox
+sources-one = 1 source
+sources-many = { $count } sources
+settings-search-title = Recherche
+settings-max-sources = Max sources
+settings-save = Enregistrer
+settings-saved = Enregistré ✓
+settings-storage-title = Stockage
+settings-cleanup-audio = Nettoyer les fichiers audio
+settings-cleanup-confirm = Confirmer ? Les notes restent intactes.
+settings-cleanup-done = fichiers audio supprimés
+settings-cleanup-error = Erreur
+settings-no-audio = Aucun fichier audio
+settings-keys-stored-locally = Les clés sont stockées localement sur cet appareil.
+settings-ai-services-title = Services IA
+settings-ai-services-description = Soniox, OpenAI et Anthropic sont utilisés pour la transcription, la recherche sémantique et le chat.
+settings-revoke-consent = Révoquer le consentement
+
+sidebar-new-conversation = Nouvelle conversation
+sidebar-no-conversations = Aucune conversation
+sidebar-untitled = Sans titre
+sidebar-delete-confirm = Supprimer ?
+sidebar-yes = Oui
+sidebar-no = Non
+sidebar-folders-title = Thèmes
+sidebar-folder-placeholder = Nom du thème
+sidebar-no-folders = Aucun thème
+sidebar-subfolder-placeholder = Sous-thème
+
+note-list-search-placeholder = Chercher mes notes...
+note-list-no-results = Aucun résultat
+note-list-no-results-hint = Essayez un autre terme
+note-list-welcome = Bienvenue
+note-list-first-note-hint = Appuie sur + pour ta première note
+
+chat-menu-rename = Renommer
+chat-menu-cancel = Annuler
+chat-menu-ok = OK
+chat-menu-delete-title = Supprimer ce chat ?
+chat-menu-delete-warning = Cette action est irréversible.
+chat-menu-delete = Supprimer
+chat-menu-rename-action = Renommer
+chat-menu-delete-chat = Supprimer le chat
+
+chat-empty-title = Chat avec tes notes
+chat-empty-hint = Pose une question, je cherche dans tes notes.
+
+chat-tool-search = Recherche dans les notes...
+chat-tool-create = Création de la note...
+chat-tool-summarize = Résumé du dossier...
+chat-tool-working = L'agent travaille...
+chat-error = Erreur
+
+recording-dictate = Dicter
+
+folder-picker-all = Toutes les notes
+
+settings-language-section = Langue
+language-en = Anglais
+language-fr = Français
+
+sidebar-tab-notes = Notes
+sidebar-tab-chats = Chats
+sidebar-all-notes = Toutes mes notes
+sidebar-settings = Réglages
+
+top-bar-folder-fallback = Thème
+top-bar-all-notes = Toutes les notes
+
+note-title-placeholder = Titre
+note-created-on = Créé le { $date }
+note-content-placeholder = Contenu de la note...
+note-transcribing-placeholder = Transcription en cours...
+note-transcribing-short = Transcription...
+note-transcribe-action = Transcrire
+note-audios-label = Enregistrements ({ $count })
+note-recording-error = Erreur : { $message }
+
+note-card-untitled = Sans titre
+
+note-menu-import = Importer un document
+note-menu-delete = Supprimer la note
+
+note-extract-interrupted = Extraction interrompue
+note-file-too-large = Fichier trop volumineux ({ $size } MB, max 20 MB)
+note-file-too-complex = Fichier trop complexe (timeout { $mins }min)
+note-import-in-progress = Importation en cours...
+note-import-save-error = Erreur sauvegarde : { $error }
+note-import-error = Erreur import : { $error }
+
+attachment-confirm-delete = Supprimer ?
+attachment-cancel = Annuler
+attachment-delete = Supprimer
+
+audio-confirm-delete = Supprimer ?
+
+tag-add-placeholder = + tag
+tag-auto-action = Auto-tag
+
+chat-input-placeholder = Pose une question...
+
+recording-cancel-hint = double-tap pour annuler
+recording-pause-label = Pause
+recording-transcribing = Transcription...
+
+date-just-now = À l'instant
+date-mins-ago = Il y a { $mins } min
+date-hours-ago = Il y a { $hours }h
+date-yesterday = Hier, { $time }

--- a/src/services/i18n/mod.rs
+++ b/src/services/i18n/mod.rs
@@ -1,0 +1,74 @@
+use fluent_bundle::concurrent::FluentBundle;
+use fluent_bundle::{FluentArgs, FluentResource, FluentValue};
+use std::sync::OnceLock;
+use unic_langid::LanguageIdentifier;
+
+const EN_FTL: &str = include_str!("locales/en.ftl");
+const FR_FTL: &str = include_str!("locales/fr.ftl");
+
+struct Bundles {
+    en: FluentBundle<FluentResource>,
+    fr: FluentBundle<FluentResource>,
+}
+
+static BUNDLES: OnceLock<Bundles> = OnceLock::new();
+
+fn build_bundle(lang: &str, ftl: &str) -> FluentBundle<FluentResource> {
+    let langid: LanguageIdentifier =
+        lang.parse().unwrap_or_else(|_| "en".parse().unwrap());
+    let mut bundle = FluentBundle::new_concurrent(vec![langid]);
+    bundle.set_use_isolating(false);
+    if let Ok(res) = FluentResource::try_new(ftl.to_string()) {
+        let _ = bundle.add_resource(res);
+    }
+    bundle
+}
+
+fn bundles() -> &'static Bundles {
+    BUNDLES.get_or_init(|| Bundles {
+        en: build_bundle("en", EN_FTL),
+        fr: build_bundle("fr", FR_FTL),
+    })
+}
+
+fn lookup(
+    bundle: &FluentBundle<FluentResource>,
+    key: &str,
+    args: Option<&FluentArgs>,
+) -> Option<String> {
+    let msg = bundle.get_message(key)?;
+    let pattern = msg.value()?;
+    let mut errors = vec![];
+    let out = bundle.format_pattern(pattern, args, &mut errors);
+    Some(out.into_owned())
+}
+
+pub fn t(lang: &str, key: &str) -> String {
+    t_args(lang, key, &[])
+}
+
+pub fn t_args(lang: &str, key: &str, args: &[(&str, &str)]) -> String {
+    let b = bundles();
+    let primary = match lang {
+        "fr" => &b.fr,
+        _ => &b.en,
+    };
+    let mut fluent_args = FluentArgs::new();
+    for (k, v) in args {
+        fluent_args.set(k.to_string(), FluentValue::from(v.to_string()));
+    }
+    let args_opt = if args.is_empty() {
+        None
+    } else {
+        Some(&fluent_args)
+    };
+    if let Some(v) = lookup(primary, key, args_opt) {
+        return v;
+    }
+    if !std::ptr::eq(primary, &b.en) {
+        if let Some(v) = lookup(&b.en, key, args_opt) {
+            return v;
+        }
+    }
+    key.to_string()
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod audio;
 pub mod constants;
 pub mod embed;
 pub mod error;
+pub mod i18n;
 pub mod llm;
 pub mod rag;
 pub mod tools;

--- a/src/ui/chat/actions.rs
+++ b/src/ui/chat/actions.rs
@@ -12,6 +12,7 @@ pub fn md_to_html(md: &str) -> String {
     html_output
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn send_question(
     question: String,
     messages: &mut Signal<Vec<ChatMsg>>,
@@ -20,6 +21,7 @@ pub fn send_question(
     conversation_id: Signal<Option<String>>,
     db: Signal<Arc<Database>>,
     folder_id: Option<String>,
+    lang: String,
 ) {
     messages.write().push(ChatMsg::User(question.clone()));
     loading.set(true);
@@ -38,11 +40,12 @@ pub fn send_question(
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
+    let lang_for_tools = lang.clone();
     spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
                 crate::services::tools::ToolEvent::Started(name) => {
-                    ts.set(Some(tool_label(&name).to_string()));
+                    ts.set(Some(tool_label(&lang_for_tools, &name)));
                 }
                 crate::services::tools::ToolEvent::Finished(_) => {
                     ts.set(None);
@@ -99,7 +102,11 @@ pub fn send_question(
                 });
             }
             Err(e) => {
-                let err_msg = format!("Erreur : {e}");
+                let err_msg = format!(
+                    "{} : {}",
+                    crate::services::i18n::t(&lang, "chat-error"),
+                    e
+                );
                 if let Some(ref cid) = conv_signal() {
                     let _ = db().add_message(cid, "bot", &err_msg, None);
                 }

--- a/src/ui/chat/empty_state.rs
+++ b/src/ui/chat/empty_state.rs
@@ -1,7 +1,11 @@
+use crate::services::i18n::t;
+use crate::ui::AppState;
 use dioxus::prelude::*;
 
 #[component]
 pub fn ChatEmptyState() -> Element {
+    let app: AppState = use_context();
+    let lang = (app.current_lang)();
     rsx! {
         div {
             class: "flex flex-col items-center justify-center px-6 h-full",
@@ -12,10 +16,10 @@ pub fn ChatEmptyState() -> Element {
                 class: "mb-6 rounded-3xl",
             }
             p { class: "text-stone-900 font-semibold text-base mb-1",
-                "Chat avec tes notes"
+                {t(&lang, "chat-empty-title")}
             }
             p { class: "text-stone-400 text-sm text-center",
-                "Pose une question, je cherche dans tes notes."
+                {t(&lang, "chat-empty-hint")}
             }
         }
     }

--- a/src/ui/chat/menu.rs
+++ b/src/ui/chat/menu.rs
@@ -1,4 +1,5 @@
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::state::View;
 use crate::ui::AppState;
@@ -26,6 +27,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
     } = props;
 
     let has_conversation = conversation_id().is_some();
+    let lang = (app.current_lang)();
 
     rsx! {
         div {
@@ -39,7 +41,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
             class: "absolute right-4 top-1 z-50 bg-warm-white rounded-xl shadow-lg border border-stone-100 py-1 min-w-[220px]",
             if renaming() {
                 div { class: "px-4 py-3",
-                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide mb-2", "Renommer" }
+                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide mb-2", {t(&lang, "chat-menu-rename")} }
                     input {
                         class: "w-full text-sm border border-stone-200 rounded-lg px-3 py-2 outline-none focus:border-ios-orange-dark",
                         value: "{rename_input}",
@@ -64,7 +66,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                                 renaming.set(false);
                                 app.show_chat_menu.set(false);
                             },
-                            "Annuler"
+                            {t(&lang, "chat-menu-cancel")}
                         }
                         button {
                             class: "flex-1 h-8 text-sm text-white bg-ios-orange rounded-lg active:opacity-80",
@@ -78,14 +80,14 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                                 renaming.set(false);
                                 app.show_chat_menu.set(false);
                             },
-                            "OK"
+                            {t(&lang, "chat-menu-ok")}
                         }
                     }
                 }
             } else if confirm_delete() {
                 div { class: "px-4 py-3",
-                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide mb-1", "Supprimer ce chat ?" }
-                    p { class: "text-xs text-stone-500 mb-3", "Cette action est irréversible." }
+                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide mb-1", {t(&lang, "chat-menu-delete-title")} }
+                    p { class: "text-xs text-stone-500 mb-3", {t(&lang, "chat-menu-delete-warning")} }
                     div { class: "flex gap-2",
                         button {
                             class: "flex-1 h-9 text-sm font-medium text-stone-900 bg-stone-100 rounded-full active:bg-stone-200",
@@ -93,7 +95,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                                 confirm_delete.set(false);
                                 app.show_chat_menu.set(false);
                             },
-                            "Annuler"
+                            {t(&lang, "chat-menu-cancel")}
                         }
                         button {
                             class: "flex-1 h-9 text-sm font-medium text-white bg-ios-red rounded-full active:opacity-80",
@@ -110,7 +112,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                                     app.view.set(View::NotesList);
                                 });
                             },
-                            "Supprimer"
+                            {t(&lang, "chat-menu-delete")}
                         }
                     }
                 }
@@ -129,7 +131,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                         renaming.set(true);
                     },
                     IconPencil { size: 18 }
-                    "Renommer"
+                    {t(&lang, "chat-menu-rename-action")}
                 }
                 button {
                     class: "w-full flex items-center gap-3 px-4 py-3 text-sm text-ios-red active:bg-stone-50",
@@ -138,7 +140,7 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                         confirm_delete.set(true);
                     },
                     IconTrash { size: 18 }
-                    "Supprimer le chat"
+                    {t(&lang, "chat-menu-delete-chat")}
                 }
             }
         }

--- a/src/ui/chat/models.rs
+++ b/src/ui/chat/models.rs
@@ -16,11 +16,14 @@ pub enum ChatMsg {
     },
 }
 
-pub fn tool_label(name: &str) -> &str {
-    match name {
-        "search_notes" => "Recherche dans les notes...",
-        "create_note" => "Création de la note...",
-        "summarize_folder" => "Résumé du dossier...",
-        _ => "L'agent travaille...",
-    }
+use crate::services::i18n::t;
+
+pub fn tool_label(lang: &str, name: &str) -> String {
+    let key = match name {
+        "search_notes" => "chat-tool-search",
+        "create_note" => "chat-tool-create",
+        "summarize_folder" => "chat-tool-summarize",
+        _ => "chat-tool-working",
+    };
+    t(lang, key)
 }

--- a/src/ui/chat/sources_accordion.rs
+++ b/src/ui/chat/sources_accordion.rs
@@ -1,3 +1,4 @@
+use crate::services::i18n::{t, t_args};
 use crate::ui::chat::models::ChatSource;
 use crate::ui::state::View;
 use crate::ui::AppState;
@@ -8,10 +9,13 @@ pub fn SourcesAccordion(
     sources: Vec<ChatSource>,
     conversation_id: Option<String>,
 ) -> Element {
+    let app: AppState = use_context();
+    let lang = (app.current_lang)();
     let label = if sources.len() == 1 {
-        "1 source".to_string()
+        t(&lang, "sources-one")
     } else {
-        format!("{} sources", sources.len())
+        let count = sources.len().to_string();
+        t_args(&lang, "sources-many", &[("count", &count)])
     };
     let mut expanded = use_signal(|| false);
     let rotation = if expanded() { "180" } else { "0" };

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -131,7 +131,8 @@ pub fn ChatView() -> Element {
                     }
                 }
                 let folder = (app.chat_scope_folder_id)();
-                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, folder);
+                let lang = (app.current_lang)();
+                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, folder, lang);
             },
         }
     }

--- a/src/ui/chat_input.rs
+++ b/src/ui/chat_input.rs
@@ -1,4 +1,5 @@
 use crate::services::audio::{AudioRecorder, RecordingState};
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::recording::{start_recording, RecordingControls};
 use crate::ui::AppState;
@@ -13,6 +14,8 @@ pub fn ChatInputBar(
 ) -> Element {
     let app: AppState = use_context();
     let recorder: Signal<Arc<Mutex<AudioRecorder>>> = use_context();
+    let lang = (app.current_lang)();
+    let placeholder = t(&lang, "chat-input-placeholder");
     let dummy_pending_audio: Signal<Option<(String, f64)>> =
         use_signal(|| None);
 
@@ -35,7 +38,7 @@ pub fn ChatInputBar(
                         class: "chat-textarea flex-1 bg-stone-100 rounded-2xl px-4 py-2.5 text-sm outline-none text-stone-900 placeholder-stone-400 resize-none overflow-y-auto",
                         style: "max-height: 120px; min-height: 40px;",
                         rows: "1",
-                        placeholder: "Pose une question...",
+                        placeholder: "{placeholder}",
                         value: "{input}",
                         oninput: move |evt| {
                             input.set(evt.value());

--- a/src/ui/consent.rs
+++ b/src/ui/consent.rs
@@ -1,4 +1,6 @@
+use crate::db::settings_repo::LANGUAGE_KEY;
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
@@ -10,6 +12,7 @@ const SPARKLE: &str =
 pub fn ConsentScreen() -> Element {
     let db: Signal<Arc<Database>> = use_context();
     let mut app: AppState = use_context();
+    let lang = (app.current_lang)();
 
     rsx! {
         div {
@@ -42,29 +45,51 @@ pub fn ConsentScreen() -> Element {
                     }
 
                     h2 { class: "font-semibold text-base text-stone-800 mb-2",
-                        "Pr\u{ea}t \u{e0} ne plus rien oublier ?"
+                        {t(&lang, "consent-title")}
                     }
                     p { class: "text-[13px] text-stone-500 leading-relaxed",
-                        "Capturez vos pens\u{e9}es \u{e0} la voix, "
-                        "organisez-les par th\u{e8}mes, importez vos documents, "
-                        "discutez avec vos notes, d\u{e9}veloppez vos id\u{e9}es "
-                        "et bien plus gr\u{e2}ce \u{e0} l\u{2019}IA !"
+                        {t(&lang, "consent-description")}
                     }
                 }
             }
 
             div { class: "w-full pb-8",
+                div { class: "flex justify-center gap-2 mb-4",
+                    button {
+                        class: if lang == "en" {
+                            "min-h-[44px] px-5 rounded-full text-sm font-medium bg-ios-orange text-white"
+                        } else {
+                            "min-h-[44px] px-5 rounded-full text-sm font-medium bg-stone-200 text-stone-700"
+                        },
+                        onclick: move |_| {
+                            let _ = db().set_setting(LANGUAGE_KEY, "en");
+                            app.current_lang.set("en".to_string());
+                        },
+                        {t(&lang, "language-en")}
+                    }
+                    button {
+                        class: if lang == "fr" {
+                            "min-h-[44px] px-5 rounded-full text-sm font-medium bg-ios-orange text-white"
+                        } else {
+                            "min-h-[44px] px-5 rounded-full text-sm font-medium bg-stone-200 text-stone-700"
+                        },
+                        onclick: move |_| {
+                            let _ = db().set_setting(LANGUAGE_KEY, "fr");
+                            app.current_lang.set("fr".to_string());
+                        },
+                        {t(&lang, "language-fr")}
+                    }
+                }
                 button {
                     class: "w-full bg-ios-orange text-white font-semibold py-4 rounded-2xl text-[15px]",
                     onclick: move |_| {
                         let _ = db().set_setting("ai_consent", "true");
                         app.ai_consent.set(Some(true));
                     },
-                    "C\u{2019}est parti !"
+                    {t(&lang, "consent-cta")}
                 }
                 p { class: "text-[10px] text-stone-400/50 text-center mt-3 px-4 leading-relaxed",
-                    "En continuant, vous acceptez que vos donn\u{e9}es soient "
-                    "trait\u{e9}es par des services d\u{2019}IA tiers via vos cl\u{e9}s API."
+                    {t(&lang, "consent-disclaimer")}
                 }
             }
 

--- a/src/ui/folder_picker.rs
+++ b/src/ui/folder_picker.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::models::Folder;
+use crate::services::i18n::t;
 use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
@@ -13,6 +14,7 @@ pub fn FolderPicker(selected: Signal<Option<String>>) -> Element {
         let _v = (app.folders_version)();
         db().list_all_folders().unwrap_or_default()
     });
+    let lang = (app.current_lang)();
 
     rsx! {
         div { class: "absolute left-0 right-0 top-0 z-20 bg-warm-white border-b border-stone-200 overflow-hidden shadow-md animate-[slideDown_150ms_ease-out]",
@@ -26,7 +28,7 @@ pub fn FolderPicker(selected: Signal<Option<String>>) -> Element {
                     selected.set(None);
                     app.show_folder_picker.set(false);
                 },
-                "Toutes les notes"
+                {t(&lang, "folder-picker-all")}
             }
             for folder in all_folders() {
                 {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -51,6 +51,10 @@ pub fn App() -> Element {
     }
     let consent_value = _db().get_setting("ai_consent").map(|v| v == "true");
 
+    let initial_lang = _db()
+        .get_setting(crate::db::settings_repo::LANGUAGE_KEY)
+        .unwrap_or_else(crate::platform::detect_system_language);
+
     let app = use_context_provider(|| AppState {
         view: Signal::new(View::NotesList),
         sidebar_open: Signal::new(false),
@@ -72,6 +76,7 @@ pub fn App() -> Element {
         chat_scope_folder_id: Signal::new(None),
         detail_folder_id: Signal::new(None),
         ai_consent: Signal::new(consent_value),
+        current_lang: Signal::new(initial_lang),
     });
 
     use_effect(|| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,6 +46,9 @@ pub fn App() -> Element {
             Signal::new(Arc::new(Mutex::new(AudioRecorder::new())))
         });
 
+    if option_env!("FLOWFLOW_RESET_CONSENT") == Some("1") {
+        let _ = _db().set_setting("ai_consent", "");
+    }
     let consent_value = _db().get_setting("ai_consent").map(|v| v == "true");
 
     let app = use_context_provider(|| AppState {

--- a/src/ui/note_card.rs
+++ b/src/ui/note_card.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::models::Note;
+use crate::services::i18n::t;
 use crate::ui::{AppState, View};
 use dioxus::prelude::*;
 use std::sync::Arc;
@@ -9,11 +10,12 @@ pub fn NoteCard(note: Note) -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
     let note_id = note.id.clone();
+    let lang = (app.current_lang)();
 
     let title = note
         .title
         .clone()
-        .unwrap_or_else(|| "Sans titre".to_string());
+        .unwrap_or_else(|| t(&lang, "note-card-untitled"));
 
     let preview = if note.content.len() > 120 {
         format!("{}...", &note.content[..120])

--- a/src/ui/note_list.rs
+++ b/src/ui/note_list.rs
@@ -1,4 +1,5 @@
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::folder_picker::FolderPicker;
 use crate::ui::icons::*;
 use crate::ui::note_card::NoteCard;
@@ -32,6 +33,7 @@ pub fn NotesList() -> Element {
     });
 
     let has_query = !(app.search_query)().is_empty();
+    let lang = (app.current_lang)();
 
     rsx! {
         if (app.show_folder_picker)() {
@@ -44,7 +46,7 @@ pub fn NotesList() -> Element {
                 }
                 input {
                     class: "w-full bg-warm-white border border-stone-200 rounded-xl pl-9 pr-9 py-2.5 text-sm outline-none text-stone-900 placeholder-stone-400",
-                    placeholder: "Chercher mes notes...",
+                    placeholder: t(&lang, "note-list-search-placeholder"),
                     value: "{app.search_query}",
                     oninput: move |evt| app.search_query.set(evt.value()),
                 }
@@ -60,12 +62,12 @@ pub fn NotesList() -> Element {
         if notes().is_empty() {
             div { class: "flex-1 flex flex-col items-center justify-center gap-2 h-[60vh]",
                 if has_query {
-                    p { class: "text-lg text-stone-400", "Aucun résultat" }
-                    p { class: "text-sm text-stone-400", "Essayez un autre terme" }
+                    p { class: "text-lg text-stone-400", {t(&lang, "note-list-no-results")} }
+                    p { class: "text-sm text-stone-400", {t(&lang, "note-list-no-results-hint")} }
                 } else {
                     img { src: asset!("/assets/flowflow-icon-300.png"), width: "200", height: "200", class: "mb-6 rounded-3xl" }
-                    p { class: "text-lg font-semibold text-stone-900", "Bienvenue" }
-                    p { class: "text-sm text-stone-400 mt-1", "Appuie sur + pour ta première note" }
+                    p { class: "text-lg font-semibold text-stone-900", {t(&lang, "note-list-welcome")} }
+                    p { class: "text-sm text-stone-400 mt-1", {t(&lang, "note-list-first-note-hint")} }
                 }
             }
         } else {

--- a/src/ui/notes/attachments.rs
+++ b/src/ui/notes/attachments.rs
@@ -1,6 +1,7 @@
 use crate::db::Database;
 use crate::models::Attachment;
 use crate::services::embed::delete_attachment_embeddings;
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::AppState;
 use dioxus::prelude::*;
@@ -14,6 +15,10 @@ pub fn AttachmentSection(
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
     let mut confirm_delete_att = confirm_delete_att;
+    let lang = (app.current_lang)();
+    let label_confirm = t(&lang, "attachment-confirm-delete");
+    let label_cancel = t(&lang, "attachment-cancel");
+    let label_delete = t(&lang, "attachment-delete");
 
     rsx! {
         for att in attachments.iter() {
@@ -56,7 +61,7 @@ pub fn AttachmentSection(
                                 class: "absolute inset-0 z-10 flex items-center px-3 bg-warm-white/95 backdrop-blur-sm",
                                 onclick: move |evt| evt.stop_propagation(),
                                 div { class: "flex-1 min-w-0 mr-3",
-                                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide leading-tight", "Supprimer ?" }
+                                    p { class: "text-[10px] font-medium text-stone-400 uppercase tracking-wide leading-tight", "{label_confirm}" }
                                     p { class: "text-sm font-medium text-stone-600 truncate leading-tight", "{att_name_confirm}" }
                                 }
                                 div { class: "flex items-center gap-2",
@@ -66,7 +71,7 @@ pub fn AttachmentSection(
                                             evt.stop_propagation();
                                             confirm_delete_att.set(None);
                                         },
-                                        "Annuler"
+                                        "{label_cancel}"
                                     }
                                     button {
                                         class: "h-9 px-4 flex items-center justify-center text-sm font-medium text-white bg-ios-red rounded-full active:opacity-80",
@@ -79,7 +84,7 @@ pub fn AttachmentSection(
                                             confirm_delete_att.set(None);
                                             app.attachments_version.set((app.attachments_version)() + 1);
                                         },
-                                        "Supprimer"
+                                        "{label_delete}"
                                     }
                                 }
                             }

--- a/src/ui/notes/audio_player.rs
+++ b/src/ui/notes/audio_player.rs
@@ -1,4 +1,6 @@
+use crate::services::i18n::t;
 use crate::ui::icons::IconDotsThree;
+use crate::ui::AppState;
 use dioxus::prelude::*;
 
 #[component]
@@ -7,6 +9,9 @@ pub fn AudioPlayer(
     duration_secs: Option<f64>,
     on_delete: EventHandler<()>,
 ) -> Element {
+    let app: AppState = use_context();
+    let lang = (app.current_lang)();
+    let confirm_label = t(&lang, "audio-confirm-delete");
     let mut playing = use_signal(|| false);
     let mut confirm_delete = use_signal(|| false);
 
@@ -53,7 +58,7 @@ pub fn AudioPlayer(
                         confirm_delete.set(false);
                         on_delete.call(());
                     },
-                    "Supprimer ?"
+                    "{confirm_label}"
                 }
             } else {
                 button {

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -5,6 +5,7 @@ use crate::models::{
 };
 use crate::services::audio::{self, RecordingState};
 use crate::services::embed::{embed_attachment, embed_note};
+use crate::services::i18n::{t, t_args};
 use crate::services::transcription::SonioxClient;
 use crate::ui::folder_picker::FolderPicker;
 use crate::ui::notes::attachments::AttachmentSection;
@@ -17,7 +18,7 @@ use chrono::{Datelike, NaiveDateTime, Utc};
 use dioxus::prelude::*;
 use std::sync::Arc;
 
-fn format_relative_date(iso: &str) -> String {
+fn format_relative_date(iso: &str, lang: &str) -> String {
     let parsed = NaiveDateTime::parse_from_str(
         &iso.replace('T', " ").replace('Z', ""),
         "%Y-%m-%d %H:%M:%S%.f",
@@ -31,27 +32,39 @@ fn format_relative_date(iso: &str) -> String {
     let secs = diff.num_seconds();
 
     if secs < 60 {
-        return "À l'instant".to_string();
+        return t(lang, "date-just-now");
     }
     if secs < 3600 {
-        let mins = secs / 60;
-        return format!("Il y a {mins} min");
+        let mins = (secs / 60).to_string();
+        return t_args(lang, "date-mins-ago", &[("mins", &mins)]);
     }
     if secs < 86400 {
-        let hours = secs / 3600;
-        return format!("Il y a {hours}h");
+        let hours = (secs / 3600).to_string();
+        return t_args(lang, "date-hours-ago", &[("hours", &hours)]);
     }
 
     let today = now.date();
     let note_date = dt.date();
     if today.pred_opt() == Some(note_date) {
-        return format!("Hier, {}", dt.format("%H:%M"));
+        let time = if lang == "fr" {
+            dt.format("%H:%M").to_string()
+        } else {
+            dt.format("%-I:%M %p").to_string()
+        };
+        return t_args(lang, "date-yesterday", &[("time", &time)]);
     }
 
-    let months = [
-        "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
-        "sept.", "oct.", "nov.", "déc.",
-    ];
+    let months: [&str; 13] = if lang == "fr" {
+        [
+            "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
+            "sept.", "oct.", "nov.", "déc.",
+        ]
+    } else {
+        [
+            "", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep",
+            "Oct", "Nov", "Dec",
+        ]
+    };
     let m = months[note_date.month() as usize];
     let d = note_date.day();
 
@@ -62,7 +75,7 @@ fn format_relative_date(iso: &str) -> String {
     }
 }
 
-fn format_absolute_short(iso: &str) -> String {
+fn format_absolute_short(iso: &str, lang: &str) -> String {
     let parsed = NaiveDateTime::parse_from_str(
         &iso.replace('T', " ").replace('Z', ""),
         "%Y-%m-%d %H:%M:%S%.f",
@@ -71,15 +84,27 @@ fn format_absolute_short(iso: &str) -> String {
         Ok(d) => d,
         Err(_) => return iso.to_string(),
     };
-    let months = [
-        "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
-        "sept.", "oct.", "nov.", "déc.",
-    ];
+    let months: [&str; 13] = if lang == "fr" {
+        [
+            "", "jan.", "fév.", "mars", "avr.", "mai", "juin", "juil.", "août",
+            "sept.", "oct.", "nov.", "déc.",
+        ]
+    } else {
+        [
+            "", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep",
+            "Oct", "Nov", "Dec",
+        ]
+    };
     let d = dt.date();
     let now = Utc::now().naive_utc().date();
     let m = months[d.month() as usize];
     if d.year() == now.year() {
-        format!("{} {}, {}", d.day(), m, dt.format("%H:%M"))
+        let time = if lang == "fr" {
+            dt.format("%H:%M").to_string()
+        } else {
+            dt.format("%-I:%M %p").to_string()
+        };
+        format!("{} {}, {}", d.day(), m, time)
     } else {
         format!("{} {} {}", d.day(), m, d.year())
     }
@@ -89,6 +114,7 @@ fn format_absolute_short(iso: &str) -> String {
 pub fn NoteDetail() -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
+    let lang = (app.current_lang)();
 
     let note_id = match (app.view)() {
         View::NoteDetail { note_id } => note_id,
@@ -104,7 +130,7 @@ pub fn NoteDetail() -> Element {
     };
 
     let initial_title = if is_new {
-        generate_auto_title()
+        generate_auto_title(&lang)
     } else {
         note.as_ref()
             .and_then(|n| n.title.clone())
@@ -142,6 +168,7 @@ pub fn NoteDetail() -> Element {
     let mut local_note_id = use_signal(|| note_id.clone());
     let mut import_requested = use_signal(|| false);
     let mut import_status: Signal<Option<String>> = use_signal(|| None);
+    let mut import_in_progress = use_signal(|| false);
     let mut pending_audio: Signal<Option<(String, f64)>> = use_signal(|| None);
     let mut audios_version = use_signal(|| 0u32);
 
@@ -356,15 +383,23 @@ pub fn NoteDetail() -> Element {
         let c = content();
         let tg = tags();
         let folder = (app.detail_folder_id)();
+        let lang_eff = (app.current_lang)();
         spawn(async move {
-            import_status.set(Some("Importation en cours...".to_string()));
-            let file = match import_file_content().await {
+            import_in_progress.set(true);
+            import_status.set(Some(t_args(
+                &lang_eff,
+                "note-import-in-progress",
+                &[],
+            )));
+            let file = match import_file_content(&lang_eff).await {
                 Ok(Some(f)) => f,
                 Ok(None) => {
+                    import_in_progress.set(false);
                     import_status.set(None);
                     return;
                 }
                 Err(e) => {
+                    import_in_progress.set(false);
                     import_status.set(Some(e));
                     spawn(async move {
                         tokio::time::sleep(tokio::time::Duration::from_secs(4))
@@ -396,8 +431,13 @@ pub fn NoteDetail() -> Element {
                             created.id
                         }
                         Err(e) => {
-                            import_status
-                                .set(Some(format!("Erreur sauvegarde: {e}")));
+                            import_in_progress.set(false);
+                            let msg = e.to_string();
+                            import_status.set(Some(t_args(
+                                &lang_eff,
+                                "note-import-save-error",
+                                &[("error", &msg)],
+                            )));
                             return;
                         }
                     }
@@ -420,10 +460,17 @@ pub fn NoteDetail() -> Element {
                         att.filename.clone(),
                         att.content_text.clone(),
                     );
+                    import_in_progress.set(false);
                     import_status.set(None);
                 }
                 Err(e) => {
-                    import_status.set(Some(format!("Erreur import: {e}")));
+                    import_in_progress.set(false);
+                    let msg = e.to_string();
+                    import_status.set(Some(t_args(
+                        &lang_eff,
+                        "note-import-error",
+                        &[("error", &msg)],
+                    )));
                 }
             }
         });
@@ -434,15 +481,26 @@ pub fn NoteDetail() -> Element {
 
     let modified_date = note
         .as_ref()
-        .map(|n| format_relative_date(&n.modified_at))
+        .map(|n| format_relative_date(&n.modified_at, &lang))
         .unwrap_or_default();
 
     let created_date = note
         .as_ref()
-        .map(|n| format_absolute_short(&n.created_at))
+        .map(|n| format_absolute_short(&n.created_at, &lang))
         .unwrap_or_default();
 
     let show_menu = (app.show_note_menu)();
+    let title_placeholder = t(&lang, "note-title-placeholder");
+    let content_placeholder = t(&lang, "note-content-placeholder");
+    let transcribing_placeholder = t(&lang, "note-transcribing-placeholder");
+    let transcribing_short = t(&lang, "note-transcribing-short");
+    let transcribe_action = t(&lang, "note-transcribe-action");
+    let created_on_text = if created_date.is_empty() {
+        String::new()
+    } else {
+        t_args(&lang, "note-created-on", &[("date", &created_date)])
+    };
+    let is_importing = import_in_progress();
 
     rsx! {
         if show_menu {
@@ -462,7 +520,10 @@ pub fn NoteDetail() -> Element {
                 div { class: "inline-block relative",
                     span {
                         class: "text-xl font-semibold invisible whitespace-pre py-1.5 px-3 border border-transparent",
-                        {if title().is_empty() { "Titre".to_string() } else { title() }}
+                        {
+                            let t_disp = if title().is_empty() { title_placeholder.clone() } else { title() };
+                            rsx! { "{t_disp}" }
+                        }
                     }
                     input {
                         class: if generating_title() {
@@ -470,7 +531,7 @@ pub fn NoteDetail() -> Element {
                         } else {
                             "absolute inset-0 text-xl font-semibold outline-none py-1.5 px-3 border border-stone-200/60 rounded-md text-stone-900 bg-white/25 focus:border-ios-orange-dark/40 transition-colors duration-150"
                         },
-                        placeholder: "Titre",
+                        placeholder: "{title_placeholder}",
                         value: "{title}",
                         oninput: move |evt| title.set(evt.value()),
                     }
@@ -479,7 +540,7 @@ pub fn NoteDetail() -> Element {
                     div { class: "mt-2 px-1",
                         p { class: "text-xs text-stone-400", "{modified_date}" }
                         if !created_date.is_empty() {
-                            p { class: "text-[10px] text-stone-300 mt-0.5", "Créé le {created_date}" }
+                            p { class: "text-[10px] text-stone-300 mt-0.5", "{created_on_text}" }
                         }
                     }
                 }
@@ -493,13 +554,14 @@ pub fn NoteDetail() -> Element {
                 } else {
                     "w-full min-h-[300px] border border-stone-200 rounded-xl p-3 mt-3 text-sm resize-none font-sans outline-none text-stone-900"
                 },
-                placeholder: if is_transcribing { "Transcription en cours..." } else { "Contenu de la note..." },
+                placeholder: if is_transcribing { transcribing_placeholder.as_str() } else { content_placeholder.as_str() },
                 value: "{content}",
                 oninput: move |evt| content.set(evt.value()),
             }
             if !audios.is_empty() {
                 {
-                    let audio_label = format!("Enregistrements ({})", audios.len());
+                    let count = audios.len().to_string();
+                    let audio_label = t_args(&lang, "note-audios-label", &[("count", &count)]);
                     rsx! {
                         div { class: "mt-3",
                             button {
@@ -523,7 +585,7 @@ pub fn NoteDetail() -> Element {
                                             let file_path = audio.file_path.clone();
                                             let file_path_tr = audio.file_path.clone();
                                             let resolved = audio::resolve_audio_path(&file_path);
-                                            let date = format_relative_date(&audio.created_at);
+                                            let date = format_relative_date(&audio.created_at, &lang);
                                             let transcription = audio.transcription.clone();
                                             let is_transcribing_this = transcribing_audio_id() == Some(audio.id.clone());
                                             rsx! {
@@ -546,7 +608,7 @@ pub fn NoteDetail() -> Element {
                                                         p {
                                                             class: "text-xs text-stone-400 px-1 pb-1",
                                                             style: "animation: pulseSoft 1.5s ease-in-out infinite;",
-                                                            "Transcription..."
+                                                            "{transcribing_short}"
                                                         }
                                                     } else {
                                                         button {
@@ -573,7 +635,7 @@ pub fn NoteDetail() -> Element {
                                                                     audios_version.set(audios_version() + 1);
                                                                 });
                                                             },
-                                                            "Transcrire"
+                                                            "{transcribe_action}"
                                                         }
                                                     }
                                                 }
@@ -588,20 +650,26 @@ pub fn NoteDetail() -> Element {
             }
             AttachmentSection { attachments, confirm_delete_att }
             if let Some(ref status) = import_status() {
-                div { class: if status.starts_with("Importation") {
+                div { class: if is_importing {
                         "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-orange/10 rounded-lg"
                     } else {
                         "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-red/10 rounded-lg"
                     },
-                    if status.starts_with("Importation") {
+                    if is_importing {
                         span { class: "inline-block w-3 h-3 border-2 border-ios-orange border-t-transparent rounded-full animate-spin" }
                     }
                     span { class: "text-xs text-stone-600", "{status}" }
                 }
             }
             if let RecordingState::Error(ref e) = recording_state {
-                p { class: "text-xs text-stone-400 text-center mt-3",
-                    "Erreur : {e}"
+                {
+                    let msg = e.clone();
+                    let recording_error = t_args(&lang, "note-recording-error", &[("message", &msg)]);
+                    rsx! {
+                        p { class: "text-xs text-stone-400 text-center mt-3",
+                            "{recording_error}"
+                        }
+                    }
                 }
             }
         }

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -1,4 +1,7 @@
 use crate::services::embed::delete_note_embeddings;
+use crate::services::i18n::t;
+#[cfg(target_os = "ios")]
+use crate::services::i18n::t_args;
 use crate::ui::icons::*;
 use crate::ui::AppState;
 use dioxus::prelude::*;
@@ -9,7 +12,9 @@ pub struct ImportedFile {
     pub content: String,
 }
 
-pub async fn import_file_content() -> Result<Option<ImportedFile>, String> {
+pub async fn import_file_content(
+    lang: &str,
+) -> Result<Option<ImportedFile>, String> {
     #[cfg(target_os = "ios")]
     {
         use crate::platform::ios::{
@@ -28,9 +33,11 @@ pub async fn import_file_content() -> Result<Option<ImportedFile>, String> {
         };
         let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
         if file_size > MAX_FILE_SIZE {
-            return Err(format!(
-                "Fichier trop volumineux ({} MB, max 20 MB)",
-                file_size / (1024 * 1024)
+            let size = (file_size / (1024 * 1024)).to_string();
+            return Err(t_args(
+                lang,
+                "note-file-too-large",
+                &[("size", &size)],
             ));
         }
         let filename = path
@@ -57,10 +64,14 @@ pub async fn import_file_content() -> Result<Option<ImportedFile>, String> {
             .await
             {
                 Ok(Ok(r)) => r,
-                Ok(Err(_)) => Err("Extraction interrompue".to_string()),
+                Ok(Err(_)) => Err(t(lang, "note-extract-interrupted")),
                 Err(_) => {
-                    let mins = timeout_secs / 60;
-                    Err(format!("Fichier trop complexe (timeout {mins}min)"))
+                    let mins = (timeout_secs / 60).to_string();
+                    Err(t_args(
+                        lang,
+                        "note-file-too-complex",
+                        &[("mins", &mins)],
+                    ))
                 }
             }
         };
@@ -74,6 +85,7 @@ pub async fn import_file_content() -> Result<Option<ImportedFile>, String> {
     }
     #[cfg(not(target_os = "ios"))]
     {
+        let _ = lang;
         Ok(None)
     }
 }
@@ -88,6 +100,9 @@ pub fn NoteMenu(
     let db: Signal<Arc<crate::db::Database>> = use_context();
     let mut deleted = deleted;
     let mut import_requested = import_requested;
+    let lang = (app.current_lang)();
+    let import_label = t(&lang, "note-menu-import");
+    let delete_label = t(&lang, "note-menu-delete");
 
     rsx! {
         div {
@@ -103,7 +118,7 @@ pub fn NoteMenu(
                     app.show_note_menu.set(false);
                 },
                 IconFileArrowUp { size: 18 }
-                "Importer un document"
+                "{import_label}"
             }
             button {
                 class: "w-full flex items-center gap-3 px-4 py-3 text-sm text-ios-red active:bg-stone-50",
@@ -121,7 +136,7 @@ pub fn NoteMenu(
                     }
                 },
                 IconTrash { size: 18 }
-                "Supprimer la note"
+                "{delete_label}"
             }
         }
     }

--- a/src/ui/notes/tags.rs
+++ b/src/ui/notes/tags.rs
@@ -1,5 +1,7 @@
+use crate::services::i18n::t;
 use crate::services::llm::LlmClient;
 use crate::ui::icons::*;
+use crate::ui::AppState;
 use dioxus::prelude::*;
 
 #[component]
@@ -9,6 +11,10 @@ pub fn TagsSection(
     tagging: Signal<bool>,
     content: Signal<String>,
 ) -> Element {
+    let app: AppState = use_context();
+    let lang = (app.current_lang)();
+    let auto_tag_label = t(&lang, "tag-auto-action");
+    let placeholder = t(&lang, "tag-add-placeholder");
     let mut tags = tags;
     let mut tag_input = tag_input;
     let mut tagging = tagging;
@@ -43,7 +49,10 @@ pub fn TagsSection(
                             tagging.set(false);
                         });
                     },
-                    if tagging() { "..." } else { "Auto-tag" }
+                    {
+                        let label = if tagging() { "...".to_string() } else { auto_tag_label.clone() };
+                        rsx! { "{label}" }
+                    }
                 }
             }
             for (i, tag) in tags().iter().enumerate() {
@@ -71,7 +80,7 @@ pub fn TagsSection(
                 div { class: "inline-flex items-center gap-1",
                     input {
                         class: "w-24 text-xs border border-stone-200 rounded-full px-2.5 py-1 outline-none",
-                        placeholder: "+ tag",
+                        placeholder: "{placeholder}",
                         value: "{tag_input}",
                         oninput: move |evt| tag_input.set(evt.value()),
                         onkeypress: move |evt| {

--- a/src/ui/recording/bar.rs
+++ b/src/ui/recording/bar.rs
@@ -1,4 +1,5 @@
 use crate::services::audio::{AudioRecorder, RecordingState};
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::recording::{start_recording, RecordingControls};
 use crate::ui::AppState;
@@ -13,6 +14,7 @@ pub fn RecordingBar(pending_audio: Signal<Option<(String, f64)>>) -> Element {
     let is_idle = recording_state == RecordingState::Idle
         || matches!(recording_state, RecordingState::Error(_))
         || matches!(recording_state, RecordingState::Transcribed(_));
+    let lang = (app.current_lang)();
 
     rsx! {
         div { class: "fixed bottom-0 left-0 right-0 px-4 py-2 bg-warm-white border-t border-stone-200 z-30 keyboard-aware",
@@ -22,7 +24,7 @@ pub fn RecordingBar(pending_audio: Signal<Option<(String, f64)>>) -> Element {
                         class: "w-full flex items-center justify-center gap-2.5 h-12 rounded-full bg-warm-white border border-ios-orange/25 text-ios-orange-dark text-sm font-medium",
                         onclick: move |_| start_recording(recorder, app),
                         IconMic { size: 22 }
-                        span { "Dicter" }
+                        span { {t(&lang, "recording-dictate")} }
                     }
                 }
                 if let RecordingState::Error(ref e) = recording_state {

--- a/src/ui/recording/controls.rs
+++ b/src/ui/recording/controls.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::services::audio::{self, AudioRecorder, RecordingState};
+use crate::services::i18n::t;
 use crate::services::transcription::SonioxClient;
 use crate::ui::icons::*;
 use crate::ui::recording::Waveform;
@@ -80,6 +81,10 @@ pub fn RecordingControls(
     let mut duration = use_signal(|| 0.0f32);
     let mut last_tap_ms = use_signal(|| 0u64);
     let mut transcription_gen = use_signal(|| 0u64);
+    let lang = (app.current_lang)();
+    let cancel_hint = t(&lang, "recording-cancel-hint");
+    let pause_label = t(&lang, "recording-pause-label");
+    let transcribing_label = t(&lang, "recording-transcribing");
 
     use_effect(move || {
         let state = (app.recording_state)();
@@ -203,12 +208,19 @@ pub fn RecordingControls(
                             }
                         }
                         if is_paused {
-                            span { class: "flex-1 text-center text-[11px] text-white/50", "double-tap pour annuler" }
+                            span { class: "flex-1 text-center text-[11px] text-white/50", "{cancel_hint}" }
                         } else {
                             Waveform { num_bars: NUM_BARS, frozen: false }
                         }
                         span { class: "text-xs tabular-nums flex-shrink-0 ml-1",
-                            if is_paused { "Pause · {m}:{s:02}" } else { "{m}:{s:02}" }
+                            {
+                                let timer_label = if is_paused {
+                                    format!("{pause_label} · {m}:{s:02}")
+                                } else {
+                                    format!("{m}:{s:02}")
+                                };
+                                rsx! { "{timer_label}" }
+                            }
                         }
                     }
                 }
@@ -256,7 +268,7 @@ pub fn RecordingControls(
                             app.recording_state.set(RecordingState::Idle);
                         }
                     },
-                    span { style: "animation: pulseSoft 1.5s ease-in-out infinite;", "Transcription..." }
+                    span { style: "animation: pulseSoft 1.5s ease-in-out infinite;", "{transcribing_label}" }
                 }
             }
         }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1,5 +1,7 @@
+use crate::db::settings_repo::LANGUAGE_KEY;
 use crate::db::Database;
 use crate::services::audio;
+use crate::services::i18n::t;
 use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
@@ -22,13 +24,14 @@ pub fn SettingsView() -> Element {
     let mut confirm_cleanup = use_signal(|| false);
     let mut cleanup_status: Signal<Option<String>> = use_signal(|| None);
     let audio_count = db().all_audio_paths().map(|p| p.len()).unwrap_or(0);
+    let lang = (app.current_lang)();
 
     rsx! {
         div { class: "space-y-6 pb-20",
-            h2 { class: "text-lg font-semibold text-stone-900", "Clés API" }
+            h2 { class: "text-lg font-semibold text-stone-900", {t(&lang, "settings-api-keys-title")} }
             div { class: "space-y-4",
                 div {
-                    label { class: "block text-sm font-medium text-stone-700 mb-1", "OpenAI API Key" }
+                    label { class: "block text-sm font-medium text-stone-700 mb-1", {t(&lang, "settings-openai-label")} }
                     input {
                         class: "w-full border border-stone-200 rounded-xl px-3 py-2.5 text-sm outline-none text-stone-900 bg-warm-white",
                         r#type: "password",
@@ -41,11 +44,11 @@ pub fn SettingsView() -> Element {
                     }
                 }
                 div {
-                    label { class: "block text-sm font-medium text-stone-700 mb-1", "Soniox API Key" }
+                    label { class: "block text-sm font-medium text-stone-700 mb-1", {t(&lang, "settings-soniox-label")} }
                     input {
                         class: "w-full border border-stone-200 rounded-xl px-3 py-2.5 text-sm outline-none text-stone-900 bg-warm-white",
                         r#type: "password",
-                        placeholder: "Clé Soniox",
+                        placeholder: t(&lang, "settings-soniox-placeholder"),
                         value: "{soniox_key}",
                         oninput: move |evt| {
                             soniox_key.set(evt.value());
@@ -55,11 +58,11 @@ pub fn SettingsView() -> Element {
                 }
             }
 
-            h2 { class: "text-lg font-semibold text-stone-900 pt-2", "Recherche" }
+            h2 { class: "text-lg font-semibold text-stone-900 pt-2", {t(&lang, "settings-search-title")} }
             div {
                 div { class: "flex justify-between items-center mb-1",
                     label { class: "text-sm font-medium text-stone-700",
-                        "Max sources"
+                        {t(&lang, "settings-max-sources")}
                     }
                     span { class: "text-sm font-semibold text-ios-orange",
                         "{max_sources}"
@@ -105,17 +108,51 @@ pub fn SettingsView() -> Element {
                     );
                     saved.set(true);
                 },
-                if saved() { "Enregistré ✓" } else { "Enregistrer" }
+                if saved() {
+                    {t(&lang, "settings-saved")}
+                } else {
+                    {t(&lang, "settings-save")}
+                }
             }
 
             div { class: "border-t border-stone-200 pt-4",
-                h2 { class: "text-lg font-semibold text-stone-900 mb-3", "Stockage" }
+                h2 { class: "text-lg font-semibold text-stone-900 mb-3", {t(&lang, "settings-language-section")} }
+                div { class: "flex gap-2",
+                    button {
+                        class: if lang == "en" {
+                            "flex-1 min-h-[44px] rounded-xl text-sm font-medium bg-ios-orange text-white"
+                        } else {
+                            "flex-1 min-h-[44px] rounded-xl text-sm font-medium bg-stone-200 text-stone-700"
+                        },
+                        onclick: move |_| {
+                            let _ = db().set_setting(LANGUAGE_KEY, "en");
+                            app.current_lang.set("en".to_string());
+                        },
+                        {t(&lang, "language-en")}
+                    }
+                    button {
+                        class: if lang == "fr" {
+                            "flex-1 min-h-[44px] rounded-xl text-sm font-medium bg-ios-orange text-white"
+                        } else {
+                            "flex-1 min-h-[44px] rounded-xl text-sm font-medium bg-stone-200 text-stone-700"
+                        },
+                        onclick: move |_| {
+                            let _ = db().set_setting(LANGUAGE_KEY, "fr");
+                            app.current_lang.set("fr".to_string());
+                        },
+                        {t(&lang, "language-fr")}
+                    }
+                }
+            }
+
+            div { class: "border-t border-stone-200 pt-4",
+                h2 { class: "text-lg font-semibold text-stone-900 mb-3", {t(&lang, "settings-storage-title")} }
                 if let Some(ref status) = cleanup_status() {
                     p { class: "text-xs text-ios-green text-center mb-2", "{status}" }
                 }
                 if audio_count > 0 {
                     {
-                        let label = format!("Nettoyer les fichiers audio ({audio_count})");
+                        let label = format!("{} ({})", t(&lang, "settings-cleanup-audio"), audio_count);
                         rsx! {
                             button {
                                 class: if confirm_cleanup() {
@@ -123,20 +160,22 @@ pub fn SettingsView() -> Element {
                                 } else {
                                     "w-full py-2.5 rounded-xl text-sm font-medium border border-stone-300 text-stone-600"
                                 },
-                                onclick: move |_| {
+                                onclick: {
+                                    let lang = lang.clone();
+                                    move |_| {
                                     if confirm_cleanup() {
                                         let dir = audio::output_dir();
                                         match db().delete_all_audios(&dir) {
                                             Ok(count) => {
                                                 cleanup_status.set(Some(
-                                                    format!("{count} fichiers audio supprimés"),
+                                                    format!("{} {}", count, t(&lang, "settings-cleanup-done")),
                                                 ));
                                                 app.notes_version
                                                     .set((app.notes_version)() + 1);
                                             }
                                             Err(e) => {
                                                 cleanup_status
-                                                    .set(Some(format!("Erreur: {e}")));
+                                                    .set(Some(format!("{}: {}", t(&lang, "settings-cleanup-error"), e)));
                                             }
                                         }
                                         confirm_cleanup.set(false);
@@ -150,9 +189,10 @@ pub fn SettingsView() -> Element {
                                             confirm_cleanup.set(false);
                                         });
                                     }
+                                }
                                 },
                                 if confirm_cleanup() {
-                                    "Confirmer ? Les notes restent intactes."
+                                    {t(&lang, "settings-cleanup-confirm")}
                                 } else {
                                     "{label}"
                                 }
@@ -160,21 +200,20 @@ pub fn SettingsView() -> Element {
                         }
                     }
                 } else {
-                    p { class: "text-xs text-stone-400 text-center", "Aucun fichier audio" }
+                    p { class: "text-xs text-stone-400 text-center", {t(&lang, "settings-no-audio")} }
                 }
             }
 
             p { class: "text-xs text-stone-400 text-center",
-                "Les clés sont stockées localement sur cet appareil."
+                {t(&lang, "settings-keys-stored-locally")}
             }
 
             div { class: "border-t border-stone-200 pt-4",
                 h2 { class: "text-lg font-semibold text-stone-900 mb-3",
-                    "Services IA"
+                    {t(&lang, "settings-ai-services-title")}
                 }
                 p { class: "text-xs text-stone-500 mb-3 leading-relaxed",
-                    "Soniox, OpenAI et Anthropic sont utilisés pour la transcription, "
-                    "la recherche sémantique et le chat."
+                    {t(&lang, "settings-ai-services-description")}
                 }
                 button {
                     class: "w-full py-2.5 rounded-xl text-sm font-medium border border-stone-300 text-stone-500",
@@ -182,7 +221,7 @@ pub fn SettingsView() -> Element {
                         let _ = db().set_setting("ai_consent", "revoked");
                         app.ai_consent.set(None);
                     },
-                    "Révoquer le consentement"
+                    {t(&lang, "settings-revoke-consent")}
                 }
             }
         }

--- a/src/ui/sidebar/conversations.rs
+++ b/src/ui/sidebar/conversations.rs
@@ -1,4 +1,5 @@
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::{AppState, View};
 use dioxus::prelude::*;
@@ -9,6 +10,7 @@ pub fn ConversationSection() -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
     let version = use_signal(|| 0u32);
+    let lang = (app.current_lang)();
 
     let conversations = use_memo(move || {
         let _v = version();
@@ -23,10 +25,10 @@ pub fn ConversationSection() -> Element {
                 app.sidebar_open.set(false);
             },
             IconPlus { size: 16 }
-            "Nouvelle conversation"
+            {t(&lang, "sidebar-new-conversation")}
         }
         if conversations().is_empty() {
-            p { class: "text-xs text-stone-400 px-2 py-3", "Aucune conversation" }
+            p { class: "text-xs text-stone-400 px-2 py-3", {t(&lang, "sidebar-no-conversations")} }
         }
         for conv in conversations() {
             ConversationItem { conv: conv, version: version }
@@ -45,13 +47,14 @@ fn ConversationItem(
     let mut confirm_delete = use_signal(|| false);
     let mut editing = use_signal(|| false);
     let mut edit_name = use_signal(|| conv.title.clone());
+    let lang = (app.current_lang)();
 
     let conv_id_nav = conv.id.clone();
     let conv_id_rename = conv.id.clone();
     let conv_id_rename2 = conv.id.clone();
     let conv_id_del = conv.id.clone();
     let title = if conv.title.is_empty() {
-        "Sans titre".to_string()
+        t(&lang, "sidebar-untitled")
     } else {
         conv.title.clone()
     };
@@ -95,19 +98,19 @@ fn ConversationItem(
             }
         } else if confirm_delete() {
             div { class: "flex items-center gap-2 py-2 px-2",
-                span { class: "flex-1 text-sm text-stone-600", "Supprimer ?" }
+                span { class: "flex-1 text-sm text-stone-600", {t(&lang, "sidebar-delete-confirm")} }
                 button {
                     class: "px-3 py-1 rounded-lg bg-ios-red text-white text-xs font-medium",
                     onclick: move |_| {
                         let _ = db().delete_conversation(&conv_id_del);
                         version.set(version() + 1);
                     },
-                    "Oui"
+                    {t(&lang, "sidebar-yes")}
                 }
                 button {
                     class: "px-3 py-1 rounded-lg bg-stone-200 text-stone-600 text-xs",
                     onclick: move |_| confirm_delete.set(false),
-                    "Non"
+                    {t(&lang, "sidebar-no")}
                 }
             }
         } else {

--- a/src/ui/sidebar/folders.rs
+++ b/src/ui/sidebar/folders.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::models::{Folder, NewFolder, UpdateFolder};
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::{AppState, View};
 use dioxus::prelude::*;
@@ -11,6 +12,7 @@ pub fn FolderSection() -> Element {
     let mut app: AppState = use_context();
     let mut creating = use_signal(|| false);
     let mut new_name = use_signal(String::new);
+    let lang = (app.current_lang)();
 
     let folders = use_memo(move || {
         let _v = (app.folders_version)();
@@ -19,7 +21,7 @@ pub fn FolderSection() -> Element {
 
     rsx! {
         div { class: "flex items-center justify-between px-2 mb-2",
-            span { class: "text-xs font-medium text-stone-400 uppercase tracking-wide", "Thèmes" }
+            span { class: "text-xs font-medium text-stone-400 uppercase tracking-wide", {t(&lang, "sidebar-folders-title")} }
             button {
                 class: "w-9 h-9 flex items-center justify-center rounded-full text-stone-500",
                 onclick: move |_| creating.set(!creating()),
@@ -30,7 +32,7 @@ pub fn FolderSection() -> Element {
             div { class: "flex items-center gap-2 px-2 mb-2",
                 input {
                     class: "flex-1 text-sm border border-stone-200 rounded-lg px-2 py-1.5 outline-none",
-                    placeholder: "Nom du thème",
+                    placeholder: t(&lang, "sidebar-folder-placeholder"),
                     value: "{new_name}",
                     oninput: move |evt| new_name.set(evt.value()),
                     onkeypress: move |evt| {
@@ -67,7 +69,7 @@ pub fn FolderSection() -> Element {
             }
         }
         if folders().is_empty() && !creating() {
-            p { class: "text-xs text-stone-400 px-2 py-3", "Aucun thème" }
+            p { class: "text-xs text-stone-400 px-2 py-3", {t(&lang, "sidebar-no-folders")} }
         }
         for folder in folders() {
             FolderItem { folder: folder, depth: 0 }
@@ -86,6 +88,7 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
     let mut edit_name = use_signal(|| folder.name.clone());
     let mut confirm_delete = use_signal(|| false);
     let mut show_actions = use_signal(|| false);
+    let lang = (app.current_lang)();
 
     let folder_id = folder.id.clone();
     let folder_id_for_delete = folder.id.clone();
@@ -151,7 +154,7 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                 }
             } else if confirm_delete() {
                 div { class: "flex items-center gap-2 py-2 px-2",
-                    span { class: "flex-1 text-sm text-stone-600", "Supprimer ?" }
+                    span { class: "flex-1 text-sm text-stone-600", {t(&lang, "sidebar-delete-confirm")} }
                     button {
                         class: "px-3 py-1 rounded-lg bg-ios-red text-white text-xs font-medium",
                         onclick: move |_| {
@@ -161,12 +164,12 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                             }
                             app.folders_version.set((app.folders_version)() + 1);
                         },
-                        "Oui"
+                        {t(&lang, "sidebar-yes")}
                     }
                     button {
                         class: "px-3 py-1 rounded-lg bg-stone-200 text-stone-600 text-xs",
                         onclick: move |_| confirm_delete.set(false),
-                        "Non"
+                        {t(&lang, "sidebar-no")}
                     }
                 }
             } else {
@@ -233,7 +236,7 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                 div { class: "flex items-center gap-2 px-2 py-1 ml-8",
                     input {
                         class: "flex-1 text-sm border border-stone-200 rounded-lg px-2 py-1.5 outline-none",
-                        placeholder: "Sous-thème",
+                        placeholder: t(&lang, "sidebar-subfolder-placeholder"),
                         value: "{sub_name}",
                         oninput: move |evt| sub_name.set(evt.value()),
                         onkeypress: move |evt| {

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -5,6 +5,7 @@ pub use conversations::*;
 pub use folders::*;
 
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::{AppState, SidebarTab, View};
 use dioxus::prelude::*;
@@ -15,6 +16,7 @@ pub fn SidebarOverlay() -> Element {
     let mut app: AppState = use_context();
     let _db: Signal<Arc<Database>> = use_context();
     let is_open = (app.sidebar_open)();
+    let lang = (app.current_lang)();
 
     rsx! {
         div {
@@ -37,7 +39,7 @@ pub fn SidebarOverlay() -> Element {
                     onclick: move |_| app.sidebar_tab.set(SidebarTab::Notes),
                     div { class: "flex items-center justify-center gap-1.5",
                         IconNotePencil { size: 16 }
-                        "Notes"
+                        {t(&lang, "sidebar-tab-notes")}
                     }
                 }
                 button {
@@ -49,7 +51,7 @@ pub fn SidebarOverlay() -> Element {
                     onclick: move |_| app.sidebar_tab.set(SidebarTab::Chats),
                     div { class: "flex items-center justify-center gap-1.5",
                         IconChats { size: 16 }
-                        "Chats"
+                        {t(&lang, "sidebar-tab-chats")}
                     }
                 }
             }
@@ -66,7 +68,7 @@ pub fn SidebarOverlay() -> Element {
                                     app.sidebar_open.set(false);
                                 },
                                 IconNotebook { size: 20 }
-                                "Toutes mes notes"
+                                {t(&lang, "sidebar-all-notes")}
                             }
                         }
                         div { class: "h-px bg-stone-200 mb-2" }
@@ -86,7 +88,7 @@ pub fn SidebarOverlay() -> Element {
                         app.sidebar_open.set(false);
                     },
                     IconGear { size: 18 }
-                    "Réglages"
+                    {t(&lang, "sidebar-settings")}
                 }
             }
         }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -38,4 +38,5 @@ pub struct AppState {
     pub chat_scope_folder_id: Signal<Option<String>>,
     pub detail_folder_id: Signal<Option<String>>,
     pub ai_consent: Signal<Option<bool>>,
+    pub current_lang: Signal<String>,
 }

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -1,4 +1,5 @@
 use crate::db::Database;
+use crate::services::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::{AppState, SidebarTab, View};
 use dioxus::prelude::*;
@@ -12,6 +13,7 @@ pub fn TopBar() -> Element {
     let is_chat = matches!((app.view)(), View::Chat { .. });
     let is_settings = matches!((app.view)(), View::Settings);
     let is_inner = is_detail || is_chat || is_settings;
+    let lang = (app.current_lang)();
 
     let title = match (app.view)() {
         View::NotesList => match (app.selected_folder_id)() {
@@ -20,8 +22,8 @@ pub fn TopBar() -> Element {
                 .ok()
                 .flatten()
                 .map(|f| f.name)
-                .unwrap_or_else(|| "Thème".to_string()),
-            None => "Toutes mes notes".to_string(),
+                .unwrap_or_else(|| t(&lang, "top-bar-folder-fallback")),
+            None => t(&lang, "sidebar-all-notes"),
         },
         View::NoteDetail { .. } => match (app.detail_folder_id)() {
             Some(ref fid) => db()
@@ -29,8 +31,8 @@ pub fn TopBar() -> Element {
                 .ok()
                 .flatten()
                 .map(|f| f.name)
-                .unwrap_or_else(|| "Toutes les notes".to_string()),
-            None => "Toutes les notes".to_string(),
+                .unwrap_or_else(|| t(&lang, "top-bar-all-notes")),
+            None => t(&lang, "top-bar-all-notes"),
         },
         View::Chat { .. } => match (app.chat_scope_folder_id)() {
             Some(ref fid) => db()
@@ -38,10 +40,10 @@ pub fn TopBar() -> Element {
                 .ok()
                 .flatten()
                 .map(|f| f.name)
-                .unwrap_or_else(|| "Toutes les notes".to_string()),
-            None => "Toutes les notes".to_string(),
+                .unwrap_or_else(|| t(&lang, "top-bar-all-notes")),
+            None => t(&lang, "top-bar-all-notes"),
         },
-        View::Settings => "Réglages".to_string(),
+        View::Settings => t(&lang, "sidebar-settings"),
     };
 
     rsx! {


### PR DESCRIPTION
## Summary

Multi-language support for FlowFlow (FR/EN) with iOS system language auto-detection and in-app picker.

- Fluent-rs i18n infrastructure (`fluent-bundle` concurrent variant for `Sync`)
- NSLocale-based system language detection on iOS with safe fallback
- 96 keys translated, strict EN/FR parity, 22 UI files touched
- Language picker on consent screen and in Settings (live update + DB persistence)
- Localized date formats: FR months + 24h time, EN months + 12h AM/PM
- Soniox auto-detect (no language hints) preserved
- README updated with App Store glossary and multilingual update workflow

## Commits

- `feat(i18n): add fluent-rs infrastructure with NSLocale detection`
- `feat(i18n): translate UI to EN/FR with picker and localized dates`
- `docs: add App Store glossary and multilingual update workflow`
- Plus prior: `feat(dev): FLOWFLOW_RESET_CONSENT env`, `chore: refresh gitnexus symbol counts`

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features mobile` no warnings
- [x] `make all` installs on device (Apple Distribution profile)
- [x] Boot: NSLocale FR phone → app FR, NSLocale EN phone → app EN
- [x] Consent: tap EN → all consent strings switch live
- [x] Settings → Langue / Language: toggle persists across relaunch
- [x] Note dates: `Created on May 21` (EN) / `Créé le 21 mai` (FR)
- [x] Note times: `6:20 PM` (EN) / `18:20` (FR)
- [x] All UI screens checked manually