### PR TITLE
feat(transcription): audio file import with background transcription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1614 symbols, 2913 relationships, 135 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1856 symbols, 3281 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (1614 symbols, 2913 relationships, 135 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (1856 symbols, 3281 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/prd/agentic-tools/prd.md
+++ b/docs/prd/agentic-tools/prd.md
@@ -1,0 +1,122 @@
+---
+feature: Outils agentiques sortants (webhook, MCP distant, Google Calendar)
+slug: agentic-tools
+type: prd
+status: ready
+stepsCompleted: [0, 1, 2, 3, 4]
+---
+
+# PRD: Outils agentiques sortants (webhook, MCP distant, Google Calendar)
+
+## Problem statement
+
+L'agent de FlowFlow (chat RAG) n'agit que sur les notes locales. Il ne peut ni
+agir sur le monde extérieur, ni tirer de connaissance externe en direct. Toute la
+valeur reste enfermée dans l'appareil.
+
+Mirko veut que FlowFlow devienne agentique au sens fort: déclencher ses automations
+(n8n, Make, Zapier), chercher le web en parallèle de ses notes, et transformer une
+note en action datée (événement Google Calendar.) Ces trois besoins partagent une
+même direction technique, la seule faisable sur iOS: le sortant. L'app appelle vers
+l'extérieur pendant qu'elle est au premier plan, jamais l'inverse (cf. la recherche
+de faisabilité iOS: aucun serveur entrant persistant possible.)
+
+Pourquoi maintenant: l'agent multi-provider (rig-core) et le client HTTP (reqwest)
+sont déjà en place. Le coût marginal pour brancher des outils sortants est faible,
+et c'est le plus gros levier produit pour un effort réduit.
+
+## Goals
+
+- Permettre à l'agent de declencher une automation externe (webhook) depuis le chat.
+- Permettre à l'agent d'utiliser des outils distants (recherche web, etc.) via des
+  serveurs MCP activables en toggle.
+- Permettre de transformer une note en événement Google Calendar.
+- Rester dans le modèle iOS faisable: 100% sortant, app au premier plan, zéro
+  dépendance à un serveur entrant ou à de l'arrière-plan.
+- Ne jamais exposer de secret: URLs, tokens et clés restent locaux sur l'appareil.
+- Dégradation gracieuse: un outil externe indisponible ne casse jamais le chat.
+
+## Non-goals / Out-of-scope
+
+- Pas de serveur entrant ni de reachability du téléphone depuis l'extérieur
+  (impossible iOS, démontré par la recherche de faisabilité.)
+- Pas d'App Intents / Siri (Swift uniquement, casse la contrainte 100% Rust.)
+- Pas d'exécution en arrière-plan: l'agent agit quand l'app est ouverte.
+- Pas d'intégration Apple Notes (aucune API publique iOS.)
+- Pas de serveurs MCP en stdio / process local (impossible iOS): uniquement MCP
+  distant via HTTP (Streamable HTTP.)
+- Pas d'OAuth 2.1 pour les MCP qui l'exigent (GitHub, Notion) dans cette version:
+  seulement les serveurs à clé statique (Exa, Linear.)
+- Pas de marketplace de serveurs MCP ni de configuration avancée multi-tenant.
+
+## User stories
+
+1. **Webhook sortant.** En tant qu'utilisateur, je veux qu'une commande du chat
+   déclenche un webhook n8n/Make, afin de brancher FlowFlow sur mes automations.
+2. **Outils MCP distants.** En tant qu'utilisateur, je veux activer des serveurs MCP
+   (Exa) en toggle, afin que l'agent cherche le web en parallèle de mes notes.
+3. **Note vers Calendar.** En tant qu'utilisateur, je veux transformer une note en
+   événement Google Calendar, afin que mes idées deviennent des actions datées.
+4. **Secrets locaux.** En tant qu'utilisateur, je veux que mes URLs, tokens et clés
+   restent sur l'appareil, afin que rien ne fuite et que mes archives restent saines.
+5. **Robustesse offline.** En tant qu'utilisateur, je veux qu'un outil externe en
+   échec ne casse pas le chat, afin de garder l'agent utilisable même réseau coupé.
+
+## Acceptance criteria
+
+**Story 1 (webhook)**
+- Given une URL de webhook et un secret configurés, When je demande à l'agent de
+  déclencher le webhook, Then une requête POST part avec le secret en en-tête et un
+  corps JSON, And la cible (n8n/Make) reçoit l'appel.
+- Given aucun webhook configuré, When je tente le déclenchement, Then l'agent répond
+  clairement qu'il faut le configurer, sans erreur bloquante.
+
+**Story 2 (MCP distant)**
+- Given le serveur Exa MCP activé avec sa clé, When je pose une question nécessitant
+  le web, Then l'agent utilise l'outil distant et cite au moins un résultat web.
+- Given le serveur MCP désactivé, When je pose la même question, Then l'agent reste
+  sur ses outils locaux sans erreur.
+
+**Story 3 (Calendar)**
+- Given un compte Google connecté, When je demande de transformer une note en
+  événement, Then l'événement apparaît dans Google Calendar.
+- Given un compte non connecté, When je tente la création, Then l'agent invite à
+  connecter Google, sans crash.
+
+**Story 4 (secrets)**
+- Given des secrets enregistrés, When j'inspecte le code et une archive de backup,
+  Then aucun secret n'y figure (tous en stockage local exclu de l'archive.)
+
+**Story 5 (robustesse)**
+- Given un outil externe injoignable (timeout/erreur), When l'agent l'appelle, Then
+  le chat répond quand même avec un message clair, And l'app ne crashe pas.
+
+## Success metrics
+
+- Un webhook configuré se déclenche et la cible reçoit le payload en moins de 5 s.
+- 0 secret présent dans le code source ou dans une archive exportée (vérifiable.)
+- Toggle Exa MCP activé: une réponse de test cite au moins 1 résultat web.
+- Note transformée en événement Calendar visible dans Google en moins de 10 s.
+- 100% des outils externes en échec laissent le chat répondre, 0 crash observé.
+- Build mobile vert sur les 3 cibles iOS avec la dépendance MCP ajoutée.
+
+## Constraints & assumptions
+
+- iOS uniquement, 100% Rust/Dioxus, agent actif seulement app au premier plan.
+- rig-core 0.36 + reqwest déjà présents; la cross-compilation de la couche MCP doit
+  être validée sur aarch64-apple-ios + simulateur AVANT tout câblage UI.
+- MCP distant via HTTP (Streamable HTTP) uniquement; pas de stdio/process local.
+- MCP à clé statique d'abord (Exa, Linear); OAuth 2.1 hors scope.
+- Google: flux auth-code + PKCE (le flux loopback est déprécié sur iOS); pas de SDK
+  Google Sign-In (casserait le 100% Rust.)
+- Ordre de livraison imposé: webhook, puis MCP distant, puis Google Calendar.
+
+## Open questions
+
+- Le webhook se déclenche-t-il uniquement à la demande (commande chat) en v1, ou
+  aussi sur des événements auto (création de note, génération de tags) plus tard ?
+- Un seul webhook nommé ou plusieurs cibles configurables ?
+- Calendar: prévoir un repli EventKit local (write-only, sans OAuth) si le flux PKCE
+  s'avère trop lourd ?
+- Serveurs MCP: liste blanche curée dans l'app vs URL libre saisie par l'utilisateur
+  (risque de pointer vers un serveur non fiable) ?

