### PR TITLE
fix(recording): reuse shared DB instead of reopening it on the main thread

### DIFF
--- a/src/services/llm.rs
+++ b/src/services/llm.rs
@@ -62,17 +62,19 @@ impl LlmClient {
     }
 
     pub fn from_env() -> Result<Self, LlmError> {
-        let db = crate::db::Database::open().ok();
-        if db.as_ref().and_then(|d| d.get_setting("ai_consent"))
-            != Some("true".to_string())
-        {
+        let db =
+            crate::db::Database::open().map_err(LlmError::NotConfigured)?;
+        Self::from_db(&db)
+    }
+
+    pub fn from_db(db: &crate::db::Database) -> Result<Self, LlmError> {
+        if db.get_setting("ai_consent") != Some("true".to_string()) {
             return Err(LlmError::NotConfigured(
                 "Consentement IA requis".into(),
             ));
         }
         let openai_key = db
-            .as_ref()
-            .and_then(|d| d.get_setting("openai_api_key"))
+            .get_setting("openai_api_key")
             .or_else(|| std::env::var("OPENAI_API_KEY").ok())
             .or_else(|| option_env!("OPENAI_API_KEY").map(String::from))
             .unwrap_or_default();
@@ -85,15 +87,13 @@ impl LlmClient {
             .map_err(|e| LlmError::NotConfigured(e.to_string()))?;
 
         let provider = db
-            .as_ref()
-            .and_then(|d| d.get_setting("llm_provider"))
+            .get_setting("llm_provider")
             .and_then(|v| Provider::from_str(&v).ok())
             .unwrap_or_default();
 
         let anthropic = if provider == Provider::Anthropic {
             let key = db
-                .as_ref()
-                .and_then(|d| d.get_setting("anthropic_api_key"))
+                .get_setting("anthropic_api_key")
                 .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
                 .or_else(|| option_env!("ANTHROPIC_API_KEY").map(String::from))
                 .unwrap_or_default();

--- a/src/services/transcription/client.rs
+++ b/src/services/transcription/client.rs
@@ -42,16 +42,12 @@ impl SonioxClient {
         Self { client, api_key }
     }
 
-    pub fn from_env() -> Result<Self, String> {
-        let db_opt = crate::db::Database::open().ok();
-        if db_opt.as_ref().and_then(|d| d.get_setting("ai_consent"))
-            != Some("true".to_string())
-        {
+    pub fn from_db(db: &crate::db::Database) -> Result<Self, String> {
+        if db.get_setting("ai_consent") != Some("true".to_string()) {
             return Err("Consentement IA requis".to_string());
         }
-        let key = db_opt
-            .as_ref()
-            .and_then(|db| db.get_setting("soniox_api_key"))
+        let key = db
+            .get_setting("soniox_api_key")
             .or_else(|| std::env::var("SONIOX_API_KEY").ok())
             .or_else(|| option_env!("SONIOX_API_KEY").map(String::from))
             .unwrap_or_default();

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -343,7 +343,7 @@ pub fn NoteDetail() -> Element {
         let preview: String = c.chars().take(1500).collect();
         spawn(async move {
             let lang = (app.current_lang)();
-            if let Ok(ai) = crate::services::llm::LlmClient::from_env() {
+            if let Ok(ai) = crate::services::llm::LlmClient::from_db(&db()) {
                 if let Ok(new_title) = ai.generate_title(&preview, &lang).await
                 {
                     title.set(new_title);
@@ -383,7 +383,7 @@ pub fn NoteDetail() -> Element {
                 return;
             }
             detecting_reminders.set(true);
-            match crate::services::llm::LlmClient::from_env() {
+            match crate::services::llm::LlmClient::from_db(&db()) {
                 Ok(ai) => {
                     if let Ok(intents) =
                         ai.extract_reminders(&c, Local::now()).await
@@ -1028,7 +1028,7 @@ pub fn NoteDetail() -> Element {
                                                                 transcribing_audio_id.set(Some(aid.clone()));
                                                                 spawn(async move {
                                                                     let result = async {
-                                                                        let client = SonioxClient::from_env()?;
+                                                                        let client = SonioxClient::from_db(&db())?;
                                                                         client.transcribe(std::path::Path::new(&path), None).await
                                                                     }.await;
                                                                     match result {

--- a/src/ui/notes/tags.rs
+++ b/src/ui/notes/tags.rs
@@ -1,8 +1,10 @@
+use crate::db::Database;
 use crate::services::i18n::t;
 use crate::services::llm::LlmClient;
 use crate::ui::icons::*;
 use crate::ui::AppState;
 use dioxus::prelude::*;
+use std::sync::Arc;
 
 #[component]
 pub fn TagsSection(
@@ -12,6 +14,7 @@ pub fn TagsSection(
     content: Signal<String>,
 ) -> Element {
     let app: AppState = use_context();
+    let db: Signal<Arc<Database>> = use_context();
     let lang = (app.current_lang)();
     let auto_tag_label = t(&lang, "tag-auto-action");
     let placeholder = t(&lang, "tag-add-placeholder");
@@ -33,7 +36,7 @@ pub fn TagsSection(
                         tagging.set(true);
                         let c = content();
                         spawn(async move {
-                            if let Ok(client) = LlmClient::from_env() {
+                            if let Ok(client) = LlmClient::from_db(&db()) {
                                 if let Ok(new_tags) =
                                     client.generate_tags(&c).await
                                 {

--- a/src/ui/recording/controls.rs
+++ b/src/ui/recording/controls.rs
@@ -20,13 +20,14 @@ fn now_ms() -> u64 {
 
 fn spawn_transcription(
     path: PathBuf,
+    db: Arc<Database>,
     mut state: Signal<RecordingState>,
     generation: u64,
     gen_signal: Signal<u64>,
     cleanup: bool,
 ) {
     spawn(async move {
-        let client = match SonioxClient::from_env() {
+        let client = match SonioxClient::from_db(&db) {
             Ok(c) => c,
             Err(e) => {
                 if cleanup {
@@ -243,7 +244,7 @@ pub fn RecordingControls(
                                 let gen = transcription_gen() + 1;
                                 transcription_gen.set(gen);
                                 app.recording_state.set(RecordingState::Transcribing);
-                                spawn_transcription(path, app.recording_state, gen, transcription_gen, transcribe_only);
+                                spawn_transcription(path, db(), app.recording_state, gen, transcription_gen, transcribe_only);
                             }
                             Err(e) => {
                                 app.recording_state.set(RecordingState::Error(e));


### PR DESCRIPTION
## Summary
Fixes a full UI freeze when starting dictation, reproducible inside a folder note (instant freeze on tap, the recording bar never appears, force-quit required).

## Root cause
\`LlmClient::from_env\` and \`SonioxClient::from_env\` reopened the SQLite database on every call (\`Connection::open\` + \`PRAGMA journal_mode=WAL\` + the migration loop). They are invoked from Dioxus \`spawn()\` tasks that run on the single-threaded UI executor:

- dictate-stop transcription (\`spawn_transcription\`)
- live reminder detection
- auto title generation
- auto tag generation
- per-audio re-transcription

Reopening and migrating the DB on the main thread blocks the only thread that renders the UI and handles input, freezing the app with no crash.

## Fix
- Add \`from_db(&Database)\` to \`LlmClient\` and \`SonioxClient\`, reusing the shared \`Arc<Database>\` already provided via Dioxus context.
- Convert the on-executor call sites to \`from_db\`.
- \`from_env\` now delegates to \`from_db\` and is kept for off-executor background callers (\`embed\`, \`rag\`, run on dedicated threads) and integration tests, so their behavior is unchanged.

## Scope
5 files, +24/-24. No semantic change for \`from_env\` callers; only removes the redundant DB open on the UI thread.

## Testing
- \`cargo fmt\` + \`cargo clippy --features mobile\`: clean.
- Verified on device: dictation inside a folder no longer freezes.