--- a/docs/prd/agentic-tools/tasks.md
+++ b/docs/prd/agentic-tools/tasks.md
@@ -1,0 +1,55 @@
+---
+feature: Outils agentiques sortants (webhook, MCP distant, Google Calendar)
+slug: agentic-tools
+type: tasks
+source_prd: docs/prd/agentic-tools/prd.md
+stepsCompleted: [0, 1, 2, 3]
+---
+
+> ⚠️ Do NOT implement. This is the derived task list. Run `apex` (or the implementer) to execute.
+
+## Relevant Files
+- `src/services/tools.rs` - rig Tool impls (TriggerWebhook, outils MCP distants, CreateCalendarEvent)
+- `src/services/llm.rs` - câblage agent loop (prompt_with_agent / prompt_agent_with_tools)
+- `src/services/constants.rs` - ajouts system prompt, endpoints MCP connus
+- `src/services/error.rs` - variantes d'erreur outils (non bloquantes)
+- `src/db/settings_repo.rs` - persistance URL+secret webhook, toggles/clés MCP, tokens Google
+- `src/ui/settings.rs` - UI config (webhook, toggles MCP, bouton Connecter Google)
+- `src/platform/ios/mod.rs` - FFI ASWebAuthenticationSession (OAuth), ouverture Réglages
+- `Cargo.toml` - feature rig-core `rmcp` + crate `rmcp` à la version exacte pinnée
+
+## Tasks
+
+- [ ] 1.0 Webhook sortant  _(PRD: stories 1, 4, 5)_
+  - [ ] 1.1 Settings: champ URL webhook + secret, persistés en SQLite (exclus de l'archive backup.)
+  - [ ] 1.2 `TriggerWebhook` (rig Tool trait): POST JSON, en-tête `x-webhook-secret`, corps rempli par le modèle.
+  - [ ] 1.3 Câbler le tool dans l'agent loop (disponible en chat.)
+  - [ ] 1.4 Déclenchement: commande chat (manuel) en v1; documenter l'option d'événements auto pour plus tard.
+  - [ ] 1.5 Échec: timeout + erreur non bloquante, message clair, le chat continue.
+
+- [ ] 2.0 Outils MCP distants (Exa / Linear)  _(PRD: stories 2, 4, 5)_
+  - [ ] 2.1 Valider la cross-compilation `rmcp` + transport Streamable HTTP sur aarch64-apple-ios + simulateur AVANT câblage.
+  - [ ] 2.2 Cargo: `rig-core -F rmcp` + `rmcp` à la version exacte pinnée par rig 0.36 (`cargo tree -p rmcp`, éviter E0308.)
+  - [ ] 2.3 Settings: liste de serveurs MCP avec toggle ON/OFF + clé Bearer par serveur (Exa, Linear.)
+  - [ ] 2.4 Connexion `StreamableHttpClientTransport`, `list_tools`, injection `.rmcp_tools` dans l'agent.
+  - [ ] 2.5 Réponse de test citant un résultat web (Exa) dans le chat.
+  - [ ] 2.6 Échec/timeout d'un MCP: dégradation gracieuse, l'agent reste sur les outils locaux.
+
+- [ ] 3.0 Google Calendar (note vers événement)  _(PRD: stories 3, 4, 5)_
+  - [ ] 3.1 FFI `ASWebAuthenticationSession` (platform/ios), URL scheme `com.mirkobozzetto.flowflow://oauth` dans Info.plist.
+  - [ ] 3.2 Flux auth-code + PKCE en Rust, échange du token via reqwest, `refresh_token` en Keychain/SQLite.
+  - [ ] 3.3 `CreateCalendarEvent` (rig Tool): appelle l'API Calendar REST avec le bearer, depuis le contenu d'une note.
+  - [ ] 3.4 Settings: bouton "Connecter Google" + état connecté/déconnecté + déconnexion.
+  - [ ] 3.5 Échec auth/API: message clair, pas de crash, l'agent reste utilisable.
+
+- [ ] 4.0 Sécurité des secrets  _(PRD: story 4)_
+  - [ ] 4.1 Toutes les valeurs sensibles (secret webhook, clés MCP, tokens Google) en SQLite, jamais en clair dans le code.
+  - [ ] 4.2 Étendre `SENSITIVE_KEYS` pour exclure ces clés de l'archive backup.
+  - [ ] 4.3 Vérifier 0 secret loggé et 0 secret envoyé vers un host non prévu.
+
+- [ ] 5.0 Tests & validation  _(PRD: acceptance criteria + success metrics)_
+  - [ ] 5.1 Webhook: déclenchement reçu < 5 s, payload correct, secret présent en en-tête.
+  - [ ] 5.2 MCP Exa: toggle ON, au moins 1 résultat web cité; OFF, outils locaux seulement.
+  - [ ] 5.3 Calendar: note vers événement visible dans Google < 10 s; le refresh token survit.
+  - [ ] 5.4 Dégradation: chaque outil externe down laisse le chat répondre, 0 crash.
+  - [ ] 5.5 Cross-compile: build mobile vert sur les 3 cibles iOS avec `rmcp`.

--- a/docs/prd/audio-import-transcription/prd.md
+++ b/docs/prd/audio-import-transcription/prd.md
@@ -1,0 +1,147 @@
+---
+feature: Import audio dans une note pour transcription
+slug: audio-import-transcription
+type: prd
+status: ready
+stepsCompleted: [0, 1, 2, 3, 4]
+---
+
+# PRD: Import audio dans une note pour transcription
+
+## Problem statement
+
+FlowFlow ne sait transcrire que ce qu'il capte **en direct au micro**. Tout audio
+déjà enregistré ailleurs est inaccessible: un mémo d'un dictaphone physique, un fichier
+Voice Memos iPhone, l'enregistrement d'une réunion fait par une autre app.
+
+Aujourd'hui, le seul contournement pour transcrire un fichier existant est de le **rejouer
+à voix haute devant le micro** de FlowFlow: lent (temps réel), dégradé (perte de qualité,
+bruit ambiant), et impossible pour une réunion de plusieurs heures.
+
+C'est un manque direct sur la promesse du produit (transformer la parole en notes
+exploitables): la matière première de l'utilisateur, ses enregistrements, reste piégée
+hors de l'app. La douleur est forte pour les réunions longues déjà capturées, qu'on ne
+peut ni importer ni transcrire.
+
+## Goals
+
+- Permettre d'**importer un fichier audio existant** dans une note depuis l'app, sans
+  ré-enregistrement, et obtenir sa **transcription texte** dans la note.
+- Couvrir les formats réels des dictaphones et téléphones (m4a/AAC, mp3, wav, caf).
+- Supporter des fichiers **longs (plusieurs heures)** — réunions, conférences — sans
+  échec dû à une limite de durée trop courte.
+- Lancer la transcription en **arrière-plan**: l'utilisateur garde l'app utilisable
+  pendant le traitement.
+- **Détecter la langue automatiquement** (l'audio importé n'est pas forcément en français).
+- Ne **jamais abîmer la note** en cas d'échec: message clair + possibilité de relancer.
+- Réutiliser le pipeline existant (transcription, ajout au contenu de la note, indexation
+  pour la recherche sémantique) pour que l'audio importé devienne une note de plein droit.
+
+## Non-goals / Out-of-scope
+
+- Pas d'import **multi-fichiers** en une fois (un seul fichier par import dans cette version).
+- Pas de conservation du **fichier audio** importé: on transcrit puis on jette le fichier
+  (pas de relecture audio de l'import). L'audio jouable reste réservé aux enregistrements live.
+- Pas d'**extraction audio depuis une vidéo** (mov/mp4) dans cette version.
+- Pas de **sélecteur de langue manuel** (l'auto-détection suffit; pas d'UI de choix).
+- Pas de transcription **offline** (le service de transcription reste en réseau).
+- Pas de **diarisation** (séparation des locuteurs) ni d'horodatage par segment.
+- Pas d'édition audio (découpe, nettoyage) avant transcription.
+- Pas de refonte de l'enregistrement live; seul le **plafond de durée partagé** (timeout)
+  est étendu pour bénéficier aussi au live (voir Goals/Contraintes).
+
+## User stories
+
+1. **Import depuis une note.** En tant qu'utilisateur, je veux importer un fichier audio
+   depuis le menu d'une note, afin d'en récupérer le contenu en texte sans le ré-enregistrer.
+2. **Formats dictaphone.** En tant qu'utilisateur d'un dictaphone ou de Voice Memos, je veux
+   que mes fichiers (m4a, mp3, wav, caf) soient acceptés, afin de ne pas avoir à les convertir.
+3. **Réunion longue.** En tant qu'utilisateur, je veux importer une réunion de plusieurs
+   heures, afin d'en obtenir la transcription complète sans échec de durée.
+4. **Travail en arrière-plan.** En tant qu'utilisateur, je veux continuer à utiliser l'app
+   pendant qu'une longue transcription tourne, afin de ne pas rester bloqué à attendre.
+5. **Langue automatique.** En tant qu'utilisateur, je veux que la langue soit détectée
+   automatiquement, afin d'importer aussi des audios non francophones.
+6. **Échec sans dégât.** En tant qu'utilisateur, je veux qu'un import raté ne casse jamais
+   ma note et me laisse relancer, afin de réessayer sans rien perdre.
+
+## Acceptance criteria
+
+**Story 1 (import depuis une note)**
+- Given une note ouverte, When j'ouvre son menu, Then une action "Importer un audio" est
+  disponible, à côté de l'import de documents.
+- Given je choisis un fichier audio valide, When l'import se lance, Then la transcription
+  démarre et, une fois prête, son texte est ajouté au contenu de la note.
+- Given la transcription aboutie, Then la note est indexée pour la recherche sémantique
+  comme une note normale (le contenu importé devient cherchable et utilisable par le chat).
+
+**Story 2 (formats dictaphone)**
+- Given le sélecteur de fichiers, When je parcours mes fichiers, Then seuls les formats
+  audio supportés (m4a/AAC, mp3, wav, caf) sont sélectionnables.
+- Given un fichier d'un format non supporté, When je tente l'import, Then il est refusé
+  avec un message clair, sans toucher à la note.
+
+**Story 3 (réunion longue)**
+- Given un fichier audio de plusieurs heures, When je l'importe, Then la transcription
+  va jusqu'au bout sans échouer à cause d'une limite de durée.
+- Given une transcription longue en cours, When elle progresse, Then une progression
+  visible indique que le traitement avance (pas d'impression de blocage).
+
+**Story 4 (arrière-plan)**
+- Given une transcription lancée, When je quitte la note ou navigue ailleurs dans l'app,
+  Then l'app reste utilisable et la transcription continue.
+- Given je reviens sur la note quand c'est prêt, Then le texte transcrit y est bien présent
+  (le résultat n'est pas perdu par la navigation).
+
+**Story 5 (langue automatique)**
+- Given un audio importé dans une langue quelconque, When il est transcrit, Then la langue
+  est détectée automatiquement (aucune sélection manuelle requise).
+
+**Story 6 (échec sans dégât)**
+- Given un échec (délai dépassé, format refusé, clé API absente, consentement IA non donné),
+  When l'import échoue, Then la note reste intacte (aucun texte partiel inséré) et un message
+  clair explique la cause.
+- Given un import échoué, When je le relance, Then je peux réessayer sans re-créer la note.
+- Given pas de clé Soniox ou pas de consentement IA, When je tente l'import, Then l'action
+  est refusée tôt avec un message indiquant quoi configurer.
+
+## Success metrics
+
+- 100% des formats ciblés (m4a/AAC, mp3, wav, caf) sont importés et transcrits avec succès
+  sur un jeu de fichiers de test représentatif.
+- 0 cas de note corrompue ou de texte partiel inséré lors d'un import qui échoue.
+- Un fichier de **≥ 2 heures** est transcrit jusqu'au bout sans échec de durée (cible:
+  pas de timeout prématuré; valeur exacte de la borne haute à confirmer — voir Open questions).
+- Pendant une transcription en cours, l'app reste **interactive** (navigation possible,
+  aucune fenêtre bloquante).
+- ≥ 90% des imports réussis aboutissent à un texte ajouté à la note et indexé pour la
+  recherche, vérifiable en retrouvant le contenu via le chat/la recherche.
+
+## Constraints & assumptions
+
+- iOS uniquement, 100% Rust/Dioxus, cohérent avec l'architecture existante.
+- Sélection de fichiers via le sélecteur de fichiers natif iOS déjà en place (Files, iCloud
+  Drive, emplacements montés). Un seul fichier à la fois.
+- Transcription via le service Soniox déjà intégré; **réseau requis**; clé Soniox + consentement
+  IA requis (mêmes prérequis que l'enregistrement live).
+- La limite de durée actuelle de la transcription est trop courte pour le multi-heures et
+  doit être **étendue**; ce relèvement est **partagé** avec l'enregistrement live (même
+  chemin de transcription) et bénéficie donc aux deux.
+- Le fichier importé n'est **pas conservé** après transcription (décision produit: transcription
+  seule). Seul le texte est gardé dans la note.
+- Langue **auto-détectée** (on n'impose plus le français strict pour ce flux d'import).
+- Le résultat de transcription doit survivre à la navigation pendant le traitement en
+  arrière-plan (ne pas dépendre du fait que la note reste à l'écran).
+
+## Open questions
+
+- Borne haute exacte de durée/taille à supporter (ex: jusqu'à combien d'heures / quelle taille
+  de fichier vise-t-on pour la métrique « va jusqu'au bout » ?).
+- Auto-détection de langue: la garder aussi pour l'**enregistrement live** (aujourd'hui FR strict),
+  ou la limiter au flux d'import pour ne pas changer le comportement live ?
+- Feedback de progression d'une longue transcription: simple indicateur « en cours » suffisant,
+  ou faut-il une progression chiffrée (pourcentage / temps écoulé) ?
+- Notification quand une transcription d'arrière-plan se termine alors que l'utilisateur est
+  ailleurs dans l'app: signal visuel discret, ou rien (il le voit en revenant sur la note) ?
+- Comportement si l'app passe en arrière-plan iOS (écran verrouillé) pendant une longue
+  transcription: à valider au regard des limites d'exécution iOS (lié au PRD `lan-serve`/agentic).

--- a/docs/prd/audio-import-transcription/tasks.md
+++ b/docs/prd/audio-import-transcription/tasks.md
@@ -1,0 +1,64 @@
+---
+feature: Import audio dans une note pour transcription
+slug: audio-import-transcription
+type: tasks
+source_prd: docs/prd/audio-import-transcription/prd.md
+stepsCompleted: [0, 1, 2, 3]
+---
+
+> ⚠️ Do NOT implement. This is the derived task list. Run `apex` (or the implementer) to execute.
+
+## Relevant Files
+- `src/platform/ios/picker.rs` - `open_file_picker(extensions)` existant (UIDocumentPicker, asCopy) à réutiliser pour les formats audio
+- `src/ui/notes/menu.rs` - menu NoteDetail (point d'entrée "Importer un audio", à côté de l'import documents)
+- `src/ui/notes/detail.rs` - NoteDetail (déclenchement import, états, progression, insertion du texte)
+- `src/services/transcription/client.rs` - SonioxClient (transcribe format-agnostic ; timeout `MAX_POLLS`/`POLL_INTERVAL` ; `language_hints_strict` à assouplir pour l'auto-détection)
+- `src/services/transcription/hesitations.rs` - nettoyage du transcript (réutilisé)
+- `src/services/audio.rs` - dossier audio / `resolve_audio_path` (référence pour le staging temporaire du fichier importé)
+- `src/db/note_repo.rs` - persistance du contenu de la note (`set_audio_transcription` / mise à jour du contenu)
+- `src/services/embed.rs` - auto-embed du contenu transcrit (indexation recherche)
+- `src/ui/consent.rs` + `get_setting("ai_consent")` / `soniox_api_key` - prérequis clé + consentement
+- `src/services/i18n/locales/en.ftl` + `fr.ftl` - libellés UI (action, états, messages d'erreur)
+
+## Tasks
+
+- [ ] 1.0 Sélection audio + point d'entrée dans la note  _(PRD: stories 1, 2)_
+  - [ ] 1.1 Ajouter l'action "Importer un audio" dans le menu de NoteDetail, distincte de l'import de documents.
+  - [ ] 1.2 Ouvrir le sélecteur de fichiers restreint aux formats audio ciblés (m4a/AAC, mp3, wav, caf), un seul fichier.
+  - [ ] 1.3 Refuser proprement un format non supporté (message clair, note intacte) avant tout traitement.
+  - [ ] 1.4 Vérifier les prérequis tôt: clé Soniox présente + consentement IA donné, sinon message indiquant quoi configurer.
+
+- [ ] 2.0 Pipeline import → transcription  _(PRD: stories 1, 5)_
+  - [ ] 2.1 Récupérer le fichier choisi dans un emplacement temporaire (staging), hors espace exposé.
+  - [ ] 2.2 Lancer la transcription du fichier via le service existant (format-agnostic).
+  - [ ] 2.3 Activer l'auto-détection de langue pour ce flux (ne plus imposer le français strict à l'import).
+  - [ ] 2.4 Nettoyer le fichier temporaire après transcription (réussie ou échouée): aucun audio conservé.
+
+- [ ] 3.0 Support des fichiers longs (multi-heures) + progression  _(PRD: story 3)_
+  - [ ] 3.1 Étendre la borne de durée de la transcription pour tenir des fichiers de plusieurs heures (timeout partagé import + live).
+  - [ ] 3.2 Exposer une progression visible pendant le traitement (pas d'impression de blocage).
+  - [ ] 3.3 Confirmer la borne haute cible (durée/taille) et l'appliquer comme garde explicite (cf. PRD Open questions).
+
+- [ ] 4.0 Transcription en arrière-plan  _(PRD: story 4)_
+  - [ ] 4.1 Exécuter la transcription en tâche de fond: l'app reste navigable pendant le traitement.
+  - [ ] 4.2 Garantir que le résultat n'est pas perdu si l'utilisateur quitte la note ou navigue ailleurs.
+  - [ ] 4.3 Signaler la fin de traitement quand l'utilisateur est ailleurs (signal discret ou visible au retour sur la note — cf. PRD Open questions).
+
+- [ ] 5.0 Insertion du texte + indexation recherche  _(PRD: story 1)_
+  - [ ] 5.1 Ajouter le texte transcrit au contenu de la note une fois la transcription prête.
+  - [ ] 5.2 Déclencher l'auto-embed du contenu pour rendre l'import cherchable (recherche sémantique + chat).
+  - [ ] 5.3 Vérifier que la note importée se comporte comme une note normale (recherche, tags, chat).
+
+- [ ] 6.0 Gestion d'échec robuste  _(PRD: story 6)_
+  - [ ] 6.1 Aucun texte partiel inséré en cas d'échec: la note reste strictement intacte.
+  - [ ] 6.2 Messages d'erreur clairs et distincts par cause (délai dépassé, format refusé, clé absente, consentement manquant, réseau).
+  - [ ] 6.3 Permettre de relancer l'import après échec sans re-créer la note.
+  - [ ] 6.4 États visuels cohérents: en cours, succès, échec (avec raison) — libellés i18n FR/EN.
+
+- [ ] 7.0 Tests & validation  _(PRD: acceptance criteria + success metrics)_
+  - [ ] 7.1 Formats: importer et transcrire un échantillon de chaque format ciblé (m4a/AAC, mp3, wav, caf).
+  - [ ] 7.2 Fichier long: transcrire un fichier ≥ 2 h jusqu'au bout sans échec de durée.
+  - [ ] 7.3 Arrière-plan: lancer une transcription, naviguer ailleurs, vérifier le résultat présent au retour.
+  - [ ] 7.4 Échec: format refusé / clé absente / consentement manquant → note intacte + message clair + retry.
+  - [ ] 7.5 Indexation: retrouver le contenu importé via la recherche/le chat après transcription.
+  - [ ] 7.6 Non-régression: l'enregistrement live continue de fonctionner après le relèvement du timeout partagé.

--- a/docs/prd/data-backup-export/prd.md
+++ b/docs/prd/data-backup-export/prd.md
@@ -1,0 +1,118 @@
+---
+feature: Backup, export & restore des données FlowFlow
+slug: data-backup-export
+type: prd
+status: ready
+stepsCompleted: [0, 1, 2, 3, 4]
+---
+
+# PRD: Backup, export & restore des données FlowFlow
+
+## Problem statement
+
+FlowFlow n'a aucun mécanisme de sauvegarde interne. Toutes les données utilisateur
+(notes, dossiers, tags, conversations, attachments, enregistrements audio, vecteurs)
+vivent uniquement dans le conteneur de l'app sur l'iPhone.
+
+Deux douleurs aujourd'hui:
+
+- **Risque de perte.** Une réinstallation, une perte ou casse du téléphone, ou un
+  changement de signature (dev vers TestFlight vers App Store) peut effacer toutes
+  les données sans recours.
+- **Pas de portabilité.** Les données sont piégées dans l'app. Impossible de les
+  sortir pour les archiver, les transférer sur un autre appareil, ou les garder
+  hors de l'app.
+
+Le seul contournement actuel (Xcode "Download Container") ne fonctionne que pour une
+app signée en développement. Il est inutilisable par un utilisateur final qui aura
+installé FlowFlow depuis l'App Store. Pour une app dont la valeur est la mémoire
+personnelle de l'utilisateur, l'absence de backup est un risque produit majeur.
+
+## Goals
+
+- Permettre à l'utilisateur d'**exporter** la totalité de ses données dans une archive
+  unique, depuis l'app, sans Xcode ni câble.
+- Permettre de **partager** cette archive vers l'extérieur (Mac, cloud perso, autre
+  appareil) via le partage natif iOS.
+- Permettre de **restaurer** une archive dans l'app pour récupérer ou migrer ses données.
+- Garantir un aller-retour fidèle: ce qui est exporté revient identique à l'import.
+- Rester 100% local et hors-ligne, sans dépendance à un service cloud tiers.
+- Ne jamais exposer de secret: les clés API ne quittent jamais l'appareil dans l'archive.
+
+## Non-goals / Out-of-scope
+
+- Pas de synchronisation automatique ni de backup cloud géré (iCloud sync, backend maison).
+- Pas de sauvegarde planifiée/automatique en arrière-plan (export = action manuelle).
+- Pas de merge ni de résolution de conflits: l'import remplace, il ne fusionne pas.
+- Pas d'export sélectif (note par note, dossier par dossier) dans cette version.
+- Pas d'export des clés API dans l'archive (elles sont volontairement exclues).
+- Pas de format d'échange interopérable avec d'autres apps (l'archive est propre à FlowFlow).
+- Pas de chiffrement de l'archive par mot de passe dans cette version.
+
+## User stories
+
+1. **Export complet.** En tant qu'utilisateur, je veux exporter toutes mes données
+   dans une archive depuis les réglages, afin de ne jamais risquer de les perdre.
+2. **Partage de l'archive.** En tant qu'utilisateur, je veux envoyer l'archive vers
+   mon Mac ou mon cloud via le partage iOS, afin de la conserver en lieu sûr.
+3. **Restauration.** En tant qu'utilisateur, je veux importer une archive dans l'app,
+   afin de récupérer mes données après une réinstallation ou sur un nouveau téléphone.
+4. **Sécurité des secrets.** En tant qu'utilisateur, je veux que mes clés API ne soient
+   jamais incluses dans l'archive, afin de pouvoir la partager sans fuite.
+5. **Sûreté de l'import.** En tant qu'utilisateur, je veux qu'un import raté n'abîme
+   jamais mes données actuelles, afin de tester une restauration sans crainte.
+
+## Acceptance criteria
+
+**Story 1 (export complet)**
+- Given des notes, dossiers, tags, conversations, attachments, audio et vecteurs présents,
+  When je lance l'export depuis les réglages,
+  Then une archive unique est produite contenant SQLite, le vector store et les fichiers audio.
+- Given l'export terminé, When j'inspecte l'archive, Then aucune clé API n'y figure.
+
+**Story 2 (partage)**
+- Given une archive générée, When je choisis de la partager,
+  Then la feuille de partage native iOS s'ouvre (AirDrop, Fichiers, mail, cloud).
+
+**Story 3 (restauration)**
+- Given une archive FlowFlow valide, When je l'importe,
+  Then les données de l'app sont remplacées par celles de l'archive (replace total),
+  And après import les notes, audio, tags et la recherche sémantique fonctionnent comme à l'export.
+- Given un nouvel appareil/app vierge, When j'importe l'archive, Then mes données réapparaissent à l'identique.
+
+**Story 4 (sécurité des secrets)**
+- Given des clés API enregistrées, When j'exporte puis réimporte,
+  Then les clés ne sont pas restaurées et l'app demande de les re-saisir.
+
+**Story 5 (sûreté de l'import)**
+- Given une archive corrompue ou de version incompatible, When je tente l'import,
+  Then l'import est refusé avec un message clair, And les données actuelles restent intactes.
+- Given un import, Then la validation se fait avant toute écriture (atomic): aucun état partiel.
+
+## Success metrics
+
+- 100% des données exportables sont restaurées à l'identique sur un aller-retour
+  export puis import (0 perte de note/audio/tag/conversation).
+- 0 clé API présente dans une archive exportée (vérifiable par inspection).
+- 0 cas de corruption des données existantes lors d'un import qui échoue.
+- Un export complet d'une base réaliste se déclenche et aboutit en moins de 30 s
+  pour un volume cible (à confirmer: par ex. 500 notes + 100 audios).
+- Restauration réussie sur un appareil vierge en moins de 3 actions utilisateur
+  (importer le fichier, confirmer le replace, attendre la fin).
+
+## Constraints & assumptions
+
+- iOS uniquement, 100% Rust/Dioxus, hors-ligne, aucun backend ni cloud tiers.
+- L'archive transite par le partage natif iOS et le picker de fichiers existant.
+- Cible: utilisateurs finaux App Store (robustesse et UX sans outil dev requis).
+- Toutes les données vivent sous le dossier Documents de l'app (préservé par iOS sur update).
+- L'import est un **replace total**: il écrase l'état courant par l'archive.
+- Les clés API sont exclues de l'archive par décision de sécurité.
+- Livraison prévue après la v1.0 App Store (priorité non urgente, mais qualité prod).
+
+## Open questions
+
+- Faut-il confirmer le volume cible exact pour la métrique de durée d'export (500 notes / 100 audios ?).
+- Faut-il une confirmation explicite "ceci va écraser vos données actuelles" avant un import replace ? (probablement oui, à valider en UX).
+- Stratégie de compatibilité ascendante: comment gérer une archive d'une future version de schéma plus récente que l'app courante (refus simple vs message de mise à jour) ?
+- Faut-il proposer plus tard une option de chiffrement par mot de passe pour autoriser l'inclusion des clés (hors scope ici, mais à noter) ?

--- a/docs/prd/data-backup-export/tasks.md
+++ b/docs/prd/data-backup-export/tasks.md
@@ -1,0 +1,56 @@
+---
+feature: Backup, export & restore des données FlowFlow
+slug: data-backup-export
+type: tasks
+source_prd: docs/prd/data-backup-export/prd.md
+stepsCompleted: [0, 1, 2, 3]
+---
+
+> ⚠️ Do NOT implement. This is the derived task list. Run `apex` (or the implementer) to execute.
+
+## Relevant Files
+- `src/services/backup.rs` - nouveau module export/import (anticipé)
+- `src/db/mod.rs` - chemin SQLite (`Documents/flowflow.db`), fermeture/réouverture DB
+- `src/services/vectordb.rs` - chemin LanceDB (`Documents/vectordb`)
+- `src/services/audio.rs` - dossier audio (`Documents/flowflow/recording_*.wav`)
+- `src/db/settings_repo.rs` - clés API à exclure de l'export
+- `src/platform/ios/mod.rs` - `documents_dir`, share sheet iOS, file picker
+- `src/ui/settings.rs` - boutons Export / Import + confirmations
+- `Cargo.toml` - crate `zip` (déjà présent via DOCX) pour l'archive
+
+## Tasks
+
+- [ ] 1.0 Format d'archive FlowFlow + manifest versionné  _(PRD: stories 1, 3, 5)_
+  - [ ] 1.1 Définir la structure de l'archive (zip): un `manifest` (version de schéma, date, compteurs) + un dossier de données.
+  - [ ] 1.2 Lister précisément ce qui entre: `flowflow.db`, `vectordb/`, fichiers audio WAV; acter l'exclusion explicite des clés API.
+  - [ ] 1.3 Définir la règle de version: numéro de schéma de l'archive + politique de compatibilité (refus si incompatible).
+
+- [ ] 2.0 Export complet vers archive, clés API exclues  _(PRD: stories 1, 4)_
+  - [ ] 2.1 Rassembler les sources sous `Documents` (SQLite + `vectordb/` + audio) dans un staging cohérent.
+  - [ ] 2.2 Produire une copie de la base SQLite sans les valeurs sensibles (clés `openai`/`anthropic`/`soniox`).
+  - [ ] 2.3 Empaqueter staging + manifest en une archive unique.
+  - [ ] 2.4 Écrire l'archive dans un emplacement partageable et retourner son chemin.
+
+- [ ] 3.0 Partage de l'archive via share sheet natif iOS  _(PRD: story 2)_
+  - [ ] 3.1 Exposer une fonction de partage iOS (UIActivityViewController) sur l'archive générée (AirDrop/Fichiers/mail/cloud).
+  - [ ] 3.2 Gérer l'annulation et l'échec du partage proprement (pas d'état bloqué).
+
+- [ ] 4.0 Import / restore replace total, atomic + validation  _(PRD: stories 3, 4, 5)_
+  - [ ] 4.1 Sélectionner l'archive via le file picker iOS existant.
+  - [ ] 4.2 Valider AVANT toute écriture: présence du manifest, version compatible, intégrité du contenu.
+  - [ ] 4.3 Validation OK → remplacer atomiquement les données actuelles (SQLite + `vectordb/` + audio) par celles de l'archive.
+  - [ ] 4.4 Validation KO → refuser avec message clair, données actuelles intactes (aucun état partiel).
+  - [ ] 4.5 Après restore → rouvrir DB + vector store; ne PAS restaurer les clés API, inviter à les re-saisir.
+
+- [ ] 5.0 UI Settings: Export / Import + confirmation du replace  _(PRD: stories 1, 2, 3)_
+  - [ ] 5.1 Ajouter les boutons Export et Import dans `SettingsView`.
+  - [ ] 5.2 Flux export: déclencher, montrer la progression, puis ouvrir le partage.
+  - [ ] 5.3 Flux import: confirmation explicite "ceci va écraser vos données actuelles" avant le replace.
+  - [ ] 5.4 États visuels: succès, échec (avec raison), invite à re-saisir les clés après import.
+
+- [ ] 6.0 Tests & validation  _(PRD: acceptance criteria + success metrics)_
+  - [ ] 6.1 Round-trip: export puis import sur base réaliste, 0 perte (notes/audio/tags/conversations + recherche sémantique OK).
+  - [ ] 6.2 Exclusion clés: aucune clé API dans l'archive; clés non restaurées après import.
+  - [ ] 6.3 Échec: archive corrompue + version incompatible → refus, données intactes.
+  - [ ] 6.4 Appareil/app vierge: import restaure tout à l'identique.
+  - [ ] 6.5 Mesurer la durée d'export sur le volume cible (à confirmer) et vérifier < 30 s.

--- a/docs/prd/lan-serve/prd.md
+++ b/docs/prd/lan-serve/prd.md
@@ -1,0 +1,130 @@
+---
+feature: Serveur LAN, exposer notes et backup sur le réseau local
+slug: lan-serve
+type: prd
+status: ready
+stepsCompleted: [0, 1, 2, 3, 4]
+---
+
+# PRD: Serveur LAN, exposer notes et backup sur le réseau local
+
+## Problem statement
+
+Les notes vivent dans l'app, consultables seulement sur le petit écran du téléphone.
+Aucun moyen simple de lire ou chercher ses notes depuis le Mac, ni de récupérer
+l'archive de backup sans passer par le share sheet ou un câble.
+
+iOS interdit un serveur entrant persistant, mais autorise un serveur HTTP local tant
+que l'app est au premier plan, joignable par les appareils du même wifi (démontré par
+la recherche de faisabilité: WorldWideWeb, Working Copy, iSH le font.) C'est exactement
+le créneau exploitable: app ouverte plus réseau local égale serveur joignable.
+
+Pourquoi maintenant: la fonctionnalité de backup (PRD data-backup-export) produit déjà
+une archive; l'exposer en téléchargement réseau est un complément naturel, et lire ses
+notes sur grand écran est une demande récurrente de Mirko.
+
+## Goals
+
+- Exposer les notes en lecture et recherche sur le réseau local (Mac, navigateur),
+  app au premier plan.
+- Télécharger l'archive de backup directement par le réseau, sans share sheet ni câble.
+- Garder la session stable: écran non mis en veille pendant le service, découverte
+  simple par nom, coupure propre quand l'app quitte le premier plan.
+- Protéger l'accès par un token: aucune note exposée sans le consentement explicite.
+- Optionnel: joindre le téléphone hors-LAN (5G) via un relais sortant.
+
+## Non-goals / Out-of-scope
+
+- Pas de serveur persistant ni d'arrière-plan: le serveur vit seulement quand l'app est
+  au premier plan (suspension iOS = serveur coupé, documenté.)
+- Pas de synchronisation multi-appareil ni d'écriture massive: lecture et téléchargement
+  d'abord; l'écriture depuis le Mac (POST note) est un stretch, pas le coeur.
+- Pas de reachability internet par défaut: LAN uniquement. Le relais 5G est une option
+  séparée qui sort du 100% offline.
+- Pas de blocage des appels entrants par l'app (impossible iOS): guidage manuel seulement
+  (Concentration, Mode Avion.)
+- Pas de TLS dans la v1 LAN (localhost/LAN); à noter pour un usage sur wifi public.
+
+## User stories
+
+1. **Lire les notes via wifi.** En tant qu'utilisateur, je veux ouvrir mes notes dans le
+   navigateur du Mac sur le même wifi, afin de lire et copier sur grand écran.
+2. **Recherche.** En tant qu'utilisateur, je veux chercher mes notes via une URL, afin de
+   retrouver vite une note depuis le Mac.
+3. **Télécharger le backup.** En tant qu'utilisateur, je veux récupérer l'archive de
+   backup par le réseau, afin d'éviter le share sheet ou le câble.
+4. **Session stable.** En tant qu'utilisateur, je veux que l'écran ne s'éteigne pas
+   pendant que je sers, afin que la connexion ne tombe pas.
+5. **Découverte.** En tant qu'utilisateur, je veux joindre le téléphone par un nom simple
+   (flowflow.local), afin de ne pas taper l'adresse IP.
+6. **Sécurité d'accès.** En tant qu'utilisateur, je veux un accès protégé par token, afin
+   que personne d'autre sur le wifi ne lise mes notes.
+7. **(Stretch) Relais 5G.** En tant qu'utilisateur, je veux joindre mon téléphone hors
+   wifi, afin que ça marche aussi en mobilité.
+
+## Acceptance criteria
+
+**Story 1 (lire)**
+- Given l'app au premier plan et le Mac sur le même wifi, When j'ouvre l'URL du serveur,
+  Then la liste de mes notes s'affiche dans le navigateur.
+
+**Story 2 (recherche)**
+- Given des notes présentes, When je recherche via l'URL, Then les résultats sont
+  identiques à ceux de l'app (aucun écart.)
+
+**Story 3 (backup)**
+- Given une archive disponible, When je la télécharge par le réseau, Then le fichier est
+  intègre et identique à un export local (aller-retour fidèle.)
+
+**Story 4 (session)**
+- Given le serve mode activé, When le temps passe, Then l'écran reste allumé.
+- Given une inactivité prolongée, When le délai est atteint, Then le serveur se coupe et
+  l'écran peut se rendormir.
+
+**Story 5 (découverte)**
+- Given le serve mode actif, When je cherche le téléphone, Then il est joignable par un
+  nom (flowflow.local) ou, à défaut, par l'IP affichée dans l'app.
+
+**Story 6 (sécurité)**
+- Given un token requis, When une requête arrive sans token valide, Then elle est refusée
+  (401) et aucune note n'est exposée.
+
+**Story 7 (stretch, relais 5G)**
+- Given le relais activé et le téléphone sur 5G, When je joins le téléphone hors wifi,
+  Then la connexion passe par un relais sortant (aucun port entrant ouvert sur le tel.)
+
+**Cycle de vie (transversal)**
+- Given le serve mode actif, When l'app passe en arrière-plan, Then le serveur se coupe
+  proprement (aucun socket fantôme), And reprend au retour au premier plan.
+
+## Success metrics
+
+- Mac sur le même wifi: la liste des notes s'affiche en moins de 2 s après ouverture
+  de l'URL.
+- Recherche réseau: 0 écart de résultats par rapport à l'app.
+- Archive téléchargée intègre, aller-retour identique à l'export local, en moins de 30 s
+  pour le volume cible.
+- Écran reste allumé tant que serve mode ON; auto-coupure après le délai d'inactivité.
+- Accès sans token: 100% refusés (401), 0 note exposée.
+- App passée en arrière-plan: serveur coupé en moins du délai de grâce iOS, 0 socket
+  fantôme.
+
+## Constraints & assumptions
+
+- iOS uniquement, 100% Rust/Dioxus, tokio déjà présent.
+- Serveur HTTP local, joignable seulement app au premier plan et sur le même wifi (LAN);
+  la suspension iOS coupe le serveur (documenté.)
+- L'app ne peut pas bloquer les appels: guidage manuel Concentration/Mode Avion, plus un
+  rappel que sur 5G un appel ne coupe pas la data (VoLTE) tant qu'on ne décroche pas.
+- Sur 5G il n'y a pas de LAN avec le Mac: un relais sortant (VPS) est requis, ce qui en
+  fait une option séparée.
+- Réutilise l'archive du PRD data-backup-export pour le téléchargement.
+
+## Open questions
+
+- Port fixe (8080) ou port aléatoire affiché dans l'app ?
+- Token: code court affiché vs lien complet contenant le token ?
+- mDNS/Bonjour disponible en pur Rust sur iOS à valider, sinon repli sur l'IP brute ?
+- Relais 5G: que faut-il héberger côté VPS, quel coût, et est-ce dans ce PRD ou un PRD
+  relais dédié ?
+- Écriture depuis le Mac (POST note) dans cette version ou plus tard ?

--- a/docs/prd/lan-serve/tasks.md
+++ b/docs/prd/lan-serve/tasks.md
@@ -1,0 +1,56 @@
+---
+feature: Serveur LAN, exposer notes et backup sur le réseau local
+slug: lan-serve
+type: tasks
+source_prd: docs/prd/lan-serve/prd.md
+stepsCompleted: [0, 1, 2, 3]
+---
+
+> ⚠️ Do NOT implement. This is the derived task list. Run `apex` (or the implementer) to execute.
+
+## Relevant Files
+- `src/services/serve.rs` - nouveau module serveur HTTP local (routes, auth token, cycle de vie)
+- `src/services/backup.rs` - réutilise l'archive export pour la route de téléchargement
+- `src/db/note_repo.rs` - lecture et recherche des notes pour les routes
+- `src/platform/ios/mod.rs` - FFI isIdleTimerDisabled, annonce mDNS/Bonjour, ouverture Réglages
+- `src/ui/settings.rs` - toggle Serve mode, affichage URL + token + état
+- `Cargo.toml` - crate serveur HTTP (tiny_http ou axum) + éventuel mDNS
+
+## Tasks
+
+- [ ] 1.0 Serveur HTTP local + lecture des notes  _(PRD: stories 1, 2)_
+  - [ ] 1.1 Module `serve.rs`: bind sur un port, démarrage/arrêt pilotés par un toggle.
+  - [ ] 1.2 Route `GET /notes` (liste JSON) + `GET /note/{id}`.
+  - [ ] 1.3 Route `GET /search?q=` renvoyant les mêmes résultats que l'app.
+  - [ ] 1.4 Page d'index HTML minimale lisible au navigateur (liste + recherche.)
+
+- [ ] 2.0 Session stable (no-veille + cycle de vie)  _(PRD: story 4 + transversal)_
+  - [ ] 2.1 `isIdleTimerDisabled = true` quand Serve ON; reset à OFF.
+  - [ ] 2.2 Couper le serveur quand l'app passe en arrière-plan; rouvrir au retour au premier plan.
+  - [ ] 2.3 Auto-coupure après N minutes sans requête: serveur OFF + écran peut se rendormir.
+  - [ ] 2.4 Bandeau de guidage Concentration/Mode Avion + bouton ouvrir Réglages (l'app ne bloque pas les appels.)
+
+- [ ] 3.0 Sécurité d'accès  _(PRD: story 6)_
+  - [ ] 3.1 Token requis sur chaque route (en-tête ou query); sans token valide, 401.
+  - [ ] 3.2 Token généré par session, affiché dans Settings; option régénérer.
+  - [ ] 3.3 LAN uniquement par défaut; avertissement pour wifi public (pas de TLS en v1.)
+
+- [ ] 4.0 Découverte réseau  _(PRD: story 5)_
+  - [ ] 4.1 Valider mDNS/Bonjour en pur Rust sur iOS; sinon repli sur l'IP affichée.
+  - [ ] 4.2 Annoncer `flowflow.local` + le port; afficher l'URL et le token dans Settings.
+
+- [ ] 5.0 Téléchargement du backup par le réseau  _(PRD: story 3)_
+  - [ ] 5.1 Route `GET /backup.zip` servant l'archive du PRD data-backup-export.
+  - [ ] 5.2 Générer l'archive à la demande (staging) puis la streamer (io::copy, pas de lecture complète en mémoire.)
+  - [ ] 5.3 Intégrité: aller-retour identique à l'export local.
+
+- [ ] 6.0 (Stretch) Relais 5G hors LAN  _(PRD: story 7)_
+  - [ ] 6.1 Évaluer un relais sortant (tel vers VPS vers client) en option séparée; chiffrer coût et scope.
+  - [ ] 6.2 Décision: inclure ici ou créer un PRD relais dédié.
+
+- [ ] 7.0 Tests & validation  _(PRD: acceptance criteria + success metrics)_
+  - [ ] 7.1 Mac même wifi: `/notes` < 2 s; recherche en parité avec l'app.
+  - [ ] 7.2 Sans token: 401, 0 note exposée.
+  - [ ] 7.3 Écran reste allumé Serve ON; auto-coupure puis l'écran se rendort.
+  - [ ] 7.4 App en arrière-plan: serveur coupé, 0 socket fantôme.
+  - [ ] 7.5 `/backup.zip` intègre, < 30 s pour le volume cible.

--- a/docs/rfcs/0001-data-backup-export/RFC.md
+++ b/docs/rfcs/0001-data-backup-export/RFC.md
@@ -1,0 +1,442 @@
+---
+rfc_id: "0001"
+slug: "data-backup-export"
+title: "Backup, export & restore des données FlowFlow"
+status: Review
+author: "Mirko Bozzetto"
+created: "2026-05-30"
+updated: "2026-05-30"
+stepsCompleted: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+scope_path: "/Users/mirkobozzetto/code/flowflow"
+auto_mode: false
+skip_review: false
+source_prd: "docs/prd/data-backup-export/prd.md"
+---
+
+# 0001 — Backup, export & restore des données FlowFlow
+
+## 1. Summary
+
+FlowFlow n'a aucun mécanisme de sauvegarde interne : toutes les données (notes, dossiers,
+tags, conversations, attachments, audio, vecteurs) vivent dans le conteneur de l'app, sans
+recours en cas de perte du téléphone, de réinstallation ou d'un changement de signature.
+
+Ce RFC recommande une **archive zip auto-portante** : snapshot SQLite consistant via
+`VACUUM INTO` (clés API expurgées), copie du dossier LanceDB `vectordb/`, copie des WAV, le
+tout décrit par un `manifest.json` versionné. Export via la feuille de partage native iOS,
+import en **replace total** validé puis appliqué au **prochain cold launch** (staging hors
+Documents → validation → swap per-store du trio db/vectordb/audio → réouverture). Aucune
+dépendance cloud, aucune clé exposée.
+
+Impact : une nouvelle couche `src/services/backup.rs` + un module de partage iOS, deux boutons
+dans Settings, et l'ouverture des chemins de stores existants. Aucune migration de schéma
+SQLite. La crate `zip` est déjà présente. Risque principal : la cohérence de l'aller-retour
+sur trois stores hétérogènes, traité par la stratégie atomique et le manifest.
+
+## 2. Context / Codebase
+
+### Affected modules
+- `src/services/backup.rs` — **nouveau** : orchestration export/import, archive, manifest, sanitization, swap atomique.
+- `src/db/mod.rs` — `db_path()` → `Documents/flowflow.db`, ouverture WAL (`PRAGMA journal_mode=WAL`), `migrate()`. Cible pour le snapshot et la réouverture.
+- `src/services/vectordb.rs` — `vectordb_path()` → `Documents/vectordb`, `VectorStore::open()` (async, `lancedb::connect`). Dossier Lance à copier/swapper.
+- `src/services/audio.rs` — `output_dir()` → `Documents/flowflow/`, `recording_*.wav`. Chemins **relatifs** en DB depuis migration v4.
+- `src/db/settings_repo.rs` — `get_setting`/`set_setting` sur table `settings` (key-value). Source des clés API à exclure.
+- `src/platform/ios/mod.rs` + **nouveau** `src/platform/ios/share.rs` — `documents_dir()`, partage `UIActivityViewController` (à créer).
+- `src/platform/ios/picker.rs` — `open_file_picker(extensions)` (UIDocumentPicker, copie le fichier choisi). Réutilisé pour l'import.
+- `src/ui/settings.rs` — boutons Export / Import + dialogues de confirmation + états visuels.
+- `Cargo.toml` — `zip = "2"` (deflate) **déjà présent** ; `sha2` optionnel pour checksums.
+
+### Key symbols
+- `db_path()` — `src/db/mod.rs:17` — utilisé par `Database::open()`.
+- `Database::open_at(PathBuf)` — `src/db/mod.rs:43` — ouvre + WAL + FK + `migrate()`. Réutilisable pour rouvrir après restore.
+- `note_audios.file_path` — schema V5, `src/db/note_repo.rs:162` — les WAV sont référencés par **filename seul** (résolus via `resolve_audio_path`, `audio.rs:229`) → portabilité OK. (NB : `migrate_audio_paths_to_relative`, `db/mod.rs:102`, est du code v4 mort — colonne `notes.audio_file_path` droppée en V7.)
+- `vectordb_path()` — `src/services/vectordb.rs:34` ; `VectorStore::open()` — `:113`.
+- `output_dir()` / `resolve_audio_path()` — `src/services/audio.rs:213` / `:229`.
+- `delete_all_audios` / `cleanup_orphan_audio` — `src/db/note_repo.rs:262` / `:237` — primitives utiles pour un reset avant restore.
+- `open_file_picker` — `src/platform/ios/picker.rs:77` — patron pour ajouter le share sheet.
+
+### Prior art
+- ADR/RFC : aucun (premier RFC du repo, `docs/rfcs/` créé pour ce document).
+- PRD source : `docs/prd/data-backup-export/prd.md` (status: ready) + `tasks.md` (6 parents / 24 sous-tâches).
+- Postmortem connexe : `docs/stories/2026-05-29-appstore-screenshots-stuck...md` (pattern iris API, non lié au backup).
+- Tests existants pertinents : `tests/lancedb_ios.rs` (open_store, vector_search), `tests/attachment_test.rs` (migrations + CRUD + cascade).
+
+### Execution flows touched
+- `App → Documents_dir` / `App → Open` : init des stores au démarrage (handles `Database`, `VectorStore` posés dans l'état Dioxus). Restore doit reconstruire ces handles.
+- `resolve_audio_path → Documents_dir` : lecture/écriture WAV.
+- `embed_note → Open` / `embed_attachment → Open` : pipeline d'embedding (pertinent uniquement si on choisissait le re-embed à l'import — voir alternatives).
+
+## 3. Problem & Motivation
+
+### Current state
+Trois stores hétérogènes coexistent sous `Documents/` :
+1. `flowflow.db` (SQLite, **WAL**) — notes, dossiers, tags, conversations, attachments, settings.
+2. `vectordb/` (dataset LanceDB on-disk : fragments + manifest + index) — vecteurs d'embeddings.
+3. `flowflow/recording_*.wav` (audio brut).
+
+Aucun chemin programmatique ne les sort de l'app. Le seul contournement (`Xcode → Download
+Container`) exige une app **signée dev** et un Mac câblé : inutilisable par un utilisateur App Store.
+
+### Pain (qui, fréquence, coût)
+- **Mirko (maintenant)** : à chaque réinstallation / changement de signature dev → distribution, risque de perte totale. Déjà vécu (l'app dev-signée disparaît au bout de quelques jours).
+- **Utilisateurs App Store (à venir)** : la valeur du produit est la mémoire personnelle ; une perte = perte de confiance définitive. Coût = churn + réputation.
+
+### Why now (trigger)
+v1.0 est en revue App Store. Le passage dev → distribution et la migration vers de vrais
+utilisateurs rendent l'absence de backup un **risque produit bloquant** dès la première mise à jour.
+
+### Signals
+- 0 mécanisme d'export aujourd'hui (mesurable : aucune fonction dans le code).
+- Incident réel documenté : disparition de l'app dev-signée → motivation directe du PRD.
+
+## 4. Goals / Non-Goals
+
+### Goals (mesurables)
+1. Exporter 100 % des données dans **une archive unique** depuis Settings, sans Xcode ni câble.
+2. Aller-retour fidèle : export → import restitue notes/audio/tags/conversations + recherche sémantique **identiques** (0 perte).
+3. Partager l'archive via la **feuille de partage native iOS** (AirDrop, Fichiers, mail, cloud perso).
+4. Import = **replace total atomique** : un échec laisse les données courantes **intactes** (0 corruption).
+5. **0 clé API** dans l'archive (vérifiable par inspection).
+
+### Non-Goals (explicitement hors scope)
+- Pas de sync auto ni de backup cloud géré (iCloud/CloudKit, backend).
+- Pas de backup planifié en arrière-plan (export = action manuelle).
+- Pas de merge ni de résolution de conflits (import = remplace, pas fusion).
+- Pas d'export sélectif (note par note) dans cette version.
+- Pas de chiffrement par mot de passe (donc clés exclues, non incluses chiffrées).
+- Pas de format interopérable avec d'autres apps (archive propre à FlowFlow).
+
+## 5. Alternatives Considered
+
+### Alt 0 — Status quo (Xcode Download Container)
+- **Résumé** : ne rien construire ; s'appuyer sur l'extraction de conteneur via Xcode.
+- **Résout** : un backup ponctuel pour le développeur uniquement.
+- **Pros** : 0 code, déjà fonctionnel aujourd'hui.
+- **Cons** : exige app **dev-signée** + Mac + câble + Xcode ; **inutilisable par un utilisateur App Store** (la cible du PRD) ; pas de restore in-app.
+- **Coût** : nul. **Réversibilité** : n/a.
+- **Verdict** : rejeté (ne résout pas le problème pour la cible).
+
+### Alt 1 — Backup cloud géré (iCloud / CloudKit)
+- **Résumé** : synchroniser automatiquement les stores vers iCloud.
+- **Résout** : durabilité + multi-appareils, transparent.
+- **Pros** : zéro action utilisateur, résilient à la perte d'appareil.
+- **Cons** : **Non-goal explicite du PRD** (zéro cloud tiers) ; complexité majeure (conflits, sync deltas sur 3 stores, Lance non sync-friendly) ; entitlements + quotas ; surface de sécurité (données hors appareil).
+- **Coût** : XL. **Réversibilité** : faible (couplage iCloud).
+- **Verdict** : rejeté (contredit les contraintes produit).
+
+### Alt 2 — Archive zip auto-portante, snapshot complet (RECOMMANDÉ)
+- **Résumé** : zip contenant `manifest.json` + `db/flowflow.db` (snapshot `VACUUM INTO`, clés expurgées) + `vectordb/**` + `audio/*.wav`. Export → share sheet. Import → staging + validation + swap atomique + réouverture.
+- **Résout** : durabilité + portabilité + restore offline complet, 100 % local.
+- **Pros** : offline total ; aller-retour **exact** (vecteurs inclus, pas de re-calcul) ; pas de clé requise au restore ; `zip` déjà présent ; restore rapide (copie, pas d'embedding).
+- **Cons** : archive plus volumineuse (WAV + vecteurs) ; couplage au format on-disk LanceDB/arrow entre versions d'app (atténué par manifest + même app) ; logique de swap atomique à écrire soigneusement.
+- **Coût** : L. **Réversibilité** : élevée (format interne, modifiable).
+- **Réfs** : SQLite `VACUUM INTO` (doc officielle), LanceDB dataset = répertoire copiable à froid, crate `zip` (déjà utilisée pour DOCX).
+
+### Alt 3 — Archive métadonnées seules + re-embed à l'import
+- **Résumé** : zip SQLite (sanitisé) + WAV, **sans** `vectordb/` ; reconstruire les vecteurs à l'import via OpenAI.
+- **Résout** : durabilité + portabilité avec archive plus petite et auto-réparante (insensible au format Lance).
+- **Pros** : archive minimale ; pas de couplage au format Lance ; vecteurs toujours « frais ».
+- **Cons** : **chicken-and-egg** — les clés API sont exclues de l'archive, donc une app vierge restaurée n'a **pas de clé** → re-embed impossible avant que l'utilisateur ressaisisse sa clé OpenAI ; nécessite **réseau** ; **coût $** (ré-embedding de tout le corpus) ; lent (500 notes × chunks) ; viole partiellement le goal « restore offline qui marche immédiatement ».
+- **Coût** : M (réutilise `embed.rs`). **Réversibilité** : élevée.
+- **Verdict** : rejeté comme stratégie primaire ; conservé comme **fallback** futur (bouton « reconstruire l'index ») si le format Lance casse entre versions.
+
+### Alt 4 — Dump SQL logique (texte) + vecteurs
+- **Résumé** : exporter un `.sql` (INSERTs) au lieu du fichier binaire `.db`.
+- **Pros** : lisible, robuste aux changements de page-format SQLite.
+- **Cons** : plus lent, plus gros que `VACUUM INTO` pour des blobs ; toujours besoin de gérer `vectordb/` séparément ; aucun gain réel vs snapshot binaire pour un usage interne mono-app.
+- **Coût** : M. **Verdict** : rejeté (complexité sans bénéfice ici).
+
+## 6. Proposed Design
+
+### Architecture overview
+
+```mermaid
+flowchart TD
+    UI[ui/settings.rs<br/>Export / Import] --> BK[services/backup.rs<br/>orchestration]
+    BK -->|VACUUM INTO + strip keys| DB[(flowflow.db<br/>WAL)]
+    BK -->|copy dir cold| VDB[(vectordb/<br/>LanceDB)]
+    BK -->|copy WAV| AUD[(flowflow/*.wav)]
+    BK -->|write/read| ZIP[[archive .ffbak.zip<br/>manifest.json]]
+    BK -->|export| SHARE[platform/ios/share.rs<br/>UIActivityViewController]
+    BK -->|import| PICK[platform/ios/picker.rs<br/>open_file_picker]
+    BK -->|after restore| REOPEN[Database::open_at + VectorStore::open]
+```
+
+### Archive layout
+
+```
+flowflow-backup-YYYYMMDD-HHMMSS.ffbak.zip
+├── manifest.json
+├── db/
+│   └── flowflow.db          # snapshot VACUUM INTO, lignes clés API supprimées
+├── vectordb/                # copie intégrale du dataset LanceDB
+│   └── ... (fragments, manifest Lance, index)
+└── audio/
+    └── recording_*.wav      # noms = filenames relatifs déjà stockés en DB
+```
+
+`.ffbak.zip` = zip standard avec extension custom (le picker filtre dessus ; le share sheet
+l'expose tel quel). Reste un zip valide → inspectable.
+
+### Data model — `manifest.json`
+
+```json
+{
+  "format": "flowflow-backup",
+  "archive_version": 1,
+  "schema_version": 7,
+  "app_version": "1.0.0",
+  "lance_format": "lancedb-0.27.2 / arrow-57",
+  "created_at": "2026-05-30T12:00:00.000Z",
+  "counts": { "notes": 0, "folders": 0, "attachments": 0,
+              "conversations": 0, "audio_files": 0, "vector_chunks": 0 },
+  "excluded": ["openai_api_key", "anthropic_api_key", "soniox_api_key"],
+  "entries": [ { "path": "db/flowflow.db", "crc32": "..." } ]
+}
+```
+
+- `schema_version` = `MAX(version)` de `MIGRATIONS`, **calculé dynamiquement** (jamais hardcodé ; actuellement **7** — V7 droppe `notes.audio_file_path`/`duration_secs`). **Règle de compat** : refuser l'import si `manifest.schema_version > app`. Si `<`, l'import passe et `migrate()` upgrade au boot. Anti-tamper : après ouverture de la DB stagée, faire confiance à `MAX(_migrations.version)` **réel** de la DB ; refuser s'il diffère du champ manifest.
+- `lance_format` : informatif ; un mismatch majeur déclenche un avertissement (cf. risques), pas un refus dur tant que LanceDB ouvre le dataset.
+- CRC32 : déjà calculé par la crate `zip` par entrée → intégrité quasi gratuite ; pas de `sha2` requis en v1.
+
+### Aucune migration SQLite
+Le backup lit le schéma existant ; il n'ajoute pas de table. La seule « version » introduite est
+`archive_version` dans le manifest (versionnement du **format d'archive**, distinct du schéma DB).
+
+### Export flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Settings UI
+    participant B as backup::export
+    participant FS as tmp staging (NSTemporaryDirectory)
+    U->>S: tap Export
+    S->>B: export() (write-gate fermé)
+    B->>FS: VACUUM INTO tmp/flowflow.db
+    B->>FS: DELETE clés (SENSITIVE_KEYS) sur la copie
+    B->>FS: VACUUM la copie (récupère les pages free)
+    B->>FS: copy vectordb/ (gate fermé + embeds drainés)
+    B->>FS: copy flowflow/*.wav
+    B->>FS: write manifest.json (counts, schema_version)
+    B->>FS: zip(tmp) -> *.ffbak.zip
+    B->>S: path de l'archive
+    S->>U: UIActivityViewController(path)
+```
+
+Détails :
+- `VACUUM INTO 'tmp/flowflow.db'` produit une **copie consistante** (frames WAL committés inclus), sans toucher la DB live. Sur la copie : `DELETE FROM settings WHERE key IN (SENSITIVE_KEYS)` **puis `VACUUM`** pour récupérer les pages libérées (sinon les octets `sk-...` survivent dans les pages free). `SENSITIVE_KEYS` = **une seule const** dans `settings_repo.rs` (pas une liste manuelle dans le manifest). Test : scanner les octets du `db/flowflow.db` final pour les préfixes de clés connus → 0 occurrence.
+- Staging dans `temp_dir`/`NSTemporaryDirectory`, **pas** dans `Documents/` (exposé par l'app Files). Cleanup garanti sur **tout** chemin de sortie (succès, échec, panic).
+- Copie de `vectordb/` valide **uniquement** write-gate fermé + embeds en vol drainés (cf. concurrence). Après copie, **valider** en ouvrant la copie stagée (`lancedb::connect` + `open_table`) avant de zipper.
+- Zip en **streaming** par entrée via `std::io::copy(File::open(wav), zip)` — jamais `fs::read` d'un WAV entier — pour tenir les gros volumes.
+
+### Import / restore flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Settings UI
+    participant P as ios::picker
+    participant B as backup::import
+    participant M as main()/boot
+    Note over U,B: Phase 1 — app en cours d'exécution
+    U->>S: tap Import
+    S->>P: open_file_picker([UTType ffbak])
+    P-->>B: archive path (copiée par iOS)
+    B->>B: unzip -> tmp/staging ; lire manifest
+    B->>B: VALIDATE avant écriture (format, schema<=app, crc zip,<br/>open staged DB+vectordb, counts == manifest)
+    alt invalide
+        B-->>S: refus + raison (données intactes)
+    else valide
+        S->>U: confirm "ceci écrase vos données actuelles"
+        U->>S: confirme
+        B->>B: écrit marqueur pending_restore -> tmp/staging
+        B-->>S: "Import prêt — relancez FlowFlow"
+    end
+    Note over M: Phase 2 — prochain cold launch, AVANT tout handle
+    M->>M: détecte pending_restore
+    M->>M: checkpoint+close (aucun handle ouvert encore)
+    M->>M: per-store move courant -> *.bak (trio db+wal+shm, vectordb/, flowflow/)
+    M->>M: move staging -> Documents
+    M->>M: Database::open_at (migrate) + VectorStore::open
+    alt succès
+        M->>M: purge *.bak ; clés NON restaurées
+    else échec
+        M->>M: rollback *.bak (3 stores, all-or-nothing)
+    end
+```
+
+**Atomicité (per-store, corrigé post-review)** : `std::fs::rename` ne *remplace pas* un répertoire
+non vide (POSIX `ENOTEMPTY`) et ne merge pas. On procède donc store par store : `move courant ->
+*.bak` (rename vers un nom inexistant, toujours légal) puis `move staging -> nom`. Pas d'atomicité
+inter-stores : un crash entre deux stores laisse un état mixte → le rollback au boot vérifie les
+**trois** stores ensemble (all-or-nothing : tout `*.bak` résiduel ⇒ on restaure tout). Pas de risque
+EXDEV (tout sous `Documents/`, même fs). **WAL** : déplacer le trio `flowflow.db` + `-wal` + `-shm`
+comme une unité, après checkpoint+close ; ne jamais laisser un `-wal` périmé à côté d'une db
+importée (SQLite rejouerait des frames de l'ancienne DB → corruption).
+
+**Handles live (corrigé post-review)** : `Database` est partagé en `Arc<Database>` cloné via
+`Signal<Arc<Database>>` sur 18+ composants ; `VectorStore` n'est **pas** dans l'état (chaque appelant
+ouvre le sien). On ne peut donc pas fermer la connexion SQLite en plein vol, et iOS n'offre aucune
+API publique de relaunch (`exit(0)` = risque de rejet App Store, écran noir). **Décision : le swap
+se fait au prochain cold launch**, dans `main()`/boot, **avant** la création de tout handle. Phase 1
+ne fait que valider + stager + poser le marqueur `pending_restore` ; Phase 2 (boot) effectue le swap
+puis ouvre les stores. Jamais de swap sous handles vivants. (v2 possible : handle unique central
+derrière un `OnceLock<Mutex<…>>` pour fermeture in-process et swap à chaud.)
+
+### Modules / files affected
+
+| Fichier | Action | Détail |
+|---|---|---|
+| `src/services/backup.rs` | **NEW** | `export() -> PathBuf`, `import(archive) -> Result`, manifest, sanitize, swap |
+| `src/db/mod.rs` | edit | helper snapshot `VACUUM INTO` ; exposer `db_path()` (déjà pub) ; réouverture |
+| `src/services/vectordb.rs` | edit | exposer `vectordb_path()` (pub) ; pas de logique réseau |
+| `src/services/audio.rs` | none/edit | `output_dir()` déjà pub |
+| `src/db/settings_repo.rs` | edit | const liste des clés sensibles à exclure |
+| `src/platform/ios/share.rs` | **NEW** | `share_file(path)` via `UIActivityViewController` |
+| `src/platform/ios/mod.rs` | edit | `pub use share::share_file` |
+| `src/platform/ios/picker.rs` | edit | accepter l'extension/UTType de l'archive |
+| `src/ui/settings.rs` | edit | boutons + confirm + états (progress/succès/échec/re-saisie clés) |
+| `Cargo.toml` | none | `zip` déjà présent ; `sha2` non requis en v1 |
+
+### Cross-cutting
+- **Sécurité** : clés jamais écrites dans l'archive (DELETE **+ VACUUM** sur la copie) ; staging hors `Documents/` ; jamais de valeurs `settings` dans les logs `[backup]` (counts/paths/tailles seulement) ; consent flag — voir Q5.
+- **Concurrence (corrigé post-review)** : un modal ne suffit pas — `embed.rs` fait `std::thread::spawn` + `Runtime::new` + `VectorStore::open` **détachés**, hors état Dioxus. Introduire un **write-gate global** (`AtomicBool`/semaphore lu dans `embed.rs` avant chaque open/write LanceDB) ; drainer les embeds en vol et refuser tout nouveau spawn pendant un backup. Sans gate : la copie de `vectordb/` peut courir contre un writer (manifest Lance copié sans son fragment → dataset illisible) et un thread périmé peut écrire dans le store fraîchement swappé.
+- **iOS sandbox** : staging en `temp_dir` ; archive finale partagée par le share sheet ; import copié par le picker (`open_file_picker`).
+- **Compat** : `archive_version` + `schema_version` dans le manifest ; refus si archive plus récente que l'app.
+- **Observabilité** : logs `eprintln!("[backup] ...")` cohérents avec le style existant (`[db]`, `[vectordb]`).
+
+## 7. Drawbacks & Risks
+
+### Drawbacks (inhérents)
+- Replace total : aucun merge ; un import écrase tout (assumé par le PRD).
+- Archive non chiffrée : qui obtient le fichier lit les notes (clés exclues atténuent la fuite de secrets, pas du contenu).
+- Taille : WAV non compressés + vecteurs → archive potentiellement lourde.
+
+### Risques
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Swap sous handles vivants (`Arc<Database>` cloné 18×, `exit()` interdit iOS) | Élevée si in-process | **Critique** | Swap au **cold launch** avant tout handle ; jamais en plein vol |
+| Embed détaché écrit pendant la copie (`vectordb` illisible / store swappé pollué) | Moyenne | Élevé | write-gate global dans `embed.rs` ; drainer + refuser les spawns pendant un backup |
+| Clés survivent en pages free (DELETE sans VACUUM) | Élevée si oubli | Élevé | DELETE **puis `VACUUM`** sur la copie ; test byte-scan ; `SENSITIVE_KEYS` const unique |
+| Sidecars WAL périmés (`-wal`/`-shm`) rejoués sur la db importée | Moyenne | Élevé | checkpoint+close ; déplacer le trio `db`+`wal`+`shm` comme une unité |
+| Copie WAL incohérente (DB corrompue dans l'archive) | Moyenne si copie naïve | Élevé | `VACUUM INTO`, jamais de copie brute de `flowflow.db` |
+| Staging plaintext visible dans l'app Files (`Documents` exposé) | Moyenne | Moyen | stager dans `temp_dir`/`NSTemporaryDirectory` ; cleanup sur tout chemin de sortie |
+| `rename` ne remplace pas un dir non vide ; pas d'atomicité inter-stores | Élevée | Moyen | per-store `move->*.bak` puis `move staging` ; rollback all-or-nothing au boot |
+| Format on-disk LanceDB diffère entre versions | Faible | Moyen | `lance_format` + smoke `vector_search` + compare `counts` ; fallback re-embed futur |
+| Volume → export > 30 s / pression mémoire | Moyenne | Moyen | `io::copy` par entrée (jamais `fs::read` du WAV entier) ; progress UI ; Q1 |
+| Archive plus récente que l'app | Faible | Moyen | Refus si `schema_version > app` + « mettez à jour FlowFlow » |
+
+### Rollout / rollback
+- Feature livrée **après** v1.0 App Store (non urgente, qualité prod).
+- Rollback produit : la feature est additive (2 boutons) ; la retirer n'affecte pas les données.
+- Rollback runtime (import raté) : `*.bak` restauré automatiquement.
+
+### Gating metrics
+- 0 perte sur aller-retour (test round-trip).
+- 0 clé API dans l'archive (test d'inspection).
+- 0 corruption sur import échoué (test fault-injection).
+
+## 8. Open Questions
+
+| # | Question | Owner | Deadline |
+|---|---|---|---|
+| 1 | Volume cible exact pour la métrique < 30 s (500 notes / 100 audios ?) | Mirko | avant impl 6.5 |
+| 2 | Confirmation explicite « ceci écrase vos données » avant import — confirmé oui ? | Mirko | impl 5.3 |
+| 3 | App plus ancienne face à une archive plus récente : refus dur (proposé) vs message dédié | Mirko | impl 4.2 |
+| 4 | Swap au **cold launch** (retenu post-review) : UX du marqueur `pending_restore` + écran « relancez FlowFlow » — acceptable, ou viser le handle central in-process (v2) ? | Mirko | impl 4.5 |
+| 5 | Le **consent flag** AI est-il restauré, ou re-consentement forcé (proposé : forcer) ? | Mirko | impl 4.5 |
+| 6 | Chiffrement par mot de passe (autoriserait l'inclusion des clés) — backlog futur ? | Mirko | post-v1 |
+
+## 9. Recommendation & Rationale
+
+**Recommandation : Alt 2 — archive zip auto-portante, snapshot complet.** Confiance : **élevée**.
+
+### Goals → mécanismes
+
+| Goal | Mécanisme |
+|---|---|
+| Export complet en 1 archive | zip `manifest + db + vectordb + audio` |
+| Aller-retour fidèle (0 perte) | snapshot binaire exact + vecteurs inclus (pas de recalcul) |
+| Partage natif iOS | `UIActivityViewController` (`share.rs`) |
+| Replace total atomique | staging → validate → `rename` swap → reopen → rollback `*.bak` |
+| 0 clé API dans l'archive | `DELETE` des 3 clés sur la copie `VACUUM INTO` |
+
+### Pourquoi pas les alternatives
+- **Status quo** : ne marche que dev-signé + Xcode → exclut la cible App Store.
+- **Cloud (iCloud)** : non-goal explicite + complexité de sync 3 stores.
+- **Re-embed à l'import** : clés exclues ⇒ pas de clé au restore ⇒ re-embed bloqué ; + réseau + coût $ + lenteur ; casse le goal « restore offline immédiat ». Gardé comme **fallback** futur.
+- **Dump SQL** : complexité sans bénéfice pour un usage mono-app interne.
+
+### Revisit-if
+- L'archive devient trop lourde pour le partage → ajouter export sélectif / compression audio.
+- Le format LanceDB casse entre deux versions d'app → activer le fallback re-embed (Alt 3).
+- Besoin de partager une archive avec les clés → introduire le chiffrement (Q6).
+
+## 10. Implementation Plan
+
+Aligné sur `docs/prd/data-backup-export/tasks.md` (6 parents), enrichi du « how » technique.
+
+| ID | Titre | Fichiers | Deps | Effort | Acceptation |
+|---|---|---|---|---|---|
+| T1 | Format archive + `manifest.json` versionné | `backup.rs` | — | S | manifest sérialisé/désérialisé, `archive_version`+`schema_version` |
+| T2 | Snapshot SQLite sanitisé (`VACUUM INTO` + DELETE clés) | `db/mod.rs`, `settings_repo.rs`, `backup.rs` | T1 | M | copie consistante, 0 clé, DB live intacte |
+| T3 | Collecte vectordb/ + audio en staging | `vectordb.rs`, `audio.rs`, `backup.rs` | T2 | S | staging complet, écritures bloquées pendant la copie |
+| T4 | Empaquetage zip streaming + écriture partageable | `backup.rs` | T2,T3 | S | `*.ffbak.zip` valide, CRC par entrée |
+| T5 | Share sheet iOS (`UIActivityViewController`) | `platform/ios/share.rs`, `mod.rs` | T4 | M | feuille native s'ouvre, annulation propre |
+| T6 | Import : picker + unzip staging + validation pré-écriture | `picker.rs`, `backup.rs` | T1 | M | refus net si invalide, données intactes |
+| T6b | Write-gate global embed (drain + refus spawn pendant backup) | `embed.rs`, `backup.rs` | — | M | aucun embed concurrent pendant export/swap |
+| T7 | Swap **cold-launch** per-store + rollback `*.bak` | `backup.rs`, `db/mod.rs`, `vectordb.rs`, `main.rs` | T6, T6b | L | swap au boot ; trio WAL déplacé ; échec → rollback all-or-nothing ; clés non restaurées |
+| T8 | UI Settings : Export/Import + confirm + états | `ui/settings.rs` | T5,T7 | M | confirm replace, progress, succès/échec, invite clés |
+| T9 | Tests & validation | `tests/` | T7,T8 | M | round-trip, exclusion clés, échec, appareil vierge, perf |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    T1 --> T2 --> T3 --> T4 --> T5 --> T8
+    T1 --> T6 --> T7 --> T8
+    T2 --> T7
+    T6b --> T3
+    T6b --> T7
+    T7 --> T9
+    T8 --> T9
+```
+
+### Verification plan
+- **Unit** : sérialisation manifest ; sanitization (asserts 0 clé) ; validation de version (refus si archive > app).
+- **Integration** (`tests/`) : round-trip export→import sur base réaliste, asserts notes/audio/tags/conversations identiques + recherche sémantique fonctionnelle ; import d'archive corrompue → refus + DB intacte ; import sur store vierge → restitution complète.
+- **Perf** : mesurer durée d'export sur le volume cible (Q1), viser < 30 s.
+- **Fault injection** : tuer le process entre swap et reopen → vérifier rollback `*.bak` au lancement.
+
+## 11. Review Findings
+
+Revue adverse (subagent, code-grounded). Toutes les BLOCKERs ont été repliées dans les sections
+6-10 ; ce tableau trace findings → disposition.
+
+| # | Sév | Finding | Disposition |
+|---|---|---|---|
+| 1 | BLOCKER | `schema_version` hardcodé 6, mais `MIGRATIONS` va jusqu'à **V7** (droppe `notes.audio_file_path`/`duration_secs`) → off-by-one, compat mal calibrée | **Fixé** : §6 calcule `MAX(version)` dynamiquement, manifest = 7 |
+| 2 | BLOCKER | Preuve de portabilité audio périmée : cite `migrate_audio_paths_to_relative` (code v4 mort, colonne droppée). Vrai chemin = `note_audios.file_path` (V5) | **Fixé** : §2 re-grounde sur `note_audios.file_path` + test round-trip à ajouter |
+| 3 | BLOCKER | « modal bloque les writes » inapplicable : `embed.rs` `thread::spawn` + `Runtime::new` + propre `VectorStore::open` détachés | **Fixé** : §6 write-gate global + drain ; tâche T6b ajoutée |
+| 4 | BLOCKER | Drop des handles impossible : `Database` = `Arc` cloné 18× via `Signal` ; `VectorStore` pas dans le state | **Fixé** : §6 swap au cold launch, pas de drop in-process |
+| 5 | BLOCKER | « redémarrer l'app » non applicable iOS (`exit(0)` = rejet) → swap sous inodes renommés = corruption | **Fixé** : §6 Phase 2 swap au boot avant tout handle ; marqueur `pending_restore` |
+| 6 | BLOCKER | `DELETE` post-`VACUUM INTO` laisse les octets clés en pages free | **Fixé** : §6 DELETE **puis** `VACUUM` ; test byte-scan ; `SENSITIVE_KEYS` const |
+| 7 | MAJOR | Sidecars `-wal`/`-shm` non traités → rejoués sur la db importée | **Fixé** : §6 trio db+wal+shm déplacé comme unité après checkpoint+close |
+| 8 | MAJOR | `std::fs::rename` ne remplace pas un dir non vide ; pas d'atomicité inter-stores | **Fixé** : §6 per-store `move->*.bak` + rollback all-or-nothing |
+| 9 | MAJOR | Copie Lance « à froid » non prouvée tant qu'un handle/embed écrit ; valider la copie | **Fixé** : §6 gate+drain + validation `connect`+`open_table` sur la copie stagée |
+| 10 | MAJOR | CRC zip ≠ cohérence dataset Lance ni `counts` ; « 0 perte » non prouvé par CRC | **Fixé** : §6 ouvrir DB+vectordb stagés et asserter `counts == manifest` avant swap |
+| 11 | MAJOR | Risque mémoire si `fs::read` du WAV entier | **Fixé** : §6 `io::copy` par entrée |
+| 12 | MAJOR | Staging plaintext dans `Documents/` (visible app Files) ; pas de cleanup-on-error | **Fixé** : §6 staging en `temp_dir` + cleanup sur tout chemin de sortie |
+| 13 | MINOR | Logs `eprintln!` ne doivent jamais imprimer les valeurs `settings` | **Fixé** : §6 whitelist counts/paths/tailles |
+| 14 | MINOR | `lance_format` soft-warn peut succeed-but-misread (vecteurs faux silencieux) | **Fixé** : §6/§7 smoke `vector_search` + compare counts |
+| 15 | MINOR | Trou compat : faire confiance au `MAX(_migrations.version)` réel, pas qu'au manifest | **Fixé** : §6 anti-tamper |
+| 16 | NIT | `counts` lus sur la DB live (drift possible) | **Fixé** : §6/§10 counts calculés sur le snapshot sanitisé |
+| — | OK | `VACUUM INTO` supporté (rusqlite 0.34 → SQLite 3.49.1) | conservé |
+| — | OK | Pas de chemins absolus dans un dataset Lance → portable si copié quiescent | conservé |
+| — | OK | Pas de risque EXDEV (même fs `Documents/`) | conservé |
+
+**Résultat** : 6 BLOCKERs + 6 MAJORs corrigés dans le design avant acceptation. Aucune BLOCKER
+ouverte. La nature du swap a changé (cold-launch, pas in-process) — c'est le changement le plus
+structurant et il conditionne T7.

--- a/docs/rfcs/0002-audio-import-transcription/RFC.md
+++ b/docs/rfcs/0002-audio-import-transcription/RFC.md
@@ -1,0 +1,539 @@
+---
+rfc_id: "0002"
+slug: "audio-import-transcription"
+title: "Import audio dans une note pour transcription"
+status: Review
+author: "Mirko Bozzetto"
+created: "2026-05-30"
+updated: "2026-05-30"
+stepsCompleted: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+scope_path: "/Users/mirkobozzetto/code/flowflow"
+base_alternative: "Alt 3 — réutilisation + tâche scope racine + budget poll ≤5h + resume"
+impact_risk: low
+modules_touched: 10
+breaking_changes: false
+auto_mode: false
+skip_review: false
+source_prd: "docs/prd/audio-import-transcription/prd.md"
+---
+
+# 0002 — Import audio dans une note pour transcription
+
+## 1. Summary
+
+FlowFlow ne transcrit que ce qu'il capte **en direct au micro** : tout audio préexistant (dictaphone,
+Voice Memos, réunion enregistrée ailleurs) est inexploitable, et le timeout serveur de 2 min casse
+déjà les enregistrements longs. Le moteur de transcription Soniox et le picker de fichiers existent
+déjà ; le manque est du **câblage** + 3 verrous (durée, langue, survie en arrière-plan).
+
+**Recommandation (Alt 3)** : réutiliser `SonioxClient::transcribe` (format-agnostic) via une 2e action
+menu « Importer un audio » → picker audio (UTType explicites, copie durable dans `Documents/`) → un
+`TranscriptionManager` qui lance la transcription sur un **thread détaché + `Runtime`** (pattern
+`embed.rs`, **pas** `spawn` Dioxus qui meurt au re-render), indexée par `note_id`, poll jusqu'à **5 h**
+(borne Soniox), **resume** au boot via une migration **V8** `pending_transcriptions`. Langue
+**auto-détectée** partout (retrait de `language_hints_strict`), `delete_file` Soniox après coup
+(hygiène quota), texte **appended au contenu uniquement** puis auto-embeddé comme une note normale.
+
+**Impact** : ~10 fichiers, 1 nouveau module, 1 migration additive réversible, **0 breaking change
+public** (impact GitNexus LOW : 1 caller de `transcribe`). Le live hérite de 3 améliorations partagées
+(durée, langue, quota). Risque principal — la survie de la tâche en arrière-plan — résolu par le
+pattern thread détaché déjà éprouvé in-repo. La revue adverse a corrigé 2 BLOCKERs + 3 MAJORs avant
+toute ligne de code. **Status : Review** (3 questions mineures ouvertes : Q4 notif, Q7 dédup, Q8 soft
+hint FR live).
+
+## 2. Context / Codebase
+
+### Affected modules
+- `src/ui/notes/menu.rs` — `NoteMenu` (point d'entrée, **une seule** action import aujourd'hui) + `import_file_content(lang)` (patron picker → contenu) + struct `ImportedFile`. Cible pour ajouter l'action "Importer un audio".
+- `src/ui/notes/detail.rs` — `use_effect` (l.306-327) qui consomme `RecordingState::Transcribed(text)` → append au contenu de la note + `set_audio_transcription`. **Point de jonction** texte → note.
+- `src/ui/recording/controls.rs` — `spawn_transcription(path, state, gen, gen_signal, cleanup)` (l.21) + prop `transcribe_only` + garde de génération anti-écriture périmée. Machinerie de transcription async réutilisable.
+- `src/services/transcription/client.rs` — `SonioxClient::transcribe(path)` **format-agnostic** (upload multipart bytes + filename). Constantes **partagées** : `MAX_POLLS=60`, `POLL_INTERVAL=2s` → plafond **2 min**. `language_hints:["fr"]` + `language_hints_strict:true` **codés en dur**. `from_env()` vérifie `ai_consent` + `soniox_api_key`.
+- `src/platform/ios/picker.rs` — `open_file_picker(extensions)` : UIDocumentPicker, `asCopy:true` (copie dans la sandbox), `setAllowsMultipleSelection(false)`, UTType résolu par extension de fichier.
+- `src/services/audio.rs` — enum `RecordingState { Idle, Recording, Paused, Transcribing, Transcribed(String), Error(String) }` ; `output_dir()`, `resolve_audio_path()`.
+- `src/services/embed.rs` — auto-embed du contenu (indexation recherche). Déclenché à la sauvegarde de note.
+- `src/services/i18n/locales/{en,fr}.ftl` — libellés (action menu, états, erreurs).
+
+### Key symbols
+- `import_file_content()` — `src/ui/notes/menu.rs:15` — **patron à cloner** : picker → garde taille → lecture → `ImportedFile{filename, content}`. Timeout dynamique `60 + (Mo)*30` s, `spawn_blocking` (lecture document, pas réseau).
+- `spawn_transcription()` — `src/ui/recording/controls.rs:21` — `spawn` async : `transcribe()` puis (si `cleanup`) `remove_file`, écrit `RecordingState::Transcribed/Error` **sous garde** `gen_signal()==generation`.
+- `RecordingState::Transcribed` (consumer) — `src/ui/notes/detail.rs:306` — append `text` au `content`, persiste via `set_audio_transcription`, repasse `Idle`.
+- `SonioxClient::transcribe` — `src/services/transcription/client.rs:186` — `upload_file → create_transcription → poll_transcript → clean_hesitations`.
+- `open_file_picker` — `src/platform/ios/picker.rs:77`.
+- `transcribe_only` — `src/ui/chat_input.rs:80` — **déjà** utilisé (saisie vocale du chat) : transcrit + jette le fichier, n'ajoute pas de `note_audio`. Comportement « transcription seule » **existant**.
+
+### Prior art
+- **RFC 0001 data-backup-export** (status Review, `docs/rfcs/0001-data-backup-export/`) — même couches `services/` + `platform/ios/` ; introduit le concept de **write-gate** sur les threads détachés d'`embed.rs` (pertinent si un long traitement coexiste avec l'embedding).
+- **PRD `lan-serve` + `agentic-tools`** (`docs/prd/`) — recherche actée : **iOS n'autorise pas l'exécution longue en arrière-plan** une fois l'app suspendue (écran verrouillé / app quittée). Contrainte directe pour la story 4 « arrière-plan ».
+- Mémoire `project_multi_audio` — `note_audios` (V5/V6), `transcribe_only` pour le scope chat.
+- Pas d'ADR. `docs/stories/2026-05-29-...` (iris API) non lié.
+- Tests pertinents : `tests/` (migrations/CRUD) ; aucun test transcription/picker actuel.
+
+### Execution flows touched
+- **Enregistrement live** : `RecordingControls` stop → `add_audio` → `spawn_transcription(cleanup=false)` → `Transcribed(text)` → effect `detail.rs:306` append + `set_audio_transcription` → `Idle`.
+- **Saisie vocale chat** : `RecordingControls{transcribe_only:true}` → `spawn_transcription(cleanup=true)` → `Transcribed` → jette le fichier. **Précédent direct** de « transcription seule ».
+- **Import document** : `NoteMenu` `import_requested` → `import_file_content` → `open_file_picker(["txt","md","csv","pdf","docx"])` → lecture → `ImportedFile` → attachment + embed.
+- **NOUVEAU import audio (cible)** : `NoteMenu` → `open_file_picker(audio exts)` → `path` → `spawn_transcription(cleanup=true)` → `Transcribed(text)` → contenu de la note.
+- **Point chaud archi** : `spawn()` est lié au **scope du composant** `NoteDetail`/`RecordingControls`. La garde `generation` empêche les écritures périmées, mais si le composant se **démonte** (navigation hors note), la future spawnée est **droppée** → transcription perdue. Bloquant pour la story 4 « continuer ailleurs dans l'app ».
+
+## 3. Problem & Motivation
+
+### Current state
+FlowFlow ne transcrit que ce qu'il **capte en direct au micro** : `AudioRecorder` (cpal/hound) →
+WAV → `spawn_transcription` → `SonioxClient::transcribe`. Aucun chemin programmatique ne fait
+entrer un **fichier audio préexistant**. Le picker (`open_file_picker`, `picker.rs:77`) existe mais
+n'est câblé que pour les **documents** texte (`["txt","md","csv","pdf","docx"]`, `menu.rs:24`).
+
+### Pain (qui, fréquence, coût)
+- **Mirko + futurs utilisateurs App Store** : tout enregistrement fait ailleurs (dictaphone
+  physique, Voice Memos iPhone, capture de réunion par une autre app) est **inexploitable** dans
+  FlowFlow. Le seul contournement = **rejouer le fichier devant le micro** : temps réel (1 h
+  d'audio = 1 h d'attente), qualité dégradée (bruit, double-encodage micro), et inutilisable pour
+  une réunion longue.
+- Fréquence : à chaque fois que la matière première existe déjà hors de l'app — cas courant pour
+  qui possède un dictaphone ou enregistre des réunions.
+- Coût produit : la promesse (parole → notes exploitables) est cassée pour tout l'audio non capté
+  par l'app elle-même.
+
+### Why now (trigger)
+v1.0 en revue App Store : l'app passe d'un usage perso (où l'on peut bricoler) à de vrais
+utilisateurs. L'import est une attente de base d'une app de prise de notes vocales, et le moteur
+de transcription est **déjà en place** — le manque est purement un défaut de câblage + 3 verrous
+(timeout 2 min, FR strict, scope de tâche). Demande explicite de Mirko.
+
+### Signals
+- 0 fonction d'import audio aujourd'hui (mesurable : `open_file_picker` n'est appelé qu'avec des
+  extensions document).
+- Plafond `MAX_POLLS=60` × `POLL_INTERVAL=2s` = **120 s** : un fichier dont la transcription serveur
+  dépasse 2 min échoue déjà (`"Transcription timeout (2 min)"`, `client.rs:159`). Donc même le live
+  long casse aujourd'hui.
+
+## 4. Goals / Non-Goals
+
+### Goals (mesurables)
+1. Importer **1 fichier audio** (m4a/AAC, mp3, wav, caf) depuis le menu d'une note et obtenir son
+   texte ajouté au contenu de la note (réutilise le point de jonction `detail.rs:306`).
+2. Transcrire un fichier **≥ 2 h** sans échec dû à une borne de durée trop courte (relève le plafond
+   `MAX_POLLS`, **partagé** live + import).
+3. Transcription en **arrière-plan** : l'app reste navigable et le résultat **survit à la navigation**
+   hors de la note (corrige le drop de `spawn()` au démontage) **et à un redémarrage de l'app**
+   (resume via `transcription_id` persisté, migration V8 — **in-scope**, décidé step-05).
+4. **Auto-détection** de langue pour **import ET live** (lève `language_hints_strict` partout — décidé
+   step-05 ; le live n'est plus forcé en FR strict).
+5. **0** note corrompue / texte partiel sur échec ; message clair + retry ; garde `ai_consent` +
+   `soniox_api_key` (réutilise `from_env()`).
+6. **Hygiène quota Soniox** : supprimer le fichier uploadé après transcription (`DELETE /v1/files/{id}`)
+   — corrige une fuite latente qui touche **aussi le live** (décidé step-05).
+
+### Non-Goals (hors scope explicite)
+- **PAS** d'import multi-fichiers (un seul à la fois ; `setAllowsMultipleSelection(false)` conservé).
+- **PAS** de conservation du fichier audio importé (transcription seule : pas de `note_audio` jouable,
+  on réutilise `cleanup=true`).
+- **PAS** d'extraction audio depuis une vidéo (mov/mp4).
+- **PAS** de sélecteur de langue manuel (auto-détection uniquement).
+- **PAS** de transcription offline (réseau requis, inchangé).
+- **PAS** de diarisation / horodatage par locuteur.
+- **PAS** de refonte de l'enregistrement live : il **hérite** de 3 changements partagés (plafond de
+  durée relevé, langue auto, suppression fichier Soniox), mais l'UX/flow live reste inchangé.
+
+## 5. Alternatives Considered
+
+Le moteur de transcription existe déjà (`SonioxClient::transcribe`, format-agnostic) et
+« transcrire + jeter » existe déjà (`transcribe_only`/`cleanup`). Les alternatives portent donc
+sur **comment câbler l'import** et surtout **comment tenir 3 verrous** : durée (timeout), survie
+en arrière-plan (scope de tâche), langue. Faits externes qui contraignent l'espace :
+
+- **Soniox** : durée max **300 min (5 h), fixe, non augmentable** ; **webhook OU polling**.
+  Source: [Soniox async](https://soniox.com/docs/stt/async/async-transcription),
+  [Limits & quotas](https://soniox.com/docs/stt/async/limits-and-quotas).
+- **Webhook** exige une **URL publique** → FlowFlow n'a **pas de backend** (lan-serve = LAN only) →
+  **webhook non viable**, le polling reste obligatoire.
+- **iOS** : une app **suspendue** (verrouillée / quittée) tue une requête `URLSession` standard en vol ;
+  `beginBackgroundTask` ne donne que ~secondes, pas des heures.
+  Source: [Apple — Extending background execution](https://developer.apple.com/documentation/uikit/extending-your-app-s-background-execution-time),
+  [Forum DTS Quinn](https://developer.apple.com/forums/thread/743847).
+- **Nuance clé** : « continuer ailleurs **dans l'app** » (story 4, app au **premier plan**) ≠ « app
+  **verrouillée/suspendue** ». Le premier est un problème de **scope de composant Dioxus** (soluble) ;
+  le second est une **limite iOS dure** (hors scope, mitigeable par resume).
+
+### Alt 0 — Status quo (rejouer au micro)
+**Summary:** ne rien construire ; l'utilisateur rejoue son fichier devant le micro.
+**Cost of inaction:** la story principale reste impossible ; réunion longue = inutilisable ;
+qualité dégradée (double-encodage, bruit). De plus le **timeout 2 min casse déjà le live long**.
+**Pros:** 0 effort, 0 régression.
+**Cons:** ne résout rien ; douleur §3 persiste ; bug timeout live non corrigé.
+**Cost:** nul. **Reversibility:** n/a. **Verdict provisoire:** rejeté.
+
+### Alt 1 — Câblage minimal, tâche au scope composant
+**Summary:** ajouter une action menu → `open_file_picker(audio exts)` → `spawn_transcription(path,
+cleanup=true)` **tel quel**, dans le scope de `NoteDetail`. Timeout relevé à un **plafond fixe** (ex.
+`MAX_POLLS=180` ≈ 6 min de poll). Langue : drapeau simple sur `transcribe()`.
+**How it solves:** couvre import + transcription seule en réutilisant la machinerie existante.
+**Pros:**
+- Effort minimal (S) ; 1 fonction clonée de `import_file_content` + 1 branche.
+- 0 nouveau module ; réutilise garde `generation`.
+- Corrige partiellement le timeout (relève le plafond).
+**Cons:**
+- **Story 4 échoue** : `spawn()` lié au scope `NoteDetail` → naviguer hors note = future **droppée** =
+  transcription perdue.
+- Plafond **fixe** = soit trop court (réunion 3 h), soit poll inutile long sur petit fichier.
+- Pas de resume : app backgroundée pendant un long poll = perte.
+**Cost:** S. **Reversibility:** élevée. **Verdict provisoire:** insuffisant pour la story 4.
+
+### Alt 2 — Pipeline import dédié + webhook + background URLSession
+**Summary:** nouveau module d'import autonome ; transcription via **webhook** Soniox ; upload via
+**background `URLSession`** pour survivre à la suspension.
+**How it solves:** viserait le « vrai » arrière-plan (app quittée, résultat livré plus tard).
+**Pros:**
+- Robuste à la suspension iOS en théorie (upload out-of-process, relance app).
+- Webhook = 0 polling.
+**Cons:**
+- **Webhook impossible sans backend public** : FlowFlow n'en a pas (rédhibitoire).
+- Background `URLSession` via objc2/Rust = **lourd**, peu de prior art, rate-limiter iOS, fiabilité
+  « best effort » (DTS Quinn : *« you can't ensure anything »*).
+- Réécrit ce qui marche déjà ; double le chemin de transcription (dette).
+**Cost:** XL. **Reversibility:** faible (couplage infra). **Verdict provisoire:** rejeté (pas de backend + sur-ingénierie).
+
+### Alt 3 — Réutilisation + tâche hissée hors composant + poll budget dérivé + resume (RECOMMANDÉ)
+**Summary:** réutiliser `transcribe()`/`cleanup` mais **sortir la tâche async du scope `NoteDetail`**
+vers un **gestionnaire au scope racine** (registre `note_id → JobState` dans l'état Dioxus global).
+Le **budget de poll est dérivé** (couvre jusqu'à 5 h, borne Soniox) au lieu d'un plafond fixe aveugle.
+Langue **auto-détectée** pour l'import via un **paramètre** sur `transcribe()` (live inchangé).
+**Resume-on-relaunch** : persister `transcription_id` + `note_id` → au retour app, reprendre le poll
+(le résultat est gardé côté Soniox).
+**How it solves:** Goal 1 (réutilise jonction `detail.rs:306`), Goal 2 (budget jusqu'à 5 h, fix
+partagé live), Goal 3 (tâche hors composant → survit à la navigation **in-app** ; resume couvre le
+cas suspendu **du mieux possible** sans backend), Goal 4 (param langue), Goal 5 (réutilise `from_env`
++ garde `generation`).
+**Pros:**
+- Survit à la navigation in-app (story 4 réelle) sans dépendre d'API iOS exotiques.
+- Pas de plafond aveugle : budget dérivé de la borne produit (≤ 5 h) ; rejette > 5 h **tôt** (limite Soniox).
+- Resume gratuit grâce au `transcription_id` déjà retourné par l'API.
+- Réutilise le moteur ; aucune dette de double-pipeline ; pas de backend requis.
+- Param langue isole l'import du live (pas de régression FR strict du live).
+**Cons:**
+- Introduit un **gestionnaire de tâches global** (état + cycle de vie) = complexité moyenne, à écrire
+  proprement (idempotence, dedup par `note_id`).
+- Le cas **app verrouillée pendant des minutes** reste « best effort » (poll suspendu → repris au
+  retour) ; pas de livraison pendant suspension (limite iOS assumée, cf. §8).
+- Persistance d'un job en cours (table légère ou settings) = petit ajout.
+**Cost:** M (L si resume persistant complet). **Reversibility:** élevée (interne, format modifiable).
+**Réfs:** [Soniox webhooks](https://soniox.com/docs/stt/async/webhooks) (écarté faute de backend),
+[Apple background limits](https://developer.apple.com/documentation/uikit/extending-your-app-s-background-execution-time).
+
+### Sous-décisions transverses (rendues visibles)
+
+| Décision | Option A | Option B | Option C |
+|---|---|---|---|
+| **Timeout/durée** | Plafond fixe `MAX_POLLS` relevé (aveugle) | **Budget dérivé ≤ 5 h + rejet > 5 h tôt** (borne Soniox) | Poll infini jusqu'à `error` serveur (risque de boucle) |
+| **Scope tâche (story 4)** | Scope composant (Alt 1, perd au démontage) | **Tâche au scope racine + registre `note_id`** | Background `URLSession`/BGTask iOS (lourd, Alt 2) |
+| **Langue** | FR strict gardé (régression import non-FR) | **Param `language: Option<…>` sur `transcribe()`** (live inchangé, import = auto) | Sélecteur UI manuel (hors scope PRD) |
+| **Resume app suspendue** | Aucun (perte au background) | **Persister `transcription_id`+`note_id`, reprendre au retour** | BGProcessingTask iOS 26 (objc2 incertain, iOS 26 only) |
+
+Les options **en gras** = pistes que le design (step 04) retiendra ; les autres documentent le tradeoff
+pour éviter de relitiger plus tard.
+
+## 6. Proposed Design
+
+**Base : Alt 3** (réutilisation du moteur + tâche hissée hors composant + budget poll ≤ 5 h + resume).
+**Impact GitNexus** : `transcribe` upstream = **LOW** (1 seul caller : `spawn_transcription`) ;
+`spawn_transcription` upstream = **LOW** (0 caller tracé). Le changement de signature `transcribe()`
+ne casse qu'**un** appelant interne. `breaking_changes: false` côté public (API interne Rust seulement).
+
+### Architecture overview
+
+Le picker fournit un fichier ; au pick il est **copié dans `Documents/`** (chemin durable, survit à la
+purge iOS du `tmp/`). Un **`TranscriptionManager`** lance la transcription sur un **thread détaché +
+`tokio::runtime::Runtime`** — pattern **déjà éprouvé dans `embed.rs`** (le `spawn` Dioxus, lui, est
+annulé au drop / re-render de `App` : voir §11 BLOCKER #1, donc **pas** utilisé). Le thread écrit
+l'avancement dans `transcription_jobs: Signal<HashMap<note_id, Job>>` (état global, indépendant du
+cycle de vie de `NoteDetail`) et persiste `transcription_id` (resume). `NoteDetail`, monté pour ce
+`note_id`, **observe** son Job et **n'append que le contenu** (jonction `detail.rs:306` **scindée** :
+`set_audio_transcription` reste live-only). L'import **ne touche jamais** `recording_state` (signal
+global, réservé au live — §11 MAJOR #3).
+
+```mermaid
+flowchart TD
+    MENU[NoteMenu<br/>action 'Importer un audio'] -->|audio_import_requested| IMP[import_audio_file<br/>menu.rs]
+    IMP -->|open_file_picker UTType audio explicites| PICK[picker.rs<br/>UIDocumentPicker]
+    PICK -->|copie vers Documents/ durable| MGR[TranscriptionManager<br/>jobs: note_id → Job]
+    MGR -->|std::thread::spawn + Runtime<br/>pattern embed.rs| ENG[SonioxClient<br/>start → poll ≤5h]
+    ENG -->|file_id, transcription_id| SX[(Soniox async API)]
+    ENG -. delete_file .-> SX
+    MGR -->|persist / resume au boot| DB[(pending_transcriptions V8)]
+    MGR -->|Job::Done text| OBS[NoteDetail observe<br/>append content only]
+    OBS -->|save effect existant| EMB[auto-embed<br/>embed.rs]
+    ENG -. à l'état terminal .-> RMDOC[remove copie Documents/]
+```
+
+### Modules / files affected
+
+| Path | Change | Why |
+|------|--------|-----|
+| `src/ui/notes/menu.rs` | modified | 2e action menu "Importer un audio" + `import_audio_file(lang) -> Result<Option<PathBuf>,String>` (clone de `import_file_content`, exts audio, garde format/taille) |
+| `src/ui/transcription_manager.rs` | **new** | `TranscriptionManager` : registre `note_id → Job` ; lance via `std::thread::spawn` + `Runtime` (**pattern `embed.rs`**, pas `spawn` Dioxus) ; start/poll ≤ 5 h/cleanup/delete_file ; resume au boot |
+| `src/ui/mod.rs` (`App`) | modified | instancier le manager (contexte) ; déclencher le **resume au boot** depuis `pending_transcriptions` |
+| `src/ui/state.rs` (`AppState`) | modified | `transcription_jobs: Signal<HashMap<String, Job>>` + `audio_import_requested: Signal<bool>` (indépendant de `recording_state`) |
+| `src/ui/notes/detail.rs` | modified | **scinder** le bloc `detail.rs:306` : append-content (partagé) vs `set_audio_transcription` (live-only) ; observer le Job du `note_id` → **append content uniquement** ; états en cours/échec/retry |
+| `src/platform/ios/picker.rs` | modified | UTType **explicites** (`public.mpeg-4-audio`, `public.mp3`, `com.microsoft.waveform-audio`, `com.apple.coreaudio-format`, `public.audio`) ; loguer un type non résolu ; **copie du fichier choisi vers `Documents/`** (durable, pas `tmp/`) |
+| `src/services/transcription/client.rs` | modified | scinder `transcribe` en `start_transcription(path, language) -> (transcription_id, file_id)` + `poll_transcript(id) -> text` ; param `language: Option<&str>` (None=auto partout) ; relever `MAX_POLLS` ; `delete_file(file_id)` après transcription |
+| `src/ui/recording/controls.rs` | modified | `spawn_transcription` passe `language = None` (live → auto comme l'import) ; appel adapté à la nouvelle signature |
+| `src/ui/chat_input.rs` | none/trivial | passe par `RecordingControls` ; `transcribe_only` inchangé |
+| `src/db/schema.rs` + `src/db/mod.rs` | modified | migration **V8** : table `pending_transcriptions` (resume) — **in-scope** |
+| `src/services/i18n/locales/{en,fr}.ftl` | modified | libellés action + états + erreurs |
+
+### Data model
+
+**En mémoire (cœur, couvre la story 4 in-app) :**
+
+```rust
+enum JobStatus { Uploading, Polling { elapsed_s: u32 }, Done(String), Failed(String) }
+struct Job { note_id: String, status: JobStatus, transcription_id: Option<String>, lang: Option<String> }
+// AppState: transcription_jobs: Signal<HashMap<String /*note_id*/, Job>>
+```
+
+La tâche vit au scope `App` → un changement de vue (NotesList ↔ Chat ↔ Settings) **ne la démonte pas**.
+Dedup par `note_id` (un import audio en cours par note).
+
+**Persistance resume (in-scope, couvre app tuée/suspendue au mieux) — migration V8 additive :**
+
+```mermaid
+erDiagram
+    pending_transcriptions {
+        TEXT note_id PK
+        TEXT transcription_id
+        TEXT lang "nullable (auto si null)"
+        TEXT created_at
+    }
+```
+
+- Écrite **après** `start_transcription` (dès qu'on a un `transcription_id`), supprimée à `Done`/`Failed`.
+- Au boot (`App`), pour chaque ligne → le manager **reprend le poll** (résultat conservé côté Soniox).
+- Réversible (drop table). Aucun impact sur les schémas existants.
+
+### API contracts (interne Rust)
+
+- `SonioxClient::start_transcription(&self, path: &Path, language: Option<&str>) -> Result<String, String>`
+  — upload + create ; retourne `transcription_id`. **Nouveau** (extrait de `transcribe`).
+- `SonioxClient::poll_transcript(&self, id: &str) -> Result<String, String>` — déjà existant, rendu `pub`.
+- `SonioxClient::transcribe(path, language)` — **conservé** comme façade `start` + `poll` pour les
+  appelants simples (live/chat). **Signature change** : ajout `language: Option<&str>`.
+  - `None` → **pas** de `language_hints` → **auto-détection Soniox**. C'est le défaut **partout**
+    (import ET live, décidé step-05) : on **retire** `language_hints_strict:true` codé en dur.
+  - `Some(lang)` → conservé pour un futur forçage explicite ; aucun caller ne l'utilise en v1.
+  - **Breaking interne** : seul `spawn_transcription` à mettre à jour (impact LOW confirmé).
+- `SonioxClient::delete_file(&self, file_id: &str) -> Result<(), String>` — **nouveau**.
+  `DELETE /v1/files/{file_id}` appelé après transcription (succès **ou** échec post-upload) pour ne
+  pas saturer le quota (10 Go / 1000). Best-effort : un échec de delete logue mais ne casse pas le flux.
+- **Budget poll** : le thread **détaché** (pattern `embed.rs`) poll la **durée pleine ≤ 5 h**
+  (`MAX_POLLS` relevé en conséquence à `POLL_INTERVAL=2s`), sans cap intermédiaire artificiel.
+  Borne **produit** = 5 h (limite Soniox 300 min, erreur serveur au-delà). Le **resume V8** couvre le
+  cas app **tuée** (thread perdu) — filet de sécurité, pas la couverture primaire (corrige §11 #10).
+- **Progress** : Soniox **ne fournit pas de %** → état **indéterminé** (spinner + `elapsed_s`).
+  Répond à la question ouverte PRD : progression = « en cours + temps écoulé », pas un pourcentage.
+
+### Flows / sequences
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant ND as NoteDetail
+    participant MG as TranscriptionManager (App scope)
+    participant SX as Soniox
+    U->>ND: menu → Importer un audio
+    ND->>ND: import_audio_file (picker audio, garde format/taille)
+    ND->>MG: enqueue(note_id, path, lang=None)
+    Note over MG: vérifie consent + clé (from_env) sinon Failed tôt
+    MG->>SX: start_transcription(path) → transcription_id
+    MG->>MG: persist pending_transcriptions(note_id, transcription_id)
+    MG->>MG: cleanup: remove sandbox copy
+    loop poll ≤ 30 min (resume au-delà)
+        MG->>SX: GET /transcriptions/{id}
+        SX-->>MG: status (queued/processing/completed/error)
+    end
+    SX-->>MG: completed → transcript
+    MG->>MG: Job::Done(text) ; delete pending row
+    alt NoteDetail monté sur ce note_id
+        MG-->>ND: observe → append au content (detail.rs:306) + save
+        ND->>ND: save effect → auto-embed (embed.rs)
+    else NoteDetail ailleurs
+        Note over MG: texte gardé dans Job + persisté en note ; visible au retour
+    end
+```
+
+Chemin d'échec : `start`/`poll` `Err` → `Job::Failed(raison)` ; aucun texte inséré ; UI montre la
+raison + bouton **Relancer** (réutilise le `path` si encore présent, sinon ré-ouvre le picker).
+
+### Cross-cutting
+
+- **Consent / clé** : `SonioxClient::from_env()` réutilisé (vérifie `ai_consent` + `soniox_api_key`).
+  Vérif **avant** upload → `Failed("Consentement IA requis")` / `"clé non configurée"` sans état partiel.
+- **Auto-embed** : aucun nouveau code. Le texte appended déclenche le `save effect` existant de
+  `NoteDetail` → pipeline `embed.rs` actuel. L'import devient cherchable comme une note normale.
+- **Garde anti-périmé** : indexation **par `note_id`** dans le manager (remplace le compteur
+  `generation` lié au composant). L'import **n'utilise pas** `recording_state` (signal global live-only)
+  → pas de race live/import (§11 MAJOR #3).
+- **Jonction scindée** : pour l'import, **append au content uniquement** ; jamais
+  `set_audio_transcription` (qui viserait à tort un `note_audios` antérieur — §11 MAJOR #2).
+- **Nettoyage** : la copie **`Documents/`** (durable) est gardée **jusqu'à l'état terminal**
+  (`Done`/abandon) → **retry** sans re-picker (la copie `tmp/` du picker serait purgée par iOS, §11
+  BLOCKER #5). Supprimée à `Done`. **Fichier Soniox** : `delete_file(file_id)` après transcription
+  (best-effort) — corrige la fuite quota qui touche **aussi le live**.
+- **i18n** : nouvelles clés `note-menu-import-audio`, `audio-transcribing`, `audio-import-failed`,
+  `audio-import-retry`, `audio-format-unsupported` — parité FR/EN.
+- **Observabilité** : logs `[import]`/`[soniox]` cohérents (durée, statut, jamais le contenu).
+- **iOS arrière-plan** : couvre la navigation **in-app** (scope racine). App **verrouillée/suspendue**
+  = poll gelé par iOS → repris au retour via `pending_transcriptions` (best effort assumé, §8).
+
+## 7. Drawbacks & Risks
+
+### Drawbacks (inhérents)
+- **App suspendue ≠ livraison directe** : verrouillage/quit prolongé → poll gelé par iOS ; le résultat
+  n'arrive qu'au retour (resume). Pas contournable sans backend (webhook) — assumé.
+- **Transcription seule** : pas de relecture audio de l'import (décision PRD).
+- **Coût Soniox proportionnel à la durée** : une réunion de plusieurs heures = coût API réel à chaque
+  import. L'utilisateur déclenche explicitement (pas de surprise silencieuse), mais le coût existe.
+- **Progression indéterminée** : Soniox ne renvoie pas de % → spinner + temps écoulé seulement.
+
+### Risques
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| UTType `m4a`/`caf` mal résolu par `typeWithFilenameExtension` → fichier non sélectionnable dans le picker | Moyenne | Élevé | Tester sur device ; fallback sur identifiants UTType explicites (`public.mpeg-4-audio`, `com.apple.coreaudio-format`, `public.mp3`, `com.microsoft.waveform-audio`) plutôt que par extension |
+| Tâche au scope racine mal nettoyée → jobs zombies / fuite mémoire | Moyenne | Moyen | Dedup par `note_id` ; suppression du Job à `Done`/`Failed` ; un seul job audio par note |
+| Copie picker `tmp/` purgée par iOS avant retry / fin de transcription longue | Moyenne | Élevé | Copier vers `Documents/` au pick (durable) ; garder jusqu'à l'état terminal (§11 BLOCKER #5) |
+| Manager via `spawn` Dioxus → annulé au re-render de `App` | Élevée si mal fait | Critique | Thread détaché + `Runtime` (pattern `embed.rs`), pas `spawn` Dioxus (§11 BLOCKER #1) |
+| Quota Soniox : fichiers uploadés jamais supprimés (10 Go / 1000) — **latent aussi pour le live** | Moyenne | Moyen | `DELETE /v1/files/{file_id}` après `start_transcription` (réussi ou en échec post-upload) |
+| Fichier > 300 min (5 h) → rejet serveur | Faible | Faible | Surfacer l'erreur Soniox en message clair ; documenter la borne 5 h |
+| Texte très long (heures) inséré d'un coup → textarea lente / gros embedding | Faible | Moyen | Le chunker `ai.rs` gère déjà l'embedding ; surveiller la perf UI sur très gros contenu |
+| Changement de signature `transcribe()` casse la compilation (caller manqué) | Faible | Faible | Impact GitNexus = LOW (1 caller `spawn_transcription`) ; `cargo build` le révèle |
+| Resume au boot lance plusieurs polls simultanés | Faible | Faible | Async non bloquant ; cap concurrent ; rares (peu de jobs en vol) |
+| Embed concurrent pendant import (cf. write-gate RFC 0001) | Faible | Faible | Pas de copie `vectordb/` ici ; juste un append + embed normal, pas de conflit |
+| Migration V8 (`pending_transcriptions`) | Faible | Faible | Additive, réversible (drop) ; testée comme les migrations existantes |
+
+### Rollout / rollback
+- Feature **additive** (action menu + manager) : la retirer n'affecte pas les données ni le live.
+- Le **fix timeout partagé** bénéficie au live immédiatement ; non-régression à tester (story live).
+- La **persistance resume (V8)** peut être livrée en **phase 2** : le cœur in-memory couvre déjà la
+  story 4 in-app ; la table ne fait qu'améliorer le cas app-tuée.
+- Rollback runtime : un import en échec laisse la note **intacte** (aucun texte partiel).
+
+### Gating metrics
+- Round-trip : chaque format ciblé (m4a/AAC, mp3, wav, caf) importé → texte dans la note + cherchable.
+- 0 note corrompue / texte partiel sur échec (test fault-injection : clé absente, format refusé, timeout).
+- Fichier ≥ 2 h transcrit jusqu'au bout (foreground) sans échec de durée.
+- Navigation in-app pendant transcription → résultat présent au retour.
+
+## 8. Open Questions
+
+**Tranchées en step-05 (verrouillées) :**
+
+| # | Question | Décision |
+|---|----------|----------|
+| 1 | Borne haute de durée | **5 h** (limite Soniox 300 min) ; > 5 h → erreur serveur surfacée |
+| 2 | Auto-détection langue aussi pour le live | **Oui, partout** — `language_hints_strict` retiré (live + import en auto) |
+| 3 | Persistance resume (V8) | **In-scope cette version** (pas phase 2) |
+| 5 | `DELETE /v1/files/{id}` Soniox | **In-scope ce RFC** (corrige le quota, bénéficie au live) |
+| 6 | Retry sans re-picker | **Oui** — garder la copie sandbox jusqu'à l'état terminal |
+
+**Encore ouvertes :**
+
+| # | Question | Owner | Deadline |
+|---|----------|-------|----------|
+| 4 | Notification de fin quand l'utilisateur est **ailleurs** : badge global discret, ou rien (visible au retour) ? | Mirko | impl UI états |
+| 7 | Dédup : refuser un 2e import audio tant qu'un est en cours sur la **même note** (défaut proposé), ou autoriser une file ? | Mirko | impl manager |
+| 8 | Langue auto pour le live : risque de mal transcrire un FR bruité pris pour une autre langue — acceptable, ou garder un *soft hint* `["fr"]` non strict comme biais ? | Mirko | impl param langue |
+
+## 9. Recommendation & Rationale
+
+**Recommandation : Alt 3** — réutilisation du moteur + tâche au scope racine + budget poll ≤ 5 h +
+resume persistant. Confiance : **élevée**. Le moteur existe, l'impact est LOW (1 caller), et le seul
+vrai défi (survie en arrière-plan) est résolu sans dépendre d'API iOS exotiques ni d'un backend.
+
+### Goals → mécanismes
+
+| Goal | Mécanisme |
+|---|---|
+| 1 — Import 1 fichier → texte dans la note | `import_audio_file` (clone de `import_file_content`) → manager → jonction `detail.rs:306` |
+| 2 — Fichier ≥ 2 h (jusqu'à 5 h) | `MAX_POLLS` relevé (fenêtre foreground) + borne Soniox 300 min ; au-delà = resume |
+| 3 — Arrière-plan (in-app + relaunch) | `TranscriptionManager` au scope `App` (survit au démontage) + `pending_transcriptions` V8 (resume au boot) |
+| 4 — Langue auto | `transcribe(path, None)` → pas de `language_hints` → auto-détection, partout |
+| 5 — Échec sans dégât | `from_env()` garde clé/consent ; `Job::Failed` n'insère aucun texte ; retry (copie gardée) |
+| 6 — Hygiène quota | `delete_file(file_id)` après transcription (best-effort) |
+
+### Pourquoi pas les alternatives
+- **Alt 0 (status quo)** : ne résout rien + laisse le bug timeout 2 min sur le live.
+- **Alt 1 (scope composant)** : compile et démo OK, mais **perd la transcription à la navigation**
+  (story 4) — faux ami.
+- **Alt 2 (webhook + background URLSession)** : webhook **impossible sans backend public** ; background
+  URLSession via objc2 = XL + fiabilité « best effort » ; double-pipeline = dette.
+
+### Revisit-if
+- Le format on-disk / l'API Soniox change la borne 5 h → réviser le budget poll.
+- iOS 26 `BGContinuedProcessingTask` obtient des bindings objc2 stables → upgrader le resume vers une
+  vraie exécution arrière-plan avec UI système (remplace le poll foreground).
+- Apparition d'un backend FlowFlow (lan-serve élargi) → réintroduire le webhook (supprime le polling).
+- Coût Soniox sur longs fichiers devient un problème → ajouter un plafond de durée configurable (Q1).
+
+## 10. Implementation Plan
+
+Aligné sur `docs/prd/audio-import-transcription/tasks.md`, enrichi du « how » + décisions step-05.
+
+| ID | Titre | Fichiers | Deps | Effort | Acceptation |
+|---|---|---|---|---|---|
+| T1 | Moteur : scinder `start`/`poll`, param `language` (None=auto partout), relever `MAX_POLLS`, `delete_file` | `services/transcription/client.rs` | — | S | live+chat compilent ; auto-détection ; fichier Soniox supprimé ; budget ≤ 5 h |
+| T2 | Picker audio + `import_audio_file` + garde format/taille + 2e action menu | `platform/ios/picker.rs`, `ui/notes/menu.rs`, `ui/state.rs` | — | M | picker liste m4a/AAC/mp3/wav/caf ; format refusé → message, note intacte ; UTType validé device |
+| T3 | `TranscriptionManager` au scope `App` : registre `note_id→Job`, enqueue, spawn start/poll hors composant, cleanup terminal, dedup | `ui/transcription_manager.rs` (new), `ui/mod.rs`, `ui/state.rs` | T1 | L | navigation in-app ne perd pas la transcription ; 1 job/note ; copie gardée jusqu'à terminal |
+| T4 | Migration **V8** `pending_transcriptions` + resume au boot | `db/schema.rs`, `db/mod.rs`, `ui/transcription_manager.rs` | T3 | M | app tuée → relance → poll repris → texte arrive ; ligne purgée à Done ; rollback drop |
+| T5 | `NoteDetail` : observer Job → append (`detail.rs:306`) + save + auto-embed ; états en cours/échec/**retry** | `ui/notes/detail.rs` | T3 | M | texte ajouté + cherchable (chat/recherche) ; retry sans re-picker ; 0 texte partiel sur échec |
+| T6 | Adapter `spawn_transcription`/live (`language=None`) + non-régression live/chat | `ui/recording/controls.rs`, `ui/chat_input.rs` | T1 | S | live + saisie vocale chat marchent en auto-détection ; timeout long bénéficie au live |
+| T7 | i18n libellés FR/EN (action, états, erreurs, retry) | `services/i18n/locales/{en,fr}.ftl` | T2, T5 | S | parité FR/EN sur toutes les clés ajoutées |
+| T8 | Tests & validation | `tests/` | T1–T7 | M | voir Verification plan |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    T1 --> T3 --> T4
+    T1 --> T6
+    T3 --> T5
+    T2 --> T5
+    T2 --> T7
+    T5 --> T7
+    T1 --> T8
+    T4 --> T8
+    T5 --> T8
+    T6 --> T8
+    T7 --> T8
+```
+
+### Verification plan
+- **Unit** : `language=None` n'émet pas `language_hints`/`_strict` ; split `start`/`poll` round-trip ;
+  `delete_file` appelé en succès et en échec post-upload ; budget poll = 5 h.
+- **Integration** (`tests/`) : import + transcription d'un échantillon par format (m4a/AAC, mp3, wav, caf) ;
+  fichier ≥ 2 h jusqu'au bout ; navigation in-app pendant transcription → résultat au retour ;
+  app tuée → relance → resume via `pending_transcriptions` ; fault-injection (clé absente, format
+  refusé, timeout) → note intacte + retry ; contenu importé retrouvé via recherche/chat.
+- **Perf** : très gros transcript (heures) inséré → textarea + embedding tiennent ; pas de blocage UI.
+- **Non-régression** : enregistrement live + saisie vocale chat OK après le changement de signature.
+
+## 11. Review Findings
+
+Revue adverse (subagent, code-grounded). 2 BLOCKERs + 2 MAJORs corrigés dans le design avant
+acceptation ; ce tableau trace findings → disposition.
+
+| # | Sév | Finding | Disposition |
+|---|-----|---------|-------------|
+| 1 | BLOCKER | « spawn hissé au scope `App` survit à la navigation » **FAUX** : `spawn` Dioxus est annulé au drop ; `App` re-render à chaque switch de vue (`mod.rs:152+`). Seul pattern de survie prouvé in-repo = `std::thread::spawn` + `tokio::runtime::Runtime` détaché (`embed.rs:43,108,194,238`). | **Fixé** : §6 — `TranscriptionManager` utilise le pattern détaché `embed.rs` (thread + Runtime), écrit dans `Signal<HashMap>` + SQLite. Abandon du framing « spawn au scope App ». |
+| 5 | BLOCKER | Retry cassé : `asCopy:true` (`picker.rs:92`) dépose en `tmp/`, **purgé par iOS** (~60 s+) → une transcription multi-heures survit au fichier. La décision Q6 (garder la copie) repose sur un fichier volatile. | **Fixé** : §6 — au pick, **copier immédiatement dans `Documents/`** (`documents_dir`), persister ce chemin durable pour le retry, supprimer à l'état terminal. |
+| 2 | MAJOR | `detail.rs:306` n'est pas réutilisable tel quel : il fait aussi `set_audio_transcription` sur le **dernier** `note_audios` (l.316-322) → un import (sans `add_audio`) écrirait son texte comme transcription d'un **enregistrement précédent**. | **Fixé** : §6 — scinder la jonction : chemin « append au content » (partagé) vs « set_audio_transcription » (live-only). Import = append content **uniquement**, ne touche jamais `note_audios`. |
+| 3 | MAJOR | `recording_state` est un **signal global unique** (`audio.rs:7`), pas par note → un import qui finit pendant un live `Transcribing` (ou l'inverse) écrase les transitions `Transcribed`/`Idle`. Coexistence non prouvée. | **Fixé** : §6 — l'import ne touche **pas** `recording_state` ; piloté seulement par `transcription_jobs[note_id]` + observateur dédié `NoteDetail`. L'enum `RecordingState` n'est pas réutilisé pour l'import. |
+| 10 | MAJOR | Budget poll incohérent : §6 disait « 900 × 2 s = 30 min » puis « borne 5 h » (= 9000 polls). Le cap 30 min + resume cassé = perte silencieuse au-delà de 30 min. | **Fixé** : §6 — le thread détaché (#1) poll la **durée pleine ≤ 5 h** ; le resume V8 devient filet de sécurité (app tuée), pas la couverture primaire. Cap 30 min supprimé. |
+| 4 | MINOR | Auto-détect Soniox CONFIRMÉ (omettre `language_hints` = auto). Mais retirer le hint FR du live dégrade le FR bruité. | Voir Open Q8 : garder un **soft hint `["fr"]` non strict** sur le live (le bug réel = `language_hints_strict:true`, pas le hint). À trancher (Q8). |
+| 6 | MINOR | UTType par extension : `caf` peut résoudre `nil`, `filter_map` (`picker.rs:83`) **drop en silence** → picker sans type, sans erreur. | **Fixé** : §6 — identifiants UTType explicites (`public.mpeg-4-audio`, `public.mp3`, `com.microsoft.waveform-audio`, `com.apple.coreaudio-format`, `public.audio`) ; loguer un type non résolu. |
+| 8 | MINOR | `from_env()` rouvre une `Database::open()` par appel ; resume au boot × N polls = churn (pas de lock dur, WAL). | **Fixé** : §6 — `Arc<Database>` partagé + cap concurrent explicite sur les resume. |
+| 9 | MINOR | `delete_file` threading CONFIRMÉ propre (`file_id` déjà nommé `client.rs:187`, 1 caller). | Conservé tel quel (best-effort). |
+| 7 | NIT | Version migration CONFIRMÉE : MAX = V7 (`schema.rs:8`), next = V8. | Conservé. |
+
+**Résultat** : 2 BLOCKERs + 3 MAJORs corrigés dans le design. Le changement structurant = le manager
+passe du « spawn Dioxus hissé » au **thread détaché + Runtime** (pattern `embed.rs` déjà éprouvé) ;
+ça résout du même coup le budget poll (#10) et fiabilise le resume.

--- a/docs/rfcs/0002-audio-import-transcription/RFC.md
+++ b/docs/rfcs/0002-audio-import-transcription/RFC.md
@@ -272,7 +272,8 @@ flowchart TD
 | `src/ui/notes/menu.rs` | modified | 2e action menu "Importer un audio" + `import_audio_file(lang) -> Result<Option<PathBuf>,String>` (clone de `import_file_content`, exts audio, garde format/taille) |
 | `src/ui/transcription_manager.rs` | **new** | `TranscriptionManager` : registre `note_id → Job` ; lance via `std::thread::spawn` + `Runtime` (**pattern `embed.rs`**, pas `spawn` Dioxus) ; start/poll ≤ 5 h/cleanup/delete_file ; resume au boot |
 | `src/ui/mod.rs` (`App`) | modified | instancier le manager (contexte) ; déclencher le **resume au boot** depuis `pending_transcriptions` |
-| `src/ui/state.rs` (`AppState`) | modified | `transcription_jobs: Signal<HashMap<String, Job>>` + `audio_import_requested: Signal<bool>` (indépendant de `recording_state`) |
+| `src/ui/state.rs` (`AppState`) | modified | `transcription_jobs: Signal<HashMap<String, VecDeque<Job>>>` (file FIFO/note, Q7) + `transcription_done_badge: Signal<usize>` (Q4) + `audio_import_requested: Signal<bool>` ; indépendant de `recording_state` |
+| `src/ui/sidebar/` ou `top_bar.rs` | modified | afficher le **badge** des jobs terminés non vus (Q4), remis à 0 à l'ouverture de la note |
 | `src/ui/notes/detail.rs` | modified | **scinder** le bloc `detail.rs:306` : append-content (partagé) vs `set_audio_transcription` (live-only) ; observer le Job du `note_id` → **append content uniquement** ; états en cours/échec/retry |
 | `src/platform/ios/picker.rs` | modified | UTType **explicites** (`public.mpeg-4-audio`, `public.mp3`, `com.microsoft.waveform-audio`, `com.apple.coreaudio-format`, `public.audio`) ; loguer un type non résolu ; **copie du fichier choisi vers `Documents/`** (durable, pas `tmp/`) |
 | `src/services/transcription/client.rs` | modified | scinder `transcribe` en `start_transcription(path, language) -> (transcription_id, file_id)` + `poll_transcript(id) -> text` ; param `language: Option<&str>` (None=auto partout) ; relever `MAX_POLLS` ; `delete_file(file_id)` après transcription |
@@ -286,13 +287,19 @@ flowchart TD
 **En mémoire (cœur, couvre la story 4 in-app) :**
 
 ```rust
-enum JobStatus { Uploading, Polling { elapsed_s: u32 }, Done(String), Failed(String) }
-struct Job { note_id: String, status: JobStatus, transcription_id: Option<String>, lang: Option<String> }
-// AppState: transcription_jobs: Signal<HashMap<String /*note_id*/, Job>>
+enum JobStatus { Queued, Uploading, Polling { elapsed_s: u32 }, Done(String), Failed(String) }
+struct Job { id: String, note_id: String, file_path: PathBuf, status: JobStatus,
+             transcription_id: Option<String>, soniox_file_id: Option<String> }
+// AppState:
+//   transcription_jobs: Signal<HashMap<String /*note_id*/, VecDeque<Job>>>  // file FIFO par note (Q7)
+//   transcription_done_badge: Signal<usize>  // compteur de jobs terminés non vus (Q4)
 ```
 
-La tâche vit au scope `App` → un changement de vue (NotesList ↔ Chat ↔ Settings) **ne la démonte pas**.
-Dedup par `note_id` (un import audio en cours par note).
+La transcription tourne sur un **thread détaché** (pattern `embed.rs`), pas un `spawn` Dioxus → elle
+survit aux changements de vue **et** au re-render de `App` (§11 BLOCKER #1). **File d'attente par
+`note_id`** (Q7) : les imports sur une même note s'enchaînent en **série**, texte appended dans l'ordre
+FIFO ; un seul job actif par note à la fois, les suivants en `Queued`. **Badge** (Q4) : à chaque
+`Done` hors-note-courante, incrémenter `transcription_done_badge` (remis à 0 à l'ouverture de la note).
 
 **Persistance resume (in-scope, couvre app tuée/suspendue au mieux) — migration V8 additive :**
 
@@ -433,15 +440,12 @@ raison + bouton **Relancer** (réutilise le `path` si encore présent, sinon ré
 | 2 | Auto-détection langue aussi pour le live | **Oui, partout** — `language_hints_strict` retiré (live + import en auto) |
 | 3 | Persistance resume (V8) | **In-scope cette version** (pas phase 2) |
 | 5 | `DELETE /v1/files/{id}` Soniox | **In-scope ce RFC** (corrige le quota, bénéficie au live) |
-| 6 | Retry sans re-picker | **Oui** — garder la copie sandbox jusqu'à l'état terminal |
+| 6 | Retry sans re-picker | **Oui** — garder la copie `Documents/` jusqu'à l'état terminal |
+| 4 | Notification de fin quand l'utilisateur est ailleurs | **Badge global discret** sur un job terminé |
+| 7 | 2e import sur la même note | **File d'attente** (série par `note_id`, FIFO, texte appended dans l'ordre) |
+| 8 | Langue live après retrait du strict | **Full auto, aucun hint** (live + import identiques) — `transcribe(None)` |
 
-**Encore ouvertes :**
-
-| # | Question | Owner | Deadline |
-|---|----------|-------|----------|
-| 4 | Notification de fin quand l'utilisateur est **ailleurs** : badge global discret, ou rien (visible au retour) ? | Mirko | impl UI états |
-| 7 | Dédup : refuser un 2e import audio tant qu'un est en cours sur la **même note** (défaut proposé), ou autoriser une file ? | Mirko | impl manager |
-| 8 | Langue auto pour le live : risque de mal transcrire un FR bruité pris pour une autre langue — acceptable, ou garder un *soft hint* `["fr"]` non strict comme biais ? | Mirko | impl param langue |
+**Encore ouvertes :** aucune. Toutes tranchées.
 
 ## 9. Recommendation & Rationale
 
@@ -482,9 +486,9 @@ Aligné sur `docs/prd/audio-import-transcription/tasks.md`, enrichi du « how »
 |---|---|---|---|---|---|
 | T1 | Moteur : scinder `start`/`poll`, param `language` (None=auto partout), relever `MAX_POLLS`, `delete_file` | `services/transcription/client.rs` | — | S | live+chat compilent ; auto-détection ; fichier Soniox supprimé ; budget ≤ 5 h |
 | T2 | Picker audio + `import_audio_file` + garde format/taille + 2e action menu | `platform/ios/picker.rs`, `ui/notes/menu.rs`, `ui/state.rs` | — | M | picker liste m4a/AAC/mp3/wav/caf ; format refusé → message, note intacte ; UTType validé device |
-| T3 | `TranscriptionManager` au scope `App` : registre `note_id→Job`, enqueue, spawn start/poll hors composant, cleanup terminal, dedup | `ui/transcription_manager.rs` (new), `ui/mod.rs`, `ui/state.rs` | T1 | L | navigation in-app ne perd pas la transcription ; 1 job/note ; copie gardée jusqu'à terminal |
+| T3 | `TranscriptionManager` : file FIFO `note_id→VecDeque<Job>`, thread détaché + `Runtime` (pattern `embed.rs`), start/poll hors composant, cleanup terminal, badge à `Done` | `ui/transcription_manager.rs` (new), `ui/mod.rs`, `ui/state.rs` | T1 | L | navigation/re-render ne perd pas la transcription ; file série par note (Q7) ; badge incrémenté (Q4) ; copie `Documents/` gardée jusqu'à terminal |
 | T4 | Migration **V8** `pending_transcriptions` + resume au boot | `db/schema.rs`, `db/mod.rs`, `ui/transcription_manager.rs` | T3 | M | app tuée → relance → poll repris → texte arrive ; ligne purgée à Done ; rollback drop |
-| T5 | `NoteDetail` : observer Job → append (`detail.rs:306`) + save + auto-embed ; états en cours/échec/**retry** | `ui/notes/detail.rs` | T3 | M | texte ajouté + cherchable (chat/recherche) ; retry sans re-picker ; 0 texte partiel sur échec |
+| T5 | `NoteDetail` : observer la file du `note_id` → **append content only** + save + auto-embed ; états en cours/échec/**retry** ; badge remis à 0 à l'ouverture | `ui/notes/detail.rs`, `ui/top_bar.rs` | T3 | M | texte ajouté + cherchable ; retry sans re-picker ; 0 texte partiel ; jamais `set_audio_transcription` (§11 #2) |
 | T6 | Adapter `spawn_transcription`/live (`language=None`) + non-régression live/chat | `ui/recording/controls.rs`, `ui/chat_input.rs` | T1 | S | live + saisie vocale chat marchent en auto-détection ; timeout long bénéficie au live |
 | T7 | i18n libellés FR/EN (action, états, erreurs, retry) | `services/i18n/locales/{en,fr}.ftl` | T2, T5 | S | parité FR/EN sur toutes les clés ajoutées |
 | T8 | Tests & validation | `tests/` | T1–T7 | M | voir Verification plan |

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,6 +2,7 @@ pub mod attachment_repo;
 pub mod conversation_repo;
 pub mod folder_repo;
 pub mod note_repo;
+pub mod pending_transcription_repo;
 mod schema;
 pub mod settings_repo;
 

--- a/src/db/pending_transcription_repo.rs
+++ b/src/db/pending_transcription_repo.rs
@@ -1,0 +1,62 @@
+use crate::db::Database;
+
+pub struct PendingTranscription {
+    pub note_id: String,
+    pub transcription_id: String,
+    pub soniox_file_id: Option<String>,
+}
+
+impl Database {
+    pub fn add_pending_transcription(
+        &self,
+        note_id: &str,
+        transcription_id: &str,
+        soniox_file_id: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO pending_transcriptions
+                (note_id, transcription_id, soniox_file_id)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(note_id) DO UPDATE SET
+                transcription_id = excluded.transcription_id,
+                soniox_file_id = excluded.soniox_file_id",
+            rusqlite::params![note_id, transcription_id, soniox_file_id],
+        )
+        .map_err(|e| format!("Add pending transcription: {e}"))?;
+        Ok(())
+    }
+
+    pub fn list_pending_transcriptions(&self) -> Vec<PendingTranscription> {
+        let conn = self.conn();
+        let mut stmt = match conn.prepare(
+            "SELECT note_id, transcription_id, soniox_file_id
+             FROM pending_transcriptions",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([], |row| {
+            Ok(PendingTranscription {
+                note_id: row.get(0)?,
+                transcription_id: row.get(1)?,
+                soniox_file_id: row.get(2)?,
+            })
+        })
+        .map(|rows| rows.flatten().collect())
+        .unwrap_or_default()
+    }
+
+    pub fn delete_pending_transcription(
+        &self,
+        note_id: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn();
+        conn.execute(
+            "DELETE FROM pending_transcriptions WHERE note_id = ?1",
+            [note_id],
+        )
+        .map_err(|e| format!("Delete pending transcription: {e}"))?;
+        Ok(())
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -6,6 +6,7 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     (5, V5_SCHEMA),
     (6, V6_SCHEMA),
     (7, V7_SCHEMA),
+    (8, V8_SCHEMA),
 ];
 
 const V1_SCHEMA: &str = "
@@ -128,4 +129,14 @@ ALTER TABLE note_audios ADD COLUMN transcription TEXT;
 const V7_SCHEMA: &str = "
 ALTER TABLE notes DROP COLUMN audio_file_path;
 ALTER TABLE notes DROP COLUMN duration_secs;
+";
+
+const V8_SCHEMA: &str = "
+CREATE TABLE IF NOT EXISTS pending_transcriptions (
+    note_id TEXT PRIMARY KEY,
+    transcription_id TEXT NOT NULL,
+    soniox_file_id TEXT,
+    created_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
 ";

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -84,7 +84,7 @@ pub fn observe_interruptions() {
 
 pub use parsers::read_file_as_text;
 pub use pdf::extract as read_pdf_text;
-pub use picker::open_file_picker;
+pub use picker::{open_audio_picker, open_file_picker};
 pub use player::{is_playing, play_audio, stop_audio};
 
 pub fn hide_keyboard_accessory() {

--- a/src/platform/ios/picker.rs
+++ b/src/platform/ios/picker.rs
@@ -73,17 +73,21 @@ impl PickerDelegate {
     }
 }
 
+const AUDIO_UT_IDENTIFIERS: &[&str] = &[
+    "public.mpeg-4-audio",
+    "public.mp3",
+    "com.microsoft.waveform-audio",
+    "com.apple.coreaudio-format",
+    "public.audio",
+];
+
 #[allow(deprecated)]
-pub async fn open_file_picker(extensions: &[&str]) -> Option<Vec<PathBuf>> {
+async fn present_picker(
+    ut_types: Vec<Retained<UTType>>,
+) -> Option<Vec<PathBuf>> {
     let mtm = MainThreadMarker::new().unwrap();
     let app = UIApplication::sharedApplication(mtm);
 
-    let ut_types: Vec<Retained<UTType>> = extensions
-        .iter()
-        .filter_map(|ext| {
-            UTType::typeWithFilenameExtension(&NSString::from_str(ext))
-        })
-        .collect();
     let ut_refs: Vec<&UTType> = ut_types.iter().map(|t| t.deref()).collect();
     let types_array = NSArray::from_slice(&ut_refs);
 
@@ -112,4 +116,62 @@ pub async fn open_file_picker(extensions: &[&str]) -> Option<Vec<PathBuf>> {
     } else {
         Some(delegate.ivars().picked_paths.take())
     }
+}
+
+pub async fn open_file_picker(extensions: &[&str]) -> Option<Vec<PathBuf>> {
+    let ut_types: Vec<Retained<UTType>> = extensions
+        .iter()
+        .filter_map(|ext| {
+            let t = UTType::typeWithFilenameExtension(&NSString::from_str(ext));
+            if t.is_none() {
+                eprintln!("[picker] UTType unresolved for ext: {ext}");
+            }
+            t
+        })
+        .collect();
+    present_picker(ut_types).await
+}
+
+pub async fn open_audio_picker() -> Option<Vec<PathBuf>> {
+    let ut_types: Vec<Retained<UTType>> = AUDIO_UT_IDENTIFIERS
+        .iter()
+        .filter_map(|id| {
+            let t = UTType::typeWithIdentifier(&NSString::from_str(id));
+            if t.is_none() {
+                eprintln!("[picker] UTType unresolved for id: {id}");
+            }
+            t
+        })
+        .collect();
+    let picked = present_picker(ut_types).await?;
+    Some(copy_to_import_dir(picked))
+}
+
+fn copy_to_import_dir(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let dir = super::documents_dir().join("flowflow_import");
+    std::fs::create_dir_all(&dir).ok();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    paths
+        .into_iter()
+        .map(|p| {
+            let name = p
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "audio".to_string());
+            let dest = dir.join(format!("{ts}_{name}"));
+            match std::fs::copy(&p, &dest) {
+                Ok(_) => {
+                    let _ = std::fs::remove_file(&p);
+                    dest
+                }
+                Err(e) => {
+                    eprintln!("[picker] durable copy failed: {e}");
+                    p
+                }
+            }
+        })
+        .collect()
 }

--- a/src/services/i18n/locales/en.ftl
+++ b/src/services/i18n/locales/en.ftl
@@ -87,7 +87,12 @@ note-recording-error = Error: { $message }
 note-card-untitled = Untitled
 
 note-menu-import = Import a document
+note-menu-import-audio = Import an audio
 note-menu-delete = Delete note
+
+audio-transcribing = Transcribing
+audio-import-failed = Audio import failed
+audio-import-retry = Retry
 
 note-extract-interrupted = Extraction interrupted
 note-file-too-large = File too large ({ $size } MB, max 20 MB)

--- a/src/services/i18n/locales/fr.ftl
+++ b/src/services/i18n/locales/fr.ftl
@@ -87,7 +87,12 @@ note-recording-error = Erreur : { $message }
 note-card-untitled = Sans titre
 
 note-menu-import = Importer un document
+note-menu-import-audio = Importer un audio
 note-menu-delete = Supprimer la note
+
+audio-transcribing = Transcription en cours
+audio-import-failed = Échec de l'import audio
+audio-import-retry = Réessayer
 
 note-extract-interrupted = Extraction interrompue
 note-file-too-large = Fichier trop volumineux ({ $size } MB, max 20 MB)

--- a/src/services/llm.rs
+++ b/src/services/llm.rs
@@ -180,7 +180,8 @@ impl LlmClient {
     ) -> Result<String, LlmError> {
         use crate::services::constants::TITLE_SYSTEM_PROMPT;
         let lang_name = if lang == "fr" { "French" } else { "English" };
-        let system = format!("{TITLE_SYSTEM_PROMPT}\n\nRespond ONLY in {lang_name}.");
+        let system =
+            format!("{TITLE_SYSTEM_PROMPT}\n\nRespond ONLY in {lang_name}.");
         let preview: String = content.chars().take(1500).collect();
         let response = self.chat(&system, &preview).await?;
         let title = response.trim().trim_matches('"').trim().to_string();

--- a/src/services/transcription/client.rs
+++ b/src/services/transcription/client.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 const BASE_URL: &str = "https://api.soniox.com";
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
-const MAX_POLLS: u32 = 60;
+const MAX_POLLS: u32 = 9000;
 
 #[derive(Deserialize)]
 struct FileResponse {
@@ -34,10 +34,12 @@ pub struct SonioxClient {
 
 impl SonioxClient {
     pub fn new(api_key: String) -> Self {
-        Self {
-            client: reqwest::Client::new(),
-            api_key,
-        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(600))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { client, api_key }
     }
 
     pub fn from_env() -> Result<Self, String> {
@@ -69,38 +71,64 @@ impl SonioxClient {
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
-        let part = reqwest::multipart::Part::bytes(bytes).file_name(filename);
-        let form = reqwest::multipart::Form::new().part("file", part);
-        let resp = self
-            .client
-            .post(format!("{BASE_URL}/v1/files"))
-            .bearer_auth(&self.api_key)
-            .multipart(form)
-            .send()
-            .await
-            .map_err(|e| format!("Upload error: {e}"))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("Upload failed ({status}): {body}"));
+        eprintln!("[soniox] upload size = {} bytes", bytes.len());
+        let mut last_err = String::new();
+        for attempt in 1..=3u32 {
+            let part = reqwest::multipart::Part::bytes(bytes.clone())
+                .file_name(filename.clone());
+            let form = reqwest::multipart::Form::new().part("file", part);
+            match self
+                .client
+                .post(format!("{BASE_URL}/v1/files"))
+                .bearer_auth(&self.api_key)
+                .multipart(form)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        let file_resp: FileResponse = resp
+                            .json()
+                            .await
+                            .map_err(|e| format!("Parse error: {e}"))?;
+                        eprintln!(
+                            "[soniox] uploaded, file_id={}",
+                            file_resp.id
+                        );
+                        return Ok(file_resp.id);
+                    }
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(format!("Upload failed ({status}): {body}"));
+                }
+                Err(e) => {
+                    last_err = format!("Upload error: {e}");
+                    eprintln!(
+                        "[soniox] upload attempt {attempt}/3 failed: {e}"
+                    );
+                }
+            }
+            if attempt < 3 {
+                tokio::time::sleep(Duration::from_secs(2 * attempt as u64))
+                    .await;
+            }
         }
-        let file_resp: FileResponse =
-            resp.json().await.map_err(|e| format!("Parse error: {e}"))?;
-        eprintln!("[soniox] uploaded, file_id={}", file_resp.id);
-        Ok(file_resp.id)
+        Err(last_err)
     }
 
     async fn create_transcription(
         &self,
         file_id: &str,
+        language: Option<&str>,
     ) -> Result<String, String> {
         eprintln!("[soniox] creating transcription for {file_id}");
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "model": "stt-async-v4",
             "file_id": file_id,
-            "language_hints": ["fr"],
-            "language_hints_strict": true
         });
+        if let Some(lang) = language {
+            body["language_hints"] = serde_json::json!([lang]);
+        }
         let resp = self
             .client
             .post(format!("{BASE_URL}/v1/transcriptions"))
@@ -122,41 +150,48 @@ impl SonioxClient {
         Ok(tr.id)
     }
 
-    async fn poll_transcript(
+    pub async fn check_status(
+        &self,
+        transcription_id: &str,
+    ) -> Result<Option<String>, String> {
+        let resp = self
+            .client
+            .get(format!("{BASE_URL}/v1/transcriptions/{transcription_id}"))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(|e| format!("Poll error: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Poll failed ({status}): {body}"));
+        }
+        let status: TranscriptionStatus =
+            resp.json().await.map_err(|e| format!("Parse error: {e}"))?;
+        eprintln!("[soniox] status={}", status.status);
+        match status.status.as_str() {
+            "completed" => {
+                Ok(Some(self.fetch_transcript(transcription_id).await?))
+            }
+            "error" | "failed" => {
+                Err("Transcription failed on server".to_string())
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub async fn poll_transcript(
         &self,
         transcription_id: &str,
     ) -> Result<String, String> {
         eprintln!("[soniox] polling for {transcription_id}");
-        for attempt in 1..=MAX_POLLS {
-            let resp = self
-                .client
-                .get(format!("{BASE_URL}/v1/transcriptions/{transcription_id}"))
-                .bearer_auth(&self.api_key)
-                .send()
-                .await
-                .map_err(|e| format!("Poll error: {e}"))?;
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                return Err(format!("Poll failed ({status}): {body}"));
+        for _ in 1..=MAX_POLLS {
+            if let Some(text) = self.check_status(transcription_id).await? {
+                return Ok(text);
             }
-            let status: TranscriptionStatus =
-                resp.json().await.map_err(|e| format!("Parse error: {e}"))?;
-            eprintln!(
-                "[soniox] poll {attempt}/{MAX_POLLS}: status={}",
-                status.status
-            );
-            match status.status.as_str() {
-                "completed" => {
-                    return self.fetch_transcript(transcription_id).await
-                }
-                "error" | "failed" => {
-                    return Err("Transcription failed on server".to_string());
-                }
-                _ => tokio::time::sleep(POLL_INTERVAL).await,
-            }
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
-        Err("Transcription timeout (2 min)".to_string())
+        Err("Transcription timeout (5 h)".to_string())
     }
 
     async fn fetch_transcript(
@@ -183,10 +218,41 @@ impl SonioxClient {
         Ok(tr.text)
     }
 
-    pub async fn transcribe(&self, path: &Path) -> Result<String, String> {
+    pub async fn start_transcription(
+        &self,
+        path: &Path,
+        language: Option<&str>,
+    ) -> Result<(String, String), String> {
         let file_id = self.upload_file(path).await?;
-        let tr_id = self.create_transcription(&file_id).await?;
-        let raw = self.poll_transcript(&tr_id).await?;
-        Ok(clean_hesitations(&raw))
+        let tr_id = self.create_transcription(&file_id, language).await?;
+        Ok((tr_id, file_id))
+    }
+
+    pub async fn delete_file(&self, file_id: &str) -> Result<(), String> {
+        eprintln!("[soniox] deleting file {file_id}");
+        let resp = self
+            .client
+            .delete(format!("{BASE_URL}/v1/files/{file_id}"))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(|e| format!("Delete file error: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Delete file failed ({status}): {body}"));
+        }
+        Ok(())
+    }
+
+    pub async fn transcribe(
+        &self,
+        path: &Path,
+        language: Option<&str>,
+    ) -> Result<String, String> {
+        let (tr_id, file_id) = self.start_transcription(path, language).await?;
+        let raw = self.poll_transcript(&tr_id).await;
+        let _ = self.delete_file(&file_id).await;
+        Ok(clean_hesitations(&raw?))
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,6 +13,7 @@ mod settings;
 mod sidebar;
 mod state;
 mod top_bar;
+pub mod transcription_manager;
 
 pub use state::{AppState, SidebarTab, View};
 
@@ -20,7 +21,11 @@ use crate::db::Database;
 use crate::services::audio::{AudioRecorder, RecordingState};
 use crate::services::embed::migrate_chunk_dates;
 use dioxus::prelude::*;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use transcription_manager::{
+    append_transcription_to_note, JobStatus, TranscriptionManager,
+};
 
 use attachment_modal::AttachmentModal;
 use chat::ChatView;
@@ -45,6 +50,12 @@ pub fn App() -> Element {
         use_context_provider(|| {
             Signal::new(Arc::new(Mutex::new(AudioRecorder::new())))
         });
+
+    let manager = use_context_provider(|| {
+        let m = TranscriptionManager::new(_db());
+        m.resume_pending();
+        m
+    });
 
     if option_env!("FLOWFLOW_RESET_CONSENT") == Some("1") {
         let _ = _db().set_setting("ai_consent", "");
@@ -77,6 +88,46 @@ pub fn App() -> Element {
         detail_folder_id: Signal::new(None),
         ai_consent: Signal::new(consent_value),
         current_lang: Signal::new(initial_lang),
+        transcription_jobs: Signal::new(HashMap::new()),
+        transcription_done_badge: Signal::new(0),
+        audio_import_requested: Signal::new(false),
+    });
+
+    use_future(move || {
+        let manager = manager.clone();
+        let db = _db();
+        let mut app = app;
+        async move {
+            loop {
+                let snap = manager.snapshot();
+                if *app.transcription_jobs.peek() != snap {
+                    app.transcription_jobs.set(snap.clone());
+                }
+                let current = (app.current_note_id)();
+                let viewing_note =
+                    matches!((app.view)(), View::NoteDetail { .. });
+                for (note_id, q) in snap.iter() {
+                    let is_done = matches!(
+                        q.front().map(|j| &j.status),
+                        Some(JobStatus::Done(_))
+                    );
+                    let is_open = viewing_note
+                        && current.as_deref() == Some(note_id.as_str());
+                    if is_done && !is_open {
+                        if let Some(text) = manager.take_done(note_id) {
+                            append_transcription_to_note(&db, note_id, &text);
+                            app.notes_version.set((app.notes_version)() + 1);
+                            app.transcription_done_badge
+                                .set((app.transcription_done_badge)() + 1);
+                        }
+                    }
+                }
+                futures_timer::Delay::new(std::time::Duration::from_millis(
+                    700,
+                ))
+                .await;
+            }
+        }
     });
 
     use_effect(|| {

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -8,11 +8,15 @@ use crate::services::embed::{embed_attachment, embed_note};
 use crate::services::i18n::{t, t_args};
 use crate::services::transcription::SonioxClient;
 use crate::ui::folder_picker::FolderPicker;
+use crate::ui::icons::IconX;
 use crate::ui::notes::attachments::AttachmentSection;
 use crate::ui::notes::audio_player::AudioPlayer;
-use crate::ui::notes::menu::{import_file_content, NoteMenu};
+use crate::ui::notes::menu::{
+    import_audio_file, import_file_content, NoteMenu,
+};
 use crate::ui::notes::tags::TagsSection;
 use crate::ui::recording::RecordingBar;
+use crate::ui::transcription_manager::{JobStatus, TranscriptionManager};
 use crate::ui::{AppState, View};
 use chrono::{Datelike, NaiveDateTime, Utc};
 use dioxus::prelude::*;
@@ -114,6 +118,7 @@ fn format_absolute_short(iso: &str, lang: &str) -> String {
 pub fn NoteDetail() -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
+    let manager: TranscriptionManager = use_context();
     let lang = (app.current_lang)();
 
     let note_id = match (app.view)() {
@@ -340,7 +345,8 @@ pub fn NoteDetail() -> Element {
         spawn(async move {
             let lang = (app.current_lang)();
             if let Ok(ai) = crate::services::llm::LlmClient::from_env() {
-                if let Ok(new_title) = ai.generate_title(&preview, &lang).await {
+                if let Ok(new_title) = ai.generate_title(&preview, &lang).await
+                {
                     title.set(new_title);
                 }
             }
@@ -476,6 +482,89 @@ pub fn NoteDetail() -> Element {
             }
         });
     });
+
+    let enqueue_manager = manager.clone();
+    use_effect(move || {
+        if !(app.audio_import_requested)() {
+            return;
+        }
+        app.audio_import_requested.set(false);
+        let manager = enqueue_manager.clone();
+        let db = db();
+        let t = title();
+        let c = content();
+        let tg = tags();
+        let folder = (app.detail_folder_id)();
+        spawn(async move {
+            let path = match import_audio_file().await {
+                Some(p) => p,
+                None => return,
+            };
+            let target_id = {
+                let current = local_note_id();
+                if current.is_empty() {
+                    let new = NewTextNote {
+                        title: if t.is_empty() {
+                            None
+                        } else {
+                            Some(t.clone())
+                        },
+                        content: c.clone(),
+                        tags: tg.clone(),
+                    };
+                    match db.create_text_note(&new) {
+                        Ok(created) => {
+                            if let Some(ref fid) = folder {
+                                let _ = db.add_note_to_folder(&created.id, fid);
+                            }
+                            local_note_id.set(created.id.clone());
+                            app.current_note_id.set(Some(created.id.clone()));
+                            app.notes_version.set((app.notes_version)() + 1);
+                            created.id
+                        }
+                        Err(_) => return,
+                    }
+                } else {
+                    current
+                }
+            };
+            manager.enqueue(target_id, path);
+        });
+    });
+
+    let observe_manager = manager.clone();
+    use_effect(move || {
+        let _ = (app.transcription_jobs)();
+        let nid = local_note_id();
+        if nid.is_empty() {
+            return;
+        }
+        if let Some(text) = observe_manager.take_done(&nid) {
+            let cur = content.peek().clone();
+            if cur.is_empty() {
+                content.set(text);
+            } else {
+                content.set(format!("{cur}\n{text}"));
+            }
+            app.transcription_jobs.set(observe_manager.snapshot());
+        }
+    });
+
+    use_effect(move || {
+        app.transcription_done_badge.set(0);
+    });
+
+    let audio_job_status: Option<JobStatus> = {
+        let jobs = (app.transcription_jobs)();
+        let nid = local_note_id();
+        if nid.is_empty() {
+            None
+        } else {
+            jobs.get(&nid)
+                .and_then(|q| q.front())
+                .map(|j| j.status.clone())
+        }
+    };
 
     let recording_state = (app.recording_state)();
     let is_transcribing = recording_state == RecordingState::Transcribing;
@@ -622,7 +711,7 @@ pub fn NoteDetail() -> Element {
                                                                 spawn(async move {
                                                                     let result = async {
                                                                         let client = SonioxClient::from_env()?;
-                                                                        client.transcribe(std::path::Path::new(&path)).await
+                                                                        client.transcribe(std::path::Path::new(&path), None).await
                                                                     }.await;
                                                                     match result {
                                                                         Ok(text) => {
@@ -660,6 +749,54 @@ pub fn NoteDetail() -> Element {
                         span { class: "inline-block w-3 h-3 border-2 border-ios-orange border-t-transparent rounded-full animate-spin" }
                     }
                     span { class: "text-xs text-stone-600", "{status}" }
+                }
+            }
+            if let Some(ref js) = audio_job_status {
+                match js {
+                    JobStatus::Failed(reason) => {
+                        let failed_label = t(&lang, "audio-import-failed");
+                        let retry_label = t(&lang, "audio-import-retry");
+                        let msg = format!("{failed_label}: {reason}");
+                        let retry_manager = manager.clone();
+                        let dismiss_manager = manager.clone();
+                        rsx! {
+                            div { class: "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-red/10 rounded-lg",
+                                span { class: "text-xs text-stone-600 flex-1", "{msg}" }
+                                button {
+                                    class: "text-xs text-ios-orange-dark font-medium active:opacity-70",
+                                    onclick: move |_| {
+                                        let nid = local_note_id();
+                                        retry_manager.retry(&nid);
+                                    },
+                                    "{retry_label}"
+                                }
+                                button {
+                                    class: "text-stone-400 active:opacity-70",
+                                    onclick: move |_| {
+                                        let nid = local_note_id();
+                                        dismiss_manager.dismiss(&nid);
+                                    },
+                                    IconX { size: 14 }
+                                }
+                            }
+                        }
+                    }
+                    JobStatus::Done(_) => rsx! {},
+                    other => {
+                        let transcribing_label = t(&lang, "audio-transcribing");
+                        let label = match other {
+                            JobStatus::Polling { elapsed_s } => {
+                                format!("{transcribing_label} · {}:{:02}", elapsed_s / 60, elapsed_s % 60)
+                            }
+                            _ => transcribing_label,
+                        };
+                        rsx! {
+                            div { class: "flex items-center gap-2 px-3 py-2 mt-2 bg-ios-orange/10 rounded-lg",
+                                span { class: "inline-block w-3 h-3 border-2 border-ios-orange border-t-transparent rounded-full animate-spin" }
+                                span { class: "text-xs text-stone-600", "{label}" }
+                            }
+                        }
+                    }
                 }
             }
             if let RecordingState::Error(ref e) = recording_state {

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -90,6 +90,19 @@ pub async fn import_file_content(
     }
 }
 
+pub async fn import_audio_file() -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "ios")]
+    {
+        use crate::platform::ios::open_audio_picker;
+        let paths = open_audio_picker().await?;
+        paths.into_iter().next()
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        None
+    }
+}
+
 #[component]
 pub fn NoteMenu(
     note_id: String,
@@ -102,6 +115,7 @@ pub fn NoteMenu(
     let mut import_requested = import_requested;
     let lang = (app.current_lang)();
     let import_label = t(&lang, "note-menu-import");
+    let import_audio_label = t(&lang, "note-menu-import-audio");
     let delete_label = t(&lang, "note-menu-delete");
 
     rsx! {
@@ -119,6 +133,15 @@ pub fn NoteMenu(
                 },
                 IconFileArrowUp { size: 18 }
                 "{import_label}"
+            }
+            button {
+                class: "w-full flex items-center gap-3 px-4 py-3 text-sm text-stone-700 active:bg-stone-50",
+                onclick: move |_| {
+                    app.audio_import_requested.set(true);
+                    app.show_note_menu.set(false);
+                },
+                IconMic { size: 18 }
+                "{import_audio_label}"
             }
             button {
                 class: "w-full flex items-center gap-3 px-4 py-3 text-sm text-ios-red active:bg-stone-50",

--- a/src/ui/recording/controls.rs
+++ b/src/ui/recording/controls.rs
@@ -38,7 +38,7 @@ fn spawn_transcription(
                 return;
             }
         };
-        let result = client.transcribe(&path).await;
+        let result = client.transcribe(&path, None).await;
         if cleanup {
             let _ = std::fs::remove_file(&path);
         }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,6 +1,8 @@
 use crate::models::Attachment;
 use crate::services::audio::RecordingState;
+use crate::ui::transcription_manager::Job;
 use dioxus::prelude::*;
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SidebarTab {
@@ -39,4 +41,7 @@ pub struct AppState {
     pub detail_folder_id: Signal<Option<String>>,
     pub ai_consent: Signal<Option<bool>>,
     pub current_lang: Signal<String>,
+    pub transcription_jobs: Signal<HashMap<String, VecDeque<Job>>>,
+    pub transcription_done_badge: Signal<usize>,
+    pub audio_import_requested: Signal<bool>,
 }

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -67,13 +67,16 @@ pub fn TopBar() -> Element {
                 }
             } else {
                 button {
-                    class: "min-w-[44px] min-h-[44px] flex items-center justify-center text-stone-700",
+                    class: "relative min-w-[44px] min-h-[44px] flex items-center justify-center text-stone-700",
                     onclick: move |_| {
                         app.show_folder_picker.set(false);
                         app.sidebar_tab.set(SidebarTab::Notes);
                         app.sidebar_open.set(true);
                     },
                     IconList { size: 22 }
+                    if (app.transcription_done_badge)() > 0 {
+                        span { class: "absolute top-2 right-2 w-2 h-2 rounded-full bg-ios-orange" }
+                    }
                 }
             }
             if is_detail || is_chat || !is_inner {

--- a/src/ui/transcription_manager.rs
+++ b/src/ui/transcription_manager.rs
@@ -1,0 +1,364 @@
+use crate::db::Database;
+use crate::models::UpdateNote;
+use crate::services::transcription::{clean_hesitations, SonioxClient};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+const MAX_ELAPSED_S: u32 = 5 * 60 * 60;
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum JobStatus {
+    Queued,
+    Uploading,
+    Polling { elapsed_s: u32 },
+    Done(String),
+    Failed(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Job {
+    pub id: String,
+    pub note_id: String,
+    pub file_path: PathBuf,
+    pub status: JobStatus,
+    pub transcription_id: Option<String>,
+    pub soniox_file_id: Option<String>,
+}
+
+#[derive(Default)]
+struct Registry {
+    queues: HashMap<String, VecDeque<Job>>,
+    active: HashSet<String>,
+}
+
+#[derive(Clone)]
+pub struct TranscriptionManager {
+    reg: Arc<Mutex<Registry>>,
+    db: Arc<Database>,
+}
+
+impl TranscriptionManager {
+    pub fn new(db: Arc<Database>) -> Self {
+        Self {
+            reg: Arc::new(Mutex::new(Registry::default())),
+            db,
+        }
+    }
+
+    pub fn snapshot(&self) -> HashMap<String, VecDeque<Job>> {
+        self.reg.lock().unwrap().queues.clone()
+    }
+
+    pub fn enqueue(&self, note_id: String, file_path: PathBuf) {
+        let job = Job {
+            id: uuid::Uuid::new_v4().to_string(),
+            note_id: note_id.clone(),
+            file_path,
+            status: JobStatus::Queued,
+            transcription_id: None,
+            soniox_file_id: None,
+        };
+        {
+            let mut g = self.reg.lock().unwrap();
+            g.queues.entry(note_id.clone()).or_default().push_back(job);
+        }
+        self.kick(note_id);
+    }
+
+    pub fn take_done(&self, note_id: &str) -> Option<String> {
+        let text = {
+            let mut g = self.reg.lock().unwrap();
+            let q = g.queues.get_mut(note_id)?;
+            let text = match q.front().map(|j| j.status.clone()) {
+                Some(JobStatus::Done(t)) => t,
+                _ => return None,
+            };
+            q.pop_front();
+            if q.is_empty() {
+                g.queues.remove(note_id);
+            }
+            text
+        };
+        eprintln!("[import] consumed note={note_id} chars={}", text.len());
+        self.kick(note_id.to_string());
+        Some(text)
+    }
+
+    pub fn retry(&self, note_id: &str) {
+        {
+            let mut g = self.reg.lock().unwrap();
+            if let Some(q) = g.queues.get_mut(note_id) {
+                if let Some(j) = q.front_mut() {
+                    if matches!(j.status, JobStatus::Failed(_)) {
+                        j.status = JobStatus::Queued;
+                        j.transcription_id = None;
+                        j.soniox_file_id = None;
+                    }
+                }
+            }
+        }
+        self.kick(note_id.to_string());
+    }
+
+    pub fn dismiss(&self, note_id: &str) {
+        let path = {
+            let mut g = self.reg.lock().unwrap();
+            let path = g
+                .queues
+                .get(note_id)
+                .and_then(|q| q.front())
+                .map(|j| j.file_path.clone());
+            if let Some(q) = g.queues.get_mut(note_id) {
+                q.pop_front();
+                if q.is_empty() {
+                    g.queues.remove(note_id);
+                }
+            }
+            path
+        };
+        if let Some(p) = path {
+            cleanup_file(&p);
+        }
+        self.kick(note_id.to_string());
+    }
+
+    pub fn resume_pending(&self) {
+        for row in self.db.list_pending_transcriptions() {
+            let job = Job {
+                id: uuid::Uuid::new_v4().to_string(),
+                note_id: row.note_id.clone(),
+                file_path: PathBuf::new(),
+                status: JobStatus::Polling { elapsed_s: 0 },
+                transcription_id: Some(row.transcription_id),
+                soniox_file_id: row.soniox_file_id,
+            };
+            {
+                let mut g = self.reg.lock().unwrap();
+                g.queues
+                    .entry(row.note_id.clone())
+                    .or_default()
+                    .push_back(job);
+            }
+            self.kick(row.note_id);
+        }
+    }
+
+    fn kick(&self, note_id: String) {
+        {
+            let mut g = self.reg.lock().unwrap();
+            if g.active.contains(&note_id) {
+                return;
+            }
+            let actionable = matches!(
+                g.queues
+                    .get(&note_id)
+                    .and_then(|q| q.front())
+                    .map(|j| &j.status),
+                Some(JobStatus::Queued)
+                    | Some(JobStatus::Uploading)
+                    | Some(JobStatus::Polling { .. })
+            );
+            if !actionable {
+                return;
+            }
+            g.active.insert(note_id.clone());
+        }
+        let reg = self.reg.clone();
+        let db = self.db.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async move {
+                process_front(&reg, &db, &note_id).await;
+                reg.lock().unwrap().active.remove(&note_id);
+            });
+        });
+    }
+}
+
+fn front_job(reg: &Mutex<Registry>, note_id: &str) -> Option<Job> {
+    reg.lock()
+        .unwrap()
+        .queues
+        .get(note_id)
+        .and_then(|q| q.front())
+        .cloned()
+}
+
+fn set_status(
+    reg: &Mutex<Registry>,
+    note_id: &str,
+    job_id: &str,
+    status: JobStatus,
+) {
+    let mut g = reg.lock().unwrap();
+    if let Some(q) = g.queues.get_mut(note_id) {
+        if let Some(j) = q.iter_mut().find(|j| j.id == job_id) {
+            j.status = status;
+        }
+    }
+}
+
+fn set_transcription_ids(
+    reg: &Mutex<Registry>,
+    note_id: &str,
+    job_id: &str,
+    transcription_id: &str,
+    soniox_file_id: &str,
+) {
+    let mut g = reg.lock().unwrap();
+    if let Some(q) = g.queues.get_mut(note_id) {
+        if let Some(j) = q.iter_mut().find(|j| j.id == job_id) {
+            j.transcription_id = Some(transcription_id.to_string());
+            j.soniox_file_id = Some(soniox_file_id.to_string());
+        }
+    }
+}
+
+fn cleanup_file(path: &Path) {
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+fn client_from_db(db: &Database) -> Result<SonioxClient, String> {
+    if db.get_setting("ai_consent") != Some("true".to_string()) {
+        return Err("Consentement IA requis".to_string());
+    }
+    let key = db
+        .get_setting("soniox_api_key")
+        .or_else(|| std::env::var("SONIOX_API_KEY").ok())
+        .or_else(|| option_env!("SONIOX_API_KEY").map(String::from))
+        .unwrap_or_default();
+    if key.is_empty() || key == "your_key_here" {
+        return Err("SONIOX_API_KEY not configured".to_string());
+    }
+    Ok(SonioxClient::new(key))
+}
+
+async fn process_front(reg: &Mutex<Registry>, db: &Database, note_id: &str) {
+    let job = match front_job(reg, note_id) {
+        Some(j) => j,
+        None => return,
+    };
+    if matches!(job.status, JobStatus::Done(_) | JobStatus::Failed(_)) {
+        return;
+    }
+
+    let client = match client_from_db(db) {
+        Ok(c) => c,
+        Err(e) => {
+            set_status(reg, note_id, &job.id, JobStatus::Failed(e));
+            return;
+        }
+    };
+
+    set_status(reg, note_id, &job.id, JobStatus::Uploading);
+
+    let (tr_id, file_id) = match job.transcription_id.clone() {
+        Some(tid) => (tid, job.soniox_file_id.clone()),
+        None => match client.start_transcription(&job.file_path, None).await {
+            Ok((tid, fid)) => {
+                let _ = db.add_pending_transcription(note_id, &tid, Some(&fid));
+                set_transcription_ids(reg, note_id, &job.id, &tid, &fid);
+                (tid, Some(fid))
+            }
+            Err(e) => {
+                set_status(reg, note_id, &job.id, JobStatus::Failed(e));
+                return;
+            }
+        },
+    };
+
+    let started = SystemTime::now();
+    let mut transient = 0u32;
+    loop {
+        let elapsed =
+            started.elapsed().map(|d| d.as_secs() as u32).unwrap_or(0);
+        if elapsed > MAX_ELAPSED_S {
+            if let Some(fid) = &file_id {
+                let _ = client.delete_file(fid).await;
+            }
+            let _ = db.delete_pending_transcription(note_id);
+            set_status(
+                reg,
+                note_id,
+                &job.id,
+                JobStatus::Failed("Transcription timeout (5 h)".to_string()),
+            );
+            return;
+        }
+        match client.check_status(&tr_id).await {
+            Ok(Some(text)) => {
+                if let Some(fid) = &file_id {
+                    let _ = client.delete_file(fid).await;
+                }
+                let _ = db.delete_pending_transcription(note_id);
+                cleanup_file(&job.file_path);
+                let clean = clean_hesitations(&text);
+                set_status(reg, note_id, &job.id, JobStatus::Done(clean));
+                return;
+            }
+            Ok(None) => {
+                transient = 0;
+                set_status(
+                    reg,
+                    note_id,
+                    &job.id,
+                    JobStatus::Polling { elapsed_s: elapsed },
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+            Err(e) => {
+                let server_failed = e == "Transcription failed on server";
+                transient += 1;
+                if server_failed || transient >= 10 {
+                    if let Some(fid) = &file_id {
+                        let _ = client.delete_file(fid).await;
+                    }
+                    let _ = db.delete_pending_transcription(note_id);
+                    set_status(reg, note_id, &job.id, JobStatus::Failed(e));
+                    return;
+                }
+                eprintln!("[soniox] poll transient {transient}/10: {e}");
+                set_status(
+                    reg,
+                    note_id,
+                    &job.id,
+                    JobStatus::Polling { elapsed_s: elapsed },
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+pub fn append_transcription_to_note(db: &Database, note_id: &str, text: &str) {
+    let note = match db.get_note(note_id) {
+        Ok(Some(n)) => n,
+        _ => return,
+    };
+    let new_content = if note.content.is_empty() {
+        text.to_string()
+    } else {
+        format!("{}\n{}", note.content, text)
+    };
+    let _ = db.update_note(
+        note_id,
+        &UpdateNote {
+            title: None,
+            content: Some(new_content.clone()),
+            tags: None,
+        },
+    );
+    crate::services::embed::embed_note(
+        note_id.to_string(),
+        note.title.unwrap_or_default(),
+        new_content,
+        note.tags,
+        note.created_at,
+    );
+}

--- a/tests/pending_transcription_test.rs
+++ b/tests/pending_transcription_test.rs
@@ -1,0 +1,85 @@
+use flowflow::db::Database;
+use tempfile::tempdir;
+
+fn open_test_db() -> (Database, tempfile::TempDir) {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("flowflow_test.db");
+    let db = Database::open_at(path).expect("open_at");
+    (db, dir)
+}
+
+#[test]
+fn test_migration_v8_creates_pending_transcriptions_table() {
+    let (db, _dir) = open_test_db();
+    let conn = db.conn();
+    let exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'table' AND name = 'pending_transcriptions'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(
+        exists, 1,
+        "pending_transcriptions table should exist after V8"
+    );
+}
+
+#[test]
+fn test_migration_v8_columns() {
+    let (db, _dir) = open_test_db();
+    let conn = db.conn();
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(pending_transcriptions)")
+        .expect("prepare pragma");
+    let cols: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>("name"))
+        .expect("query")
+        .filter_map(Result::ok)
+        .collect();
+    assert!(cols.contains(&"note_id".to_string()));
+    assert!(cols.contains(&"transcription_id".to_string()));
+    assert!(cols.contains(&"soniox_file_id".to_string()));
+    assert!(cols.contains(&"created_at".to_string()));
+}
+
+#[test]
+fn test_pending_transcription_crud() {
+    let (db, _dir) = open_test_db();
+
+    db.add_pending_transcription("note-1", "tr-1", Some("file-1"))
+        .expect("add");
+    db.add_pending_transcription("note-2", "tr-2", None)
+        .expect("add none");
+
+    let rows = db.list_pending_transcriptions();
+    assert_eq!(rows.len(), 2);
+
+    let r1 = rows.iter().find(|r| r.note_id == "note-1").expect("note-1");
+    assert_eq!(r1.transcription_id, "tr-1");
+    assert_eq!(r1.soniox_file_id.as_deref(), Some("file-1"));
+
+    let r2 = rows.iter().find(|r| r.note_id == "note-2").expect("note-2");
+    assert_eq!(r2.soniox_file_id, None);
+
+    db.delete_pending_transcription("note-1").expect("delete");
+    let rows = db.list_pending_transcriptions();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].note_id, "note-2");
+}
+
+#[test]
+fn test_pending_transcription_upsert_replaces() {
+    let (db, _dir) = open_test_db();
+
+    db.add_pending_transcription("note-1", "tr-old", Some("file-old"))
+        .expect("add");
+    db.add_pending_transcription("note-1", "tr-new", Some("file-new"))
+        .expect("upsert");
+
+    let rows = db.list_pending_transcriptions();
+    assert_eq!(rows.len(), 1, "upsert must not duplicate the note_id");
+    assert_eq!(rows[0].transcription_id, "tr-new");
+    assert_eq!(rows[0].soniox_file_id.as_deref(), Some("file-new"));
+}


### PR DESCRIPTION
## Summary

Ships **audio file import → transcription** (RFC 0002), plus planning docs (PRDs/RFCs). Covers all commits since last merge to `main`.

Import an existing audio file (dictaphone, Voice Memos, recorded meeting) into a note → Soniox transcription → text appended to the note and auto-embedded for semantic search/chat. No re-recording.

## Shipped (code) — audio import & transcription

- **Entry**: NoteMenu "Import audio" action → native audio picker (m4a/AAC, mp3, wav, caf).
- **Picker** (`platform/ios`): explicit UTType identifiers (fixes m4a/caf dropped as nil) + durable copy into `Documents/flowflow_import` (survives iOS tmp purge → enables retry).
- **Engine** (`SonioxClient`): split into `start_transcription`/`poll_transcript`/`check_status` + `delete_file`; `language: Option<&str>` = auto-detect everywhere (live + import); 5h poll cap.
- **Background** (`TranscriptionManager`): detached thread + Runtime (survives navigation + App re-render); FIFO queue per note; **atomic `take_done`** = single consume (no duplication); App `use_future` bridge mirrors registry → Signal.
- **Resume**: DB **V8** `pending_transcriptions` (additive, reversible) → in-flight transcriptions re-polled at app relaunch.
- **Robust failure**: note never corrupted, clear message + retry/dismiss; consent/key guard; done badge.
- **Network race hardening**: reqwest/hyper pooled-connection failure (`error sending request`) → connect/request timeouts + 3x upload retry + poll tolerates transient transport errors (vs terminal server-failed).
- **i18n**: FR/EN labels. **Tests**: V8 migration + repo CRUD/upsert.

Commits: `feat(transcription)` engine, `feat(ios)` picker, `feat(db)` V8, `feat(transcription)` manager+bridge, `feat(notes)` UI, `feat(i18n)`, `test(db)`, `chore` fmt/stats.

## Docs (no code) — planning

- RFC 0002 audio-import-transcription (design + adversarial review) + PRD/tasks.
- RFC 0001 data-backup-export + PRD.
- PRDs: agentic-tools, lan-serve.

## Validation

- `cargo check` + `clippy` clean on host **and** `aarch64-apple-ios-sim`.
- V8 repo/migration tests pass.
- **Device-tested by owner**: import works, single (non-duplicated) transcription, network retry confirmed.

## Migration

- DB **V8** additive (`pending_transcriptions`), reversible (drop table). No change to existing schemas.