### PR TITLE
feat(ux): real-time sync experience, safe-area, QR pairing, FAB redesign, docs restructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ ddev:
 ddev-build:
 	set -a && . ./.env && IPHONEOS_DEPLOYMENT_TARGET=16.0 dx build --platform ios --device true
 	bash scripts/sign-widget.sh debug
+	bash scripts/inject-url-scheme.sh || true
 	bash scripts/inject-icon.sh || true
 
 deploy:
-	set -a && . ./.env && IPHONEOS_DEPLOYMENT_TARGET=16.0 dx build --platform ios --device true && bash scripts/inject-icon.sh
+	set -a && . ./.env && IPHONEOS_DEPLOYMENT_TARGET=16.0 dx build --platform ios --device true && bash scripts/inject-url-scheme.sh && bash scripts/inject-icon.sh
 
 # Defensive restore: if a desktop build was killed (SIGKILL/power loss) it can
 # leave Dioxus.toml stripped of the iOS widget and the original parked in
@@ -43,6 +44,7 @@ restore-ios-toml:
 all: restore-ios-toml ensure-profiles
 	set -a && . ./.env && IPHONEOS_DEPLOYMENT_TARGET=16.0 dx build --platform ios --device true
 	bash scripts/sign-widget.sh debug
+	bash scripts/inject-url-scheme.sh || true
 	bash scripts/inject-icon.sh || true
 
 check-profiles:
@@ -71,6 +73,7 @@ desktop-build: desktop-toml
 	set -a && . ./.env && set +a; \
 	trap 'mv .Dioxus.toml.ios Dioxus.toml' EXIT INT TERM; \
 	dx build --platform desktop
+	APP_PATH=target/dx/flowflow/debug/macos/Flowflow.app bash scripts/inject-desktop-icon.sh
 
 # Standalone Mac app: release build installed in /Applications, runs without
 # any dev server. Data lives in ~/Library/Application Support/FlowFlow.
@@ -78,6 +81,7 @@ desktop-app: desktop-toml
 	set -a && . ./.env && set +a; \
 	trap 'mv .Dioxus.toml.ios Dioxus.toml' EXIT INT TERM; \
 	dx build --platform desktop --release
+	APP_PATH=target/dx/flowflow/release/macos/Flowflow.app bash scripts/inject-desktop-icon.sh
 	rsync -a --delete target/dx/flowflow/release/macos/Flowflow.app/ /Applications/Flowflow.app/
 	@echo ">> Flowflow.app installed in /Applications"
 
@@ -150,6 +154,8 @@ appstore:
 	plutil -replace BuildMachineOSBuild -string $$OS_BUILD $$WPLIST 2>/dev/null || plutil -insert BuildMachineOSBuild -string $$OS_BUILD $$WPLIST; \
 	plutil -replace LSRequiresIPhoneOS -bool true $$WPLIST 2>/dev/null || plutil -insert LSRequiresIPhoneOS -bool true $$WPLIST; \
 	plutil -replace CFBundleSupportedPlatforms -json '["iPhoneOS"]' $$WPLIST 2>/dev/null || plutil -insert CFBundleSupportedPlatforms -json '["iPhoneOS"]' $$WPLIST
+	@echo ">> Registering URL scheme (release: re-sign deferred)..."
+	APP_PATH=target/dx/flowflow/release/ios/Flowflow.app bash scripts/inject-url-scheme.sh || true
 	@echo ">> Injecting icon (release: re-sign deferred)..."
 	APP_PATH=target/dx/flowflow/release/ios/Flowflow.app bash scripts/inject-icon.sh || true
 	@echo ">> Replacing main app provisioning profile with App Store distribution..."

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">FlowFlow</h1>
 
 <p align="center">
-  Voice notes app for mobile — 100% Rust, built with <a href="https://github.com/DioxusLabs/dioxus">Dioxus</a>.<br/>
+  Voice notes app for mobile - 100% Rust, built with <a href="https://github.com/DioxusLabs/dioxus">Dioxus</a>.<br/>
   Featured on <a href="https://dioxuslabs.com/awesome/">Awesome Dioxus</a>.
 </p>
 
@@ -13,58 +13,39 @@
 
 Most of my ideas come when I'm walking or between two tasks. And they vanish just as fast.
 
-FlowFlow is a voice notes app that captures what you say, transcribes it, and lets you **chat with your notes** later. You ask "what was that pricing idea?" and the right passages come up — with links to the original notes.
+FlowFlow is a voice notes app that captures what you say, transcribes it, and lets you **chat with your notes** later. You ask "what was that pricing idea?" and the right passages come up - with links to the original notes.
 
 No manual searching. No folders to dig through. Just talk, and find it later.
 
 ## What it does
 
-- **Voice capture** — tap to record, real-time waveform visualization, pause/resume, auto-transcription via Soniox
-- **Background audio + Dynamic Island Live Activity** — recording keeps going when you lock the phone or switch apps, with a live timer in the Dynamic Island
-- **Interruption handling** — auto-pause on incoming calls / FaceTime via AVAudioSession observers, auto-resume after
-- **Audio playback** — play, pause, and delete voice recordings directly from any note
-- **RAG chat** — powered by [rig](https://github.com/0xPlaygrounds/rig), ask questions about your notes and get answers with tappable source references
-- **Hybrid search** — BM25 keyword + vector similarity + RRF fusion + LLM reranking for precise retrieval
-- **Temporal queries** — ask "what did I note yesterday?" with automatic French date detection (regex + LLM fallback)
-- **Folder-scoped chat** — chat searches only within the selected folder when one is active
-- **Agent tools** — the chat agent can search notes by meaning, create new notes, or summarize entire folders autonomously
-- **AI auto-title** — LLM generates a 1-3 word title while you write, with pulse animation
-- **Auto-tagging** — LLM generates single-word tags per note, or add your own
-- **Document import** — PDF (with native OCR for scanned documents), DOCX, TXT, MD, CSV via native iOS picker
-- **Filler removal** — auto-strips hesitations (euh, um, hmm) from transcriptions so your notes read clean
-- **Local-first** — SQLite for metadata, LanceDB for semantic search, your data stays on device
+- **Voice capture** - tap to record, real-time waveform, pause/resume, auto-transcription via Soniox, background audio with a Dynamic Island live timer
+- **Multi-device sync** - encrypted LAN P2P between iPhone and Mac (Noise protocol, no server, no cloud), QR pairing, real-time UI refresh, zero data loss by design
+- **RAG chat** - powered by [rig](https://github.com/0xPlaygrounds/rig): ask questions about your notes, get answers with tappable sources; hybrid search (BM25 + vector + RRF + LLM rerank), temporal queries, folder-scoped chat, agent tools
+- **Smart reminders** - notes like "pick up the kids at 5pm" become iOS reminders, detected by LLM with one-tap confirm
+- **AI organization** - auto-title while you write, single-word auto-tags, folders with hierarchy
+- **Document import** - PDF (native OCR for scans), DOCX, TXT, MD, CSV via the native iOS picker, auto-embedded for chat
+- **Audio playback** - play, pause, delete recordings from any note; filler words (euh, um) auto-stripped from transcripts
+- **Bilingual** - English + French UI, auto-detected, switchable in Settings
+- **Local-first** - SQLite for metadata, LanceDB for vectors, your data stays on your devices
 
 ## Stack
 
-100% Rust. Zero JavaScript.
-
-The UI runs on [Dioxus](https://github.com/DioxusLabs/dioxus), a React-like framework for Rust that renders natively on iOS through WKWebView. Styling is handled by [Tailwind CSS V4](https://tailwindcss.com) — Dioxus auto-detects and compiles it, so every class just works without a separate build step.
-
-The RAG pipeline is built on [rig](https://github.com/0xPlaygrounds/rig), an LLM orchestration framework for Rust. It handles agent construction, tool calling, and OpenAI provider dispatch in a unified API. The agent gets custom tools — search notes, create notes, summarize folders — and can chain up to 4 tool calls per question before answering.
-
-Embeddings go through OpenAI's text-embedding-3-small and land in [LanceDB](https://lancedb.com), a local vector database that runs entirely on device. Cosine similarity search over chunked notes and documents, no server needed.
-
-Document import uses Apple's native PDFKit on iOS — text extraction with automatic OCR fallback for scanned documents. DOCX parsing is handled directly via zip + quick-xml, no external dependencies.
-
-The Dynamic Island Live Activity bridges Rust to Swift via a thin FFI layer over ActivityKit, so the recording timer renders natively while the audio pipeline stays in Rust.
-
-Everything async runs on [tokio](https://tokio.rs) — audio recording, API calls, embedding jobs, transcription polling. The iOS audio pipeline uses cpal for CoreAudio capture and hound for WAV encoding.
+100% Rust. Zero JavaScript. The UI is [Dioxus](https://github.com/DioxusLabs/dioxus) rendering natively on iOS and macOS; the Dynamic Island Live Activity is the only Swift, bridged via FFI.
 
 |               |                                                                                                |
 | ------------- | ---------------------------------------------------------------------------------------------- |
-| UI            | [Dioxus 0.7.9](https://github.com/DioxusLabs/dioxus) (iOS, desktop, web)                       |
+| UI            | [Dioxus 0.7.9](https://github.com/DioxusLabs/dioxus) (iOS, desktop)                            |
 | Styling       | [Tailwind CSS V4](https://tailwindcss.com)                                                     |
-| LLM           | [rig-core 0.36](https://github.com/0xPlaygrounds/rig) (OpenAI)                                 |
+| LLM           | [rig-core 0.36](https://github.com/0xPlaygrounds/rig) (OpenAI, Anthropic)                      |
 | Embeddings    | OpenAI text-embedding-3-small (1536 dims)                                                      |
 | Vector DB     | [LanceDB 0.27.2](https://lancedb.com) (local, cosine)                                          |
-| Async         | [tokio](https://tokio.rs)                                                                      |
 | Database      | SQLite ([rusqlite](https://github.com/rusqlite/rusqlite) 0.34, bundled, WAL mode)              |
+| Sync          | LAN P2P, [snow](https://github.com/mcginty/snow) (Noise XXpsk3), version vectors, tombstones   |
 | Audio         | [cpal](https://github.com/RustAudio/cpal) 0.17 + [hound](https://github.com/ruuda/hound) 3.5   |
 | Transcription | [Soniox](https://soniox.com) REST API                                                          |
-| Live Activity | ActivityKit via Swift FFI (Dynamic Island recording timer)                                     |
-| PDF           | Apple PDFKit (iOS, native OCR) / [pdf-extract](https://crates.io/crates/pdf-extract) (desktop) |
-| DOCX          | [quick-xml](https://crates.io/crates/quick-xml) + [zip](https://crates.io/crates/zip)          |
-| Icons         | [Phosphor](https://phosphoricons.com) (MIT)                                                    |
+| PDF / DOCX    | Apple PDFKit (iOS, OCR) / [pdf-extract](https://crates.io/crates/pdf-extract); quick-xml + zip |
+| Async         | [tokio](https://tokio.rs)                                                                      |
 | Min iOS       | 16.0 (aarch64-apple-ios)                                                                       |
 
 ## How it works
@@ -74,6 +55,8 @@ Talk → Record → Transcribe → Clean fillers → Auto-embed → Store → AI
 
 Later: Ask → Embed query → Hybrid search (BM25 + vector + RRF)
      → LLM rerank → Temporal boost → Tag-enriched context → Agent with tools → Answer with sources
+
+Sync:  Save → debounced trigger → Noise-encrypted LAN session → version-vector merge → UI refresh < 1 s
 ```
 
 ## Setup
@@ -89,157 +72,27 @@ API keys can be set in-app via Settings (stored in SQLite, no recompile). OpenAI
 ## Commands
 
 ```bash
-make all            # build + sign widget + icon + install (auto-renews expired profiles)
-make ddev           # dx serve --ios --device (hot reload, no widget signing)
-make dev            # dx serve --ios (simulator)
-make desktop        # dx serve --desktop (Mac window, real mic)
-make build          # cargo build --features mobile
-make format         # cargo fmt
-make check          # fmt check + clippy
-make deploy         # dx build device + icon injection
-make appstore       # release build + distribution signing + IPA
-make renew          # regenerate iOS provisioning profiles (xcodebuild)
-make check-profiles # show profile expiration dates
-make logs           # open Console.app (select iPhone, filter "FlowFlow")
-make clean          # rm target/dx
+make all          # build + sign + icon + install on iPhone
+make ddev         # dx serve --ios --device (hot reload)
+make desktop-app  # build + install the Mac app
+make check        # fmt check + clippy
+make appstore     # release build + signed IPA
 ```
 
-## iOS Device Provisioning
+Full command list in the [Makefile](Makefile).
 
-Running on a physical iPhone requires a valid provisioning profile. Apple enforces code signing for all device builds.
+## Documentation
 
-**Free Apple account**: profiles expire after 7 days. **Paid Apple Developer Program** (€99/year): profiles last 1 year, plus App Store and TestFlight access.
+Everything beyond this page lives in [`docs/INDEX.md`](docs/INDEX.md):
 
-`make all` auto-detects expiry < 24h and runs `make renew` before building. Renewal uses a minimal Xcode project template under `tools/provision-renew/` invoked via `xcodebuild -allowProvisioningUpdates`. Zero manual Xcode GUI required.
-
-```bash
-make check-profiles  # show expiration dates
-make renew           # regenerate now
-```
-
-**On your iPhone** (first time only): Settings → General → VPN & Device Management → tap your developer certificate → Trust.
-
-Once your paid Apple Developer Program is active, profiles last 1 year and `make renew` becomes a once-a-year operation.
-
-## App Store distribution
-
-`make appstore` produces a `FlowFlow.ipa` that passes Apple's validator with zero errors. The Dioxus CLI omits several keys required for App Store distribution (`CFBundlePackageType`, `DT*`, widget `UIRequiredDeviceCapabilities`, ...) and uses a `ditto` invocation that strips the `Payload/` directory; the Makefile patches all of these. Full breakdown of every Apple validation error we hit and the corresponding fix: [docs/deploy/04-dioxus-app-store-workarounds.md](docs/deploy/04-dioxus-app-store-workarounds.md). Upstream tracking: [Dioxus issue #3817](https://github.com/DioxusLabs/dioxus/issues/3817).
-
-End-to-end submission walkthrough: [docs/deploy/02-app-store-submission.md](docs/deploy/02-app-store-submission.md). Sequential execution plan: [docs/deploy/03-execution-plan.md](docs/deploy/03-execution-plan.md).
-
-### Optional: server-side IPA validation
-
-`make appstore` can call `xcrun altool --validate-app` against Apple's servers after the IPA is built, so you catch rejections (missing keys, wrong cert, version conflict) before opening Transporter. Add these to `.env`:
-
-```
-APPLE_ID=you@example.com
-APP_SPEC_PASSWORD=xxxx-xxxx-xxxx-xxxx
-```
-
-Generate the app-specific password at https://account.apple.com/account/manage/section/security → **App-Specific Passwords** → **Generate Password**. Treat it like a secret. If either env var is missing, the validation step is skipped silently and you can still drag the IPA into Transporter manually.
-
-### Troubleshooting `make appstore` after a fresh Xcode install
-
-A fresh Xcode install (e.g. upgrading 26.4.1 → 26.5 via the `.xip` from developer.apple.com) wipes the local Apple ID account, the provisioning profiles folder, and the SDK stat caches. `make appstore` will then fail with one of the errors below. The fix is sequential, do them in this order:
-
-1. **`error: No Accounts: Add a new account in Accounts settings.`**
-   Open Xcode → `cmd+,` → **Accounts** → click **+** → **Apple ID** → log in with the developer account. Your paid team (`R477R8NK27` in our case) appears automatically because the certs are already in the Keychain.
-
-2. **`No provisioning profiles found when trying to codesign the app.`**
-   Run `make renew`. This regenerates the iOS App Development profiles in `~/Library/Developer/Xcode/UserData/Provisioning Profiles/`. Verify with `make check-profiles`.
-
-3. **`ERROR: no App Store provisioning profile for com.mirkobozzetto.flowflow.`**
-   `make renew` only creates *development* profiles. The App Store *distribution* profiles must be downloaded manually from Apple Developer Portal:
-   - Go to https://developer.apple.com/account/resources/profiles/list
-   - Click **FlowFlow App Store** → **Download** → double-click the `.mobileprovision` to install it
-   - Repeat for **flowflow recording-widget**
-   - Verify: `ls ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/` should show 4 files (2 dev + 2 App Store)
-
-4. **`ClangStatCache failed with a nonzero exit code`**
-   Xcode 26.5 fresh install sometimes corrupts its SDK stat cache. Wipe it:
-   ```bash
-   rm -rf ~/Library/Developer/Xcode/DerivedData
-   rm -rf /var/folders/*/C/com.apple.DeveloperTools/26.5-*/Xcode/SDKStatCaches.noindex/
-   sudo chown -R $USER ~/Library/Developer/Xcode/DerivedData 2>/dev/null
-   ```
-   Xcode will rebuild the cache on the next invocation.
-
-5. **`Ce build utilise une version bêta de Xcode et ne peut donc pas être soumis.`** (ASC submission error)
-   The currently-active Xcode is older than the latest stable release. Update to the newest stable Xcode (App Store first, fallback to `.xip` download at https://developer.apple.com/download/all/?q=xcode), then `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` and rebuild.
-
-### Glossary
-
-- **IPA** — iOS App Archive. A signed `.ipa` is the zipped, signed bundle Apple accepts. `make appstore` builds it.
-- **ASC** — [App Store Connect](https://appstoreconnect.apple.com). Apple's web dashboard to upload builds, fill metadata, attach screenshots, and submit for review.
-- **Transporter** — [free Mac app](https://apps.apple.com/app/transporter/id1450874784) to upload an `.ipa` to ASC.
-- **Provisioning profile** — Apple signed file that authorizes your bundle ID + cert combo. Generated once at [developer.apple.com](https://developer.apple.com/account/resources/profiles/list).
-- **CFBundleVersion / CFBundleShortVersionString** — build number (must increment every upload) and user-visible version (e.g. `1.0.0`).
-- **Bundle ID** — unique app identifier (`com.mirkobozzetto.flowflow`). Tied to the provisioning profile.
-
-### Manual steps before submitting for review
-
-Everything below has to be done by hand in the App Store Connect web UI or on the simulator. Tooling cannot automate these.
-
-1. **Generate 2 review-only API keys, capped at $5 each.** Create dedicated keys (not your prod keys) for the Apple reviewer, with hard spending limits. Revoke after approval.
-   - OpenAI key: https://platform.openai.com/api-keys → spending cap at https://platform.openai.com/settings/organization/limits
-   - Soniox key: https://console.soniox.com/api-keys → top up $5 prepaid credit
-
-2. **Capture screenshots on the iOS simulator** (1284 × 2778 for iPhone 6.5" slot, or 1320 × 2868 for 6.9").
-   ```bash
-   xcrun simctl boot "iPhone 17 Pro Max"
-   xcrun simctl io booted screenshot slot-1.png
-   ```
-   Take 3 to 4 screens showing the app in English. Upload them in the iPhone slot on the ASC version page (see Quick links below).
-
-3. **Fill App Review Information** (bottom of the ASC version page):
-   - **Contact**: your first name, last name, email, phone number.
-   - **Sign-in required**: check the box, then paste the 2 review API keys + setup instructions in the Notes field. Template:
-     ```
-     FlowFlow requires 2 API keys for AI features:
-     - Soniox API Key: <paste review key>
-     - OpenAI API Key: <paste review key>
-
-     Setup: launch app → Settings (gear icon) → paste both keys.
-     AI consent screen appears on first launch, tap "Enable".
-     Microphone permission requested on first recording.
-     Keys will be revoked after approval. Please limit testing to ~5-10 transcriptions/queries.
-     ```
-
-4. **Click "Add for Review"** (top right of the version page) once every section shows a green check, then **"Submit for Review"** on the next screen. Apple usually responds within 24 to 48 hours.
-
-### Quick links (App Store dashboards)
-
-| Where | URL |
-|-------|-----|
-| App Store Connect — FlowFlow distribution | https://appstoreconnect.apple.com/apps/6773033233/distribution |
-| ASC — App Information (name, subtitle, primary language, category) | https://appstoreconnect.apple.com/apps/6773033233/distribution/info |
-| ASC — Version page (description, promo text, keywords, support URL, copyright) | https://appstoreconnect.apple.com/apps/6773033233/distribution/ios/version/inflight |
-| ASC — Privacy (policy URL + nutrition labels) | https://appstoreconnect.apple.com/apps/6773033233/distribution/privacy |
-| ASC — Age rating questionnaire | https://appstoreconnect.apple.com/apps/6773033233/distribution/ratings/ios |
-| ASC — Pricing and availability | https://appstoreconnect.apple.com/apps/6773033233/distribution/pricing |
-| ASC — Submit for review | https://appstoreconnect.apple.com/apps/6773033233/distribution/reviewsubmissions |
-| Apple Developer Portal (certs + profiles) | https://developer.apple.com/account |
-| OpenAI API keys + spending limits | https://platform.openai.com/api-keys |
-| Soniox console (API keys, billing) | https://console.soniox.com |
-| Privacy policy (live, GitHub Pages) | https://mirkobozzetto.github.io/flowflow-privacy/ |
-| Privacy policy source repo | https://github.com/mirkobozzetto/flowflow-privacy |
-
-### Push an update (continuous releases)
-
-Workflow once the app is live on the Store:
-
-1. Bump `CFBundleVersion` in `Makefile` (line 74) by `+1`. ASC rejects duplicate build numbers. Bump `CFBundleShortVersionString` only on user-visible releases (e.g. `1.0.0` → `1.0.1`).
-2. `make appstore` → fresh signed `FlowFlow.ipa`.
-3. Open Transporter → drag the `.ipa` → Deliver. Apple processes the build (5–30 min).
-4. ASC → your app → **TestFlight or App Store tab** → attach the new build to the current version, or create a new version (`+ Version` button) if you bumped the short version string.
-5. Update locale-specific metadata (description, keywords, screenshots) if needed — see *Multilingual releases* below.
-6. **Submit for Review**. Apple usually answers within 24h.
-
-### Multilingual releases
-
-The app auto-detects the iPhone system language at boot (NSLocale) and falls back to English. Users can switch language any time via Settings → Langue / Language. Supported locales: `en`, `fr`.
-
-For ASC: add **English (U.S.)** and **French (France)** under App Information → Localizations. Each locale needs its own screenshots (iPhone 6.9", 1320×2868), description, and keywords. Upload locale screenshots separately in each language tab.
+| Chapter | What you find there |
+|---------|---------------------|
+| [01 Product](docs/INDEX.md#01-product) | Vision, features, history of what shipped |
+| [02 Architecture](docs/INDEX.md#02-architecture) | Modules, pipelines, data model |
+| [03 Dev guides](docs/INDEX.md#03-dev-guides) | Build, device setup, tests |
+| [04 App Store](docs/guides/appstore.md) | Provisioning, signing, submission, troubleshooting |
+| [05 Specs](docs/INDEX.md#05-specs) | RFCs and PRDs (sync, backup, realtime UX) |
+| [06 History](docs/HISTORY.md) | Chronological log of every milestone |
 
 ## Tests
 
@@ -250,7 +103,7 @@ cargo test -- --ignored
 
 ## Status
 
-Actively developed. The codebase evolves constantly — new features, better architecture, and deeper iOS integration land regularly.
+Actively developed. The codebase evolves constantly - new features, better architecture, and deeper iOS integration land regularly.
 
 ## Contributing
 
@@ -258,4 +111,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Copyright 2026 Mirko Bozzetto — [EUPL v1.2](LICENSE)
+Copyright 2026 Mirko Bozzetto - [EUPL v1.2](LICENSE)

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,0 +1,47 @@
+# FlowFlow history
+
+> Everything that shipped, oldest first. One block per milestone, updated with each significant merged PR.
+
+## 2026-05 - Foundations (Tracks A-D)
+
+Dioxus iOS scaffold, mic capture (cpal + hound, WAV), Soniox REST transcription, SQLite storage, Tailwind V4 UI. The 5-layer architecture (models / db / services / platform / ui) lands here.
+
+## 2026-05 - RAG and chat (Track E)
+
+OpenAI embeddings + LanceDB on device, auto-embed on save, in-app Settings for API keys, tag chips with LLM auto-gen, chat UI with RAG pipeline and source citations, persistent conversations with sidebar tabs.
+
+## 2026-05 - Agent and providers (Track F)
+
+Migration to rig-core: agent tools (search_notes, create_note, summarize_folder), unified reqwest, Anthropic as second chat provider.
+
+## 2026-05 - Document attachments (Track G)
+
+SQLite V3 migration, attachment cards + modal viewer, native iOS file picker, PDF (pdf-extract, then PDFKit with OCR) and DOCX (zip + quick-xml) parsing, auto-embed of imported documents.
+
+## 2026-05 - Architecture and audio rewrite (PR #3, #4)
+
+SRP refactoring (6 files -> 22 then 64 modules), audio player (AVAudioPlayer FFI, V4 migration, WAV lifecycle), recording UX fixes, orange rebrand (#E85D0A) and gear icon, EUPL 1.2.
+
+## 2026-05 - Multi-audio and i18n
+
+V5/V6 migrations, multiple audios per note, chat scope per folder, smart mic routing, FR/EN i18n (fluent, 96+ keys, system-language detection).
+
+## 2026-06 - App Store v1.0
+
+Release pipeline (make appstore: distribution signing, IPA, validator green), CFBundleVersion auto-bump, screenshots, AI consent screen, review API keys flow. v1.0 approved and live (non-EU; EU pending DSA trader verification). See [guides/appstore.md](guides/appstore.md).
+
+## 2026-06 - Smart reminders (RFC 0003)
+
+LLM detection of reminder intents in notes ("pick up the kids at 5pm"), EventKit integration, one-tap confirm, recurrence basics. Device-validated.
+
+## 2026-06 - Multidevice sync (RFC 0004)
+
+Encrypted LAN P2P sync iPhone <-> Mac: Noise XXpsk3 over TCP, pairing by code/QR, version-vector merge, tombstones + GC, full-state reconcile, conflict policy, sync triggers, at-rest protection. SQLite V10. 200+ tests. See [rfcs/0004-multidevice-sync/](rfcs/0004-multidevice-sync/).
+
+## 2026-06 - Desktop app hardening (PR #20)
+
+Mac build without the iOS widget, durable data dir in Application Support.
+
+## 2026-06 - Sync realtime UX (PRD sync-realtime-ux, issues #22 #23 #24)
+
+Real-time UI refresh after inbound sync (< 1 s, global data-version signal), edit-collision banner with zero keystroke loss, full safe-area support (viewport-fit=cover, top + bottom insets), QR pairing via the flowflow:// URL scheme (camera scan -> prefilled one-tap confirm, cold-start included). Device-validated. See [prd/sync-realtime-ux/](prd/sync-realtime-ux/).

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,45 @@
+# FlowFlow documentation index
+
+> The README is the showcase; this is the map. One line per document, grouped by chapter.
+
+## 01 Product
+
+- [README](../README.md) - pitch, features, stack, quick start
+- [HISTORY](HISTORY.md) - chronological log of every shipped milestone
+- [Roadmap](roadmap/) - what comes next (post-RFC-0004 plan)
+- [Stories](stories/) - debugging war stories worth keeping
+
+## 02 Architecture
+
+- [CLAUDE.md](../CLAUDE.md) - the living architecture reference: modules, data entities, pipelines, stack versions
+- [Brainstorm](brainstorm/) - deep dives and explorations (system audio, imports)
+
+## 03 Dev guides
+
+- Build and run: see [README - Setup](../README.md#setup) and [README - Commands](../README.md#commands)
+- Physical device setup (one-time pairing, certificates): [CLAUDE.md - Physical Device Setup](../CLAUDE.md)
+- Tests: `cargo test` (208 tests), `cargo test -- --ignored` for API-key-gated ones
+
+## 04 App Store
+
+- [App Store guide](guides/appstore.md) - provisioning, signing, IPA, submission, troubleshooting, quick links
+- [Deploy notes](deploy/) - fresh setup, submission walkthrough, execution plan, Dioxus workarounds
+
+## 05 Specs
+
+- [RFCs](rfcs/) - technical designs: 0001 data backup/export, 0004 multidevice sync
+- [PRDs](prd/) - product specs: multidevice-sync, sync-realtime-ux, data-backup-export
+
+## 06 History
+
+- [HISTORY.md](HISTORY.md) - everything that shipped, by milestone, with links
+
+---
+
+## Doc rules (how to keep this readable)
+
+1. The README is a showcase: hard ceiling ~100 lines, no ops content, no troubleshooting.
+2. Anything longer goes into `docs/` and gets ONE line in this index, in the right chapter.
+3. `HISTORY.md` gets one entry per significant merged PR (3-4 lines, date + links). Update it in the same PR.
+4. Never duplicate content between README, INDEX, and guides; link instead.
+5. New chapter only when an existing one clearly does not fit. Prefer fewer, fuller chapters.

--- a/docs/guides/appstore.md
+++ b/docs/guides/appstore.md
@@ -1,0 +1,140 @@
+# iOS provisioning and App Store distribution
+
+> Moved out of the README to keep it slim. Everything operational about signing, provisioning, and shipping to the App Store lives here.
+
+## iOS Device Provisioning
+
+Running on a physical iPhone requires a valid provisioning profile. Apple enforces code signing for all device builds.
+
+**Free Apple account**: profiles expire after 7 days. **Paid Apple Developer Program** (€99/year): profiles last 1 year, plus App Store and TestFlight access.
+
+`make all` auto-detects expiry < 24h and runs `make renew` before building. Renewal uses a minimal Xcode project template under `tools/provision-renew/` invoked via `xcodebuild -allowProvisioningUpdates`. Zero manual Xcode GUI required.
+
+```bash
+make check-profiles  # show expiration dates
+make renew           # regenerate now
+```
+
+**On your iPhone** (first time only): Settings → General → VPN & Device Management → tap your developer certificate → Trust.
+
+Once your paid Apple Developer Program is active, profiles last 1 year and `make renew` becomes a once-a-year operation.
+
+## App Store distribution
+
+`make appstore` produces a `FlowFlow.ipa` that passes Apple's validator with zero errors. The Dioxus CLI omits several keys required for App Store distribution (`CFBundlePackageType`, `DT*`, widget `UIRequiredDeviceCapabilities`, ...) and uses a `ditto` invocation that strips the `Payload/` directory; the Makefile patches all of these. Full breakdown of every Apple validation error we hit and the corresponding fix: [../deploy/04-dioxus-app-store-workarounds.md](../deploy/04-dioxus-app-store-workarounds.md). Upstream tracking: [Dioxus issue #3817](https://github.com/DioxusLabs/dioxus/issues/3817).
+
+End-to-end submission walkthrough: [../deploy/02-app-store-submission.md](../deploy/02-app-store-submission.md). Sequential execution plan: [../deploy/03-execution-plan.md](../deploy/03-execution-plan.md).
+
+### Optional: server-side IPA validation
+
+`make appstore` can call `xcrun altool --validate-app` against Apple's servers after the IPA is built, so you catch rejections (missing keys, wrong cert, version conflict) before opening Transporter. Add these to `.env`:
+
+```
+APPLE_ID=you@example.com
+APP_SPEC_PASSWORD=xxxx-xxxx-xxxx-xxxx
+```
+
+Generate the app-specific password at https://account.apple.com/account/manage/section/security → **App-Specific Passwords** → **Generate Password**. Treat it like a secret. If either env var is missing, the validation step is skipped silently and you can still drag the IPA into Transporter manually.
+
+### Troubleshooting `make appstore` after a fresh Xcode install
+
+A fresh Xcode install (e.g. upgrading 26.4.1 → 26.5 via the `.xip` from developer.apple.com) wipes the local Apple ID account, the provisioning profiles folder, and the SDK stat caches. `make appstore` will then fail with one of the errors below. The fix is sequential, do them in this order:
+
+1. **`error: No Accounts: Add a new account in Accounts settings.`**
+   Open Xcode → `cmd+,` → **Accounts** → click **+** → **Apple ID** → log in with the developer account. Your paid team (`R477R8NK27` in our case) appears automatically because the certs are already in the Keychain.
+
+2. **`No provisioning profiles found when trying to codesign the app.`**
+   Run `make renew`. This regenerates the iOS App Development profiles in `~/Library/Developer/Xcode/UserData/Provisioning Profiles/`. Verify with `make check-profiles`.
+
+3. **`ERROR: no App Store provisioning profile for com.mirkobozzetto.flowflow.`**
+   `make renew` only creates *development* profiles. The App Store *distribution* profiles must be downloaded manually from Apple Developer Portal:
+   - Go to https://developer.apple.com/account/resources/profiles/list
+   - Click **FlowFlow App Store** → **Download** → double-click the `.mobileprovision` to install it
+   - Repeat for **flowflow recording-widget**
+   - Verify: `ls ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/` should show 4 files (2 dev + 2 App Store)
+
+4. **`ClangStatCache failed with a nonzero exit code`**
+   Xcode 26.5 fresh install sometimes corrupts its SDK stat cache. Wipe it:
+   ```bash
+   rm -rf ~/Library/Developer/Xcode/DerivedData
+   rm -rf /var/folders/*/C/com.apple.DeveloperTools/26.5-*/Xcode/SDKStatCaches.noindex/
+   sudo chown -R $USER ~/Library/Developer/Xcode/DerivedData 2>/dev/null
+   ```
+   Xcode will rebuild the cache on the next invocation.
+
+5. **`Ce build utilise une version bêta de Xcode et ne peut donc pas être soumis.`** (ASC submission error)
+   The currently-active Xcode is older than the latest stable release. Update to the newest stable Xcode (App Store first, fallback to `.xip` download at https://developer.apple.com/download/all/?q=xcode), then `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` and rebuild.
+
+### Glossary
+
+- **IPA** - iOS App Archive. A signed `.ipa` is the zipped, signed bundle Apple accepts. `make appstore` builds it.
+- **ASC** - [App Store Connect](https://appstoreconnect.apple.com). Apple's web dashboard to upload builds, fill metadata, attach screenshots, and submit for review.
+- **Transporter** - [free Mac app](https://apps.apple.com/app/transporter/id1450874784) to upload an `.ipa` to ASC.
+- **Provisioning profile** - Apple signed file that authorizes your bundle ID + cert combo. Generated once at [developer.apple.com](https://developer.apple.com/account/resources/profiles/list).
+- **CFBundleVersion / CFBundleShortVersionString** - build number (must increment every upload) and user-visible version (e.g. `1.0.0`).
+- **Bundle ID** - unique app identifier (`com.mirkobozzetto.flowflow`). Tied to the provisioning profile.
+
+### Manual steps before submitting for review
+
+Everything below has to be done by hand in the App Store Connect web UI or on the simulator. Tooling cannot automate these.
+
+1. **Generate 2 review-only API keys, capped at $5 each.** Create dedicated keys (not your prod keys) for the Apple reviewer, with hard spending limits. Revoke after approval.
+   - OpenAI key: https://platform.openai.com/api-keys → spending cap at https://platform.openai.com/settings/organization/limits
+   - Soniox key: https://console.soniox.com/api-keys → top up $5 prepaid credit
+
+2. **Capture screenshots on the iOS simulator** (1284 × 2778 for iPhone 6.5" slot, or 1320 × 2868 for 6.9").
+   ```bash
+   xcrun simctl boot "iPhone 17 Pro Max"
+   xcrun simctl io booted screenshot slot-1.png
+   ```
+   Take 3 to 4 screens showing the app in English. Upload them in the iPhone slot on the ASC version page (see Quick links below).
+
+3. **Fill App Review Information** (bottom of the ASC version page):
+   - **Contact**: your first name, last name, email, phone number.
+   - **Sign-in required**: check the box, then paste the 2 review API keys + setup instructions in the Notes field. Template:
+     ```
+     FlowFlow requires 2 API keys for AI features:
+     - Soniox API Key: <paste review key>
+     - OpenAI API Key: <paste review key>
+
+     Setup: launch app → Settings (gear icon) → paste both keys.
+     AI consent screen appears on first launch, tap "Enable".
+     Microphone permission requested on first recording.
+     Keys will be revoked after approval. Please limit testing to ~5-10 transcriptions/queries.
+     ```
+
+4. **Click "Add for Review"** (top right of the version page) once every section shows a green check, then **"Submit for Review"** on the next screen. Apple usually responds within 24 to 48 hours.
+
+### Quick links (App Store dashboards)
+
+| Where | URL |
+|-------|-----|
+| App Store Connect - FlowFlow distribution | https://appstoreconnect.apple.com/apps/6773033233/distribution |
+| ASC - App Information (name, subtitle, primary language, category) | https://appstoreconnect.apple.com/apps/6773033233/distribution/info |
+| ASC - Version page (description, promo text, keywords, support URL, copyright) | https://appstoreconnect.apple.com/apps/6773033233/distribution/ios/version/inflight |
+| ASC - Privacy (policy URL + nutrition labels) | https://appstoreconnect.apple.com/apps/6773033233/distribution/privacy |
+| ASC - Age rating questionnaire | https://appstoreconnect.apple.com/apps/6773033233/distribution/ratings/ios |
+| ASC - Pricing and availability | https://appstoreconnect.apple.com/apps/6773033233/distribution/pricing |
+| ASC - Submit for review | https://appstoreconnect.apple.com/apps/6773033233/distribution/reviewsubmissions |
+| Apple Developer Portal (certs + profiles) | https://developer.apple.com/account |
+| OpenAI API keys + spending limits | https://platform.openai.com/api-keys |
+| Soniox console (API keys, billing) | https://console.soniox.com |
+| Privacy policy (live, GitHub Pages) | https://mirkobozzetto.github.io/flowflow-privacy/ |
+| Privacy policy source repo | https://github.com/mirkobozzetto/flowflow-privacy |
+
+### Push an update (continuous releases)
+
+Workflow once the app is live on the Store:
+
+1. Bump `CFBundleVersion` in `Makefile` (line 74) by `+1`. ASC rejects duplicate build numbers. Bump `CFBundleShortVersionString` only on user-visible releases (e.g. `1.0.0` → `1.0.1`).
+2. `make appstore` → fresh signed `FlowFlow.ipa`.
+3. Open Transporter → drag the `.ipa` → Deliver. Apple processes the build (5-30 min).
+4. ASC → your app → **TestFlight or App Store tab** → attach the new build to the current version, or create a new version (`+ Version` button) if you bumped the short version string.
+5. Update locale-specific metadata (description, keywords, screenshots) if needed - see *Multilingual releases* below.
+6. **Submit for Review**. Apple usually answers within 24h.
+
+### Multilingual releases
+
+The app auto-detects the iPhone system language at boot (NSLocale) and falls back to English. Users can switch language any time via Settings → Langue / Language. Supported locales: `en`, `fr`.
+
+For ASC: add **English (U.S.)** and **French (France)** under App Information → Localizations. Each locale needs its own screenshots (iPhone 6.9", 1320×2868), description, and keywords. Upload locale screenshots separately in each language tab.

--- a/docs/prd/sync-realtime-ux/contract.md
+++ b/docs/prd/sync-realtime-ux/contract.md
@@ -1,0 +1,51 @@
+---
+artifact: "docs/prd/sync-realtime-ux/"
+artifact_kind: "prd"
+locked: "2026-06-10"
+---
+
+# Definition of Done: Real-time sync experience and cross-device UI polish
+
+> Immutable target. Every item below is a concrete, checkable condition the final verification bundle validates against. Requirement changes get a NEW entry; never silently rewrite an existing line.
+
+## Acceptance criteria (the contract)
+
+| # | Criterion (from spec) | Source | Validated by |
+|---|------------------------|--------|--------------|
+| C1 | Given any data view open, when an inbound sync applies >= 1 change, then the view reflects the new data in under ~1 s (no restart, no manual action) | prd.md US1 | device test: 10 timed trials, both directions |
+| C2 | Given the inbound change arrived via the background listener, when applied, then the refresh happens exactly as for a user-triggered sync | prd.md US1 | integration test on the three bump paths + device test |
+| C3 | Given a sync pass applies zero changes, when it completes, then no visible refresh or flicker occurs | prd.md US1 | test asserting no bump on zero-change pass + visual check |
+| C4 | Given a full-state reconcile applies many rows in bursts, when it runs, then the UI refreshes smoothly (debounced, no freeze) | prd.md US1 | restore-scenario device test |
+| C5 | Given the open note detail has NO unsaved edits, when an inbound sync updates that note, then the detail reloads silently | prd.md US2 | device test: edit on iPhone, Mac detail updates in place |
+| C6 | Given the open note detail HAS unsaved edits, when an inbound sync updates that note, then a non-blocking banner appears, editor untouched, tap reloads the merged note | prd.md US2 | device test: typed text intact, banner tap shows merged content |
+| C7 | Given the banner is shown and the user keeps typing and saves, when the save completes, then zero keystrokes are lost (normal merge path) | prd.md US2 | 5 deliberate collision tests, 0 lost characters |
+| C8 | Given any view on a home-indicator iPhone, when displayed, then bottom content and controls are fully visible and tappable above the home indicator | prd.md US3 | visual sweep checklist, every view |
+| C9 | Given the on-screen keyboard closes, when it does, then no white band or clipped zone remains at the bottom | prd.md US3 | device test after keyboard close |
+| C10 | Given the same build on macOS, when displayed, then the layout is unchanged (no spurious bottom padding) | prd.md US3 | desktop visual check, all views |
+| C11 | Given the Mac shows the pairing QR, when the iPhone scans it, then the app opens/foregrounds with the pairing screen prefilled and pairing completes after one confirmation | prd.md US4 | full pairing Mac <-> iPhone < 30 s, zero copy-paste |
+| C12 | Given the app is cold, when the QR is scanned, then the pairing data still reaches the pairing screen (cold-start verified or in-app scanner covers it) | prd.md US4 | cold-start spike result recorded in trace |
+| C13 | Given the scan path fails, when the user falls back, then copy-paste pairing still works (never removed) | prd.md US4 | camera-permission-denied pairing test |
+| C14 | Full existing test suite (205 tests) passes; fmt + clippy clean; make all and make desktop-app build and install | prd.md success metrics | cargo test, make check, make all, make desktop-app all exit 0 |
+| C15 | Sync invariants (zero data loss, convergence, RFC 0004 protocol/merge/GC) untouched | prd.md constraints | existing sync test suite green, no protocol file regression |
+
+## Out of scope (never build)
+
+- Full desktop UX / responsive overhaul (issue #25, separate PRD)
+- README slimming, docs index, landing page (issue #26)
+- Audio file sync (descoped from sync v1)
+- Android support
+- Multi-user collaboration or any third-party backend
+- Push-style instant sync (sync triggers stay as shipped in RFC 0004)
+
+## Edit scope
+
+- src/main.rs (launch config: custom index.html, app-level Event::Opened handler)
+- src/ui/mod.rs (root layout, keyboard handler)
+- src/ui/state.rs (data-version signal, pairing prefill state)
+- src/ui/note_list.rs, src/ui/sidebar.rs, src/ui/note_detail.rs, src/ui/chat.rs (signal subscription + safe-area sweep)
+- src/services/sync/engine.rs (bump points: manual pass, served session, post-reconcile)
+- pairing module (URI parsing reuse) + pairing/sync screen UI
+- src/platform/ios.rs (AVFoundation FFI only if the in-app scanner path is needed)
+- Makefile + scripts/ (CFBundleURLTypes post-build plist injection)
+- tailwind.css (safe-area utilities)
+- tests/ (refresh-signal assertions)

--- a/docs/prd/sync-realtime-ux/prd.md
+++ b/docs/prd/sync-realtime-ux/prd.md
@@ -1,0 +1,196 @@
+---
+feature: Real-time sync experience and cross-device UI polish
+slug: sync-realtime-ux
+type: prd
+status: ready
+stepsCompleted: [0, 1, 2, 3, 4]
+issues: [22, 23, 24]
+---
+
+# PRD - Real-time sync experience and cross-device UI polish
+
+## Problem statement
+
+Multi-device LAN sync (RFC 0004) shipped and works end to end at the data level:
+pairing, encrypted bidirectional sync, merge, tombstones, GC, full-state
+reconcile, all validated on real devices (iPhone <-> Mac). But the EXPERIENCE
+around it is unfinished. Three gaps, observed during real device testing and
+tracked as GitHub issues:
+
+1. **No real-time refresh (#22).** After an inbound sync the data is in SQLite
+   but the UI keeps showing stale state until the app is quit and relaunched.
+   The user watched 25 notes land in the Mac database while the Mac window
+   showed nothing new. The SyncEngine already exposes `SyncActivity`
+   (Idle / Syncing / Done{applied} / Error) and the UI already polls it for the
+   activity indicator; nothing makes the data views react.
+
+2. **Bottom-of-screen cut on iPhone (#23).** On home-indicator iPhones the last
+   line of content and bottom controls are clipped or covered by a white band.
+   The bottom safe-area inset is not honored by the root layout. Root cause is
+   verified: the default Dioxus 0.7.7 viewport meta lacks `viewport-fit=cover`,
+   so `env(safe-area-inset-*)` evaluates to 0 inside the WKWebView, and the one
+   existing safe-area padding in the app is a silent no-op.
+
+3. **QR pairing does not work (#24).** Scanning the pairing QR with the iPhone
+   camera fails ("no usable data found") because the `flowflow://` URL scheme
+   is not registered. Copy-pasting the URI is the only working path, which is
+   not an acceptable pairing experience between a Mac and an iPhone.
+
+Why now: sync is the headline feature of the next release. Shipping it with a
+stale UI, a clipped layout, and broken QR pairing undermines the feature users
+will judge first.
+
+## Goals
+
+- A change synced from the other device is visible on screen in under ~1 s,
+  with no app restart and no manual action, on both iOS and macOS.
+- In-progress local edits are never silently overwritten by an inbound sync
+  (zero-data-loss prime directive extends to screen state).
+- On home-indicator iPhones, all bottom content and controls are fully visible
+  above the home indicator in every view.
+- Pairing two devices requires scanning the QR code and confirming, with no
+  manual copy-paste of the URI.
+
+## Non-goals / Out-of-scope
+
+- Full desktop UX / responsive overhaul (issue #25, separate PRD).
+- README slimming, docs index, landing page (issue #26 and follow-ups).
+- Audio file sync (descoped from sync v1, unchanged).
+- Android support.
+- Multi-user collaboration or any third-party backend.
+- Push-style instant sync between devices (sync triggers stay as shipped in
+  RFC 0004; this PRD only makes the UI react to what sync already applies).
+
+## User stories
+
+### US1 - Live refresh after inbound sync
+As a FlowFlow user with two paired devices, I want data synced from the other
+device to appear on my screen immediately, so that I never wonder whether sync
+worked or have to restart the app.
+
+Acceptance criteria:
+- Given the app is open on any data view (notes list, sidebar folders and
+  conversations, note detail, chat, reminders), when an inbound sync applies at
+  least one change, then the visible view reflects the new data in under ~1 s.
+- Given the inbound change arrived through the background listener (the other
+  device pushed), when it is applied, then the refresh happens exactly as it
+  does for a user-triggered sync (both paths covered).
+- Given a sync pass applies zero changes, when it completes, then no visible
+  refresh or flicker occurs.
+- Given a full-state reconcile applies many rows in bursts, when it runs, then
+  the UI refreshes smoothly (no refresh storm, no frozen UI).
+
+### US2 - Never clobber an edit in progress
+As a user typing in a note while an inbound sync updates that same note, I want
+to be warned instead of having my editor replaced, so that I never lose what I
+am typing.
+
+Acceptance criteria:
+- Given the open note detail has NO unsaved local edits, when an inbound sync
+  updates that note, then the detail reloads silently with the new content.
+- Given the open note detail HAS unsaved local edits, when an inbound sync
+  updates that note, then a non-blocking banner appears ("Note updated from
+  another device"), the editor content is untouched, and tapping the banner
+  reloads the merged note.
+- Given the banner is shown and the user keeps typing and saves, when the save
+  completes, then the local edit is persisted through the normal merge path and
+  no keystrokes are lost.
+
+### US3 - Bottom safe-area respected on iPhone
+As an iPhone user, I want every view to keep its bottom content above the home
+indicator, so that nothing is clipped or hidden.
+
+Acceptance criteria:
+- Given any view (notes list, note detail, chat, settings, sync screen), when
+  displayed on a home-indicator iPhone, then the last line of content and all
+  bottom controls are fully visible and tappable above the home indicator.
+- Given the on-screen keyboard opens, when it closes, then no white band or
+  clipped zone remains at the bottom.
+- Given the same build runs on macOS desktop, when displayed, then the layout
+  is unchanged (no spurious bottom padding on devices without insets).
+
+### US4 - Pair by scanning the QR code
+As a user pairing my iPhone with my Mac, I want to scan the QR code shown on
+the Mac and confirm, so that I never copy-paste a pairing URI by hand.
+
+Acceptance criteria:
+- Given the Mac shows the pairing QR, when the iPhone scans it (system camera
+  via the registered `flowflow://` scheme, or the in-app scanner if the scheme
+  path fails the spike), then the iOS app opens or foregrounds with the pairing
+  screen prefilled and pairing completes after one confirmation.
+- Given the app is cold (not running), when the QR is scanned, then the pairing
+  data still reaches the pairing screen (cold-start delivery verified or the
+  in-app scanner covers it).
+- Given the scan path fails for any reason, when the user falls back, then the
+  existing copy-paste path still works (kept as a fallback, never removed).
+
+## Settled decisions
+
+These were the three open points; all are settled with verified evidence
+(Exa research, 2026-06-10).
+
+1. **Refresh mechanism: one global data-version signal, all data views react.**
+   A single reactive version counter bumped after any inbound apply with
+   `applied > 0` (manual sync button AND background listener path, including
+   post-reconcile), debounced so reconcile bursts coalesce. All data views
+   (list, sidebar, detail, chat, reminders) subscribe. Per-entity targeted
+   invalidation is rejected for v1: more surface for staleness bugs, no
+   measured need at FlowFlow's data scale. The open note detail applies the
+   US2 smart rule (silent reload vs banner) on top of the global signal.
+
+2. **QR pairing: register the `flowflow://` scheme, in-app scanner as the
+   committed fallback.** Verified: Dioxus 0.7 runs on tao; the lockfile has
+   tao 0.34.8 which implements `application:openURL:options:` on iOS and emits
+   `Event::Opened { urls }` (tauri-apps/tao commit ad652e5), and dioxus-desktop
+   0.7.7 forwards every tao event to app-level handlers before its own match
+   (`app.tick()` -> `event_handlers.apply_event`), so the app can receive the
+   URL. Scheme registration goes through `CFBundleURLTypes` in Info.plist
+   (post-build injection, same pattern as the existing icon injection). One
+   spike remains: cold-start delivery when the app is not running. If the spike
+   fails, the v1 path becomes the in-app QR scanner on the iPhone pairing
+   screen (camera via AVFoundation FFI); the scheme stays registered as a
+   nice-to-have. Copy-paste remains as last-resort fallback either way.
+
+3. **Safe-area: pure CSS via `env(safe-area-inset-*)`, enabled by fixing the
+   viewport meta.** Verified: the default dioxus-desktop 0.7.7 index.html
+   viewport meta lacks `viewport-fit=cover`, so the WKWebView reports inset 0.
+   Dioxus exposes `Config::with_custom_index` to control the full index.html.
+   With `viewport-fit=cover` set, `env(safe-area-inset-bottom)` works in pure
+   CSS and applies uniformly; macOS reports 0 insets so desktop is unaffected.
+   Per-platform Rust-side padding adjustments are rejected: CSS env() is the
+   platform-native mechanism and needs no platform branching.
+
+## Success metrics
+
+- Inbound change visible on screen in < 1 s after apply completes, measured on
+  real iPhone and Mac (manual stopwatch over 10 trials, all < 1 s).
+- 0 lost keystrokes across 5 deliberate edit-during-sync collisions on device.
+- 0 clipped or hidden bottom controls across all views on a home-indicator
+  iPhone (visual sweep checklist, every view passes).
+- Pairing two devices via QR completes in < 30 s with 0 manual copy-paste.
+- 0 regressions: full existing test suite (205 tests) still passes; sync
+  invariants (zero data loss, convergence) untouched.
+- All acceptance criteria validated on real devices (iPhone + Mac), not only
+  simulator.
+
+## Constraints and assumptions
+
+- 100% Rust, zero JS/TS. UI is Dioxus 0.7 (tao 0.34.8 / wry 0.53.5 locked).
+- Targets: iOS (primary) + macOS desktop app. Behavior must be correct on both.
+- Zero data loss; any migration is non-destructive.
+- Must not break RFC 0004 sync (protocol, merge, GC) or the RAG pipeline.
+- No third-party backend; everything stays local / LAN P2P.
+- SyncEngine `SyncActivity` polling already exists and stays the integration
+  surface for the activity indicator; the refresh signal is additive.
+- Existing Makefile post-build plist injection is available for Info.plist
+  changes (used today for the icon).
+
+## Open questions
+
+- Cold-start open-URL delivery: does tao's `Event::Opened` fire when the app is
+  launched (not just foregrounded) by a `flowflow://` URL on iOS? Spike first;
+  the in-app scanner decision already covers a negative outcome.
+- Banner copy and placement for US2 (top of detail vs above keyboard): decide
+  during implementation with on-device feel; not blocking.
+- Whether the desktop Mac app needs the same banner rule (concurrent edit on
+  Mac while iPhone pushes): assumed yes for symmetry, confirm during testing.

--- a/docs/prd/sync-realtime-ux/tasks.md
+++ b/docs/prd/sync-realtime-ux/tasks.md
@@ -1,0 +1,49 @@
+---
+feature: Real-time sync experience and cross-device UI polish
+slug: sync-realtime-ux
+type: tasks
+source_prd: docs/prd/sync-realtime-ux/prd.md
+stepsCompleted: [0, 1, 2, 3]
+---
+
+> ⚠️ Do NOT implement. This is the derived task list. Run `ship` (or the implementer) to execute.
+
+## Relevant Files
+
+- `src/main.rs` - app launch; custom launch config entry point for the viewport fix
+- `src/ui/mod.rs` - root layout (h-screen, fixed bottom padding); keyboard handler
+- `src/ui/state.rs` - AppState; home of the new data-version signal
+- `src/ui/note_list.rs`, `src/ui/sidebar.rs`, `src/ui/note_detail.rs`, `src/ui/chat.rs` - data views that must subscribe to the refresh signal
+- `src/services/sync/engine.rs` - inbound apply completion points (manual pass, served session, reconcile) where the signal is bumped
+- `src/services/sync/pairing.rs` (or equivalent) - pairing URI parsing reused by the deep link / scanner path
+- `src/platform/ios.rs` - AVFoundation FFI home if the in-app scanner path is needed
+- `Makefile` + `scripts/` - post-build Info.plist injection pattern (CFBundleURLTypes)
+- `tailwind.css` - safe-area utility classes
+- `tests/` - sync engine tests extended with refresh-signal assertions
+
+## Tasks
+
+- [ ] 1.0 Safe-area foundation: bottom of screen fully visible on iPhone _(PRD: US3, decision 3)_
+  - [ ] 1.1 Enable real safe-area values: ship a custom index.html (viewport meta with `viewport-fit=cover`) through the launch config, identical behavior on iOS and desktop. Test: a debug element styled with `env(safe-area-inset-bottom)` shows a non-zero inset on the iPhone and zero on the Mac.
+  - [ ] 1.2 Replace the fixed bottom paddings in the root layout with safe-area-aware spacing, and sweep every view (notes list, note detail, chat, settings, sync screen) for bottom clipping. Test: on the iPhone, in each view, the last line and bottom controls are fully visible and tappable above the home indicator; no white band after keyboard close.
+  - [ ] 1.3 Desktop neutrality check. Test: same build on the Mac shows no added bottom gap in any view.
+
+- [ ] 2.0 Real-time refresh after inbound sync _(PRD: US1, decision 1)_
+  - [ ] 2.1 Introduce one global data-version signal in app state, bumped after every inbound apply with `applied > 0`: manual sync pass, background served session, and post-reconcile; debounced so reconcile bursts coalesce into one bump. Test: a unit/integration test asserts the bump fires on each of the three paths and not on a zero-change pass.
+  - [ ] 2.2 Subscribe all data views (notes list, sidebar folders + conversations, chat, reminders) to the signal so they re-query on bump. Test: with both apps open, create a note on the iPhone, run sync; the Mac list and sidebar show it in under ~1 s without any click; repeat in the other direction.
+  - [ ] 2.3 No-flicker and burst behavior. Test: a zero-change sync causes no visible refresh; a full-state reconcile (restore scenario) refreshes smoothly without freezing the UI.
+
+- [ ] 3.0 Smart open-detail handling: never clobber an edit in progress _(PRD: US2)_
+  - [ ] 3.1 Silent reload of the open note detail when it has no unsaved local edits and an inbound sync touched that note. Test: open the same note on both devices, edit on the iPhone, sync; the Mac detail updates in place in under ~1 s.
+  - [ ] 3.2 Non-destructive banner when local unsaved edits exist: "Note updated from another device", editor untouched, tap reloads the merged note. Test: type in the note on the Mac without saving, push an edit from the iPhone; the banner appears, the typed text is intact, tapping the banner shows the merged content.
+  - [ ] 3.3 Collision save path: saving after the banner goes through the normal merge with zero keystroke loss. Test: 5 deliberate edit-during-sync collisions on device, 0 lost characters (PRD metric).
+
+- [ ] 4.0 QR pairing without copy-paste _(PRD: US4, decision 2)_
+  - [ ] 4.1 Spike: register `CFBundleURLTypes` for `flowflow://` via the post-build plist injection and listen for the tao `Event::Opened { urls }` in an app-level event handler; verify delivery foregrounded AND cold-start on the real iPhone. Test: tapping a `flowflow://test` link opens the app and the URL reaches the handler in both states; result recorded in trace.
+  - [ ] 4.2 If the spike passes: wire the received pairing URI into the pairing screen (prefill + one-tap confirm), reusing the existing URI parser; iOS camera scan of the Mac QR opens the app on the pairing screen. Test: full pairing Mac <-> iPhone via camera scan in under 30 s, zero copy-paste.
+  - [ ] 4.3 If the spike fails: in-app QR scanner on the iPhone pairing screen (camera via AVFoundation FFI, permission prompt, scan -> prefill -> confirm). Test: same full-pairing test as 4.2 through the in-app scanner.
+  - [ ] 4.4 Keep copy-paste as the always-available fallback and make the pairing screen present the paths clearly. Test: with camera permission denied, pairing still completes via copy-paste.
+
+- [ ] 5.0 Device validation and regression pass _(PRD: success metrics)_
+  - [ ] 5.1 Full regression: existing test suite (205 tests) green, fmt + clippy clean, `make all` and `make desktop-app` build and install. Test: all commands exit 0.
+  - [ ] 5.2 Measured acceptance on real devices: 10 timed inbound-refresh trials all < 1 s, bottom-clipping sweep checklist all views pass, QR pairing < 30 s, 5 collision tests 0 loss. Test: each PRD success metric checked off with measured values recorded in the trace.

--- a/docs/prd/sync-realtime-ux/trace.md
+++ b/docs/prd/sync-realtime-ux/trace.md
@@ -1,0 +1,54 @@
+---
+artifact: "docs/prd/sync-realtime-ux/"
+artifact_kind: "prd"
+engine_tier: "teams"
+stepsCompleted: [0, 1, 2, 3, 4, 5, 6]
+final_status: "shipped"
+updated: "2026-06-10"
+---
+
+# Trace Ledger: Real-time sync experience and cross-device UI polish
+
+> Single source of truth for progress. A fresh session reads ONLY this file to resume. One row per task/T-id.
+
+## Tasks
+
+| Unit | Contract item | Status | Files touched | Engine | Notes |
+|------|---------------|--------|---------------|--------|-------|
+| 1.0 safe-area foundation | C8 C9 C10 | done (code) | src/main.rs, tailwind.css, src/ui/mod.rs, src/ui/note_list.rs, src/ui/notes/detail.rs, src/ui/chat/view.rs, src/ui/fab.rs, src/ui/attachment_modal.rs | teams (worker-a) | custom prod-style index.html with viewport-fit=cover via LaunchBuilder::with_cfg + client! (dioxus 0.7.9 API verified in vendored sources); safe-pb-* env() utilities replace fixed paddings; .keyboard-aware rule covers chat input + recording bars; attachment_modal safe-py-3 added by lead (scope-edge, logged); device sweep pending user |
+| 2.0 real-time refresh | C1 C2 C3 C4 | done (code) | src/services/sync/engine.rs, src/ui/state.rs, src/ui/mod.rs, src/ui/sidebar/conversations.rs, src/ui/chat/view.rs, tests/sync_data_version_test.rs (new) | teams (worker-b) | data_version AtomicU64 on SyncEngine, bumped in serve_loop (~209) and run_pass (~349) only when applied>0; full-state reconcile is a session MODE so it flows through those 2 points; 400ms UI poll writes sync_data_version + bumps notes/folders/attachments versions only on change (debounce + C3); 3 tests written NOT run |
+| 3.0 smart open-detail | C5 C6 C7 | done (code) | src/ui/notes/detail.rs | teams (worker-b) | base_title/base_content/base_tags baselines + updated_from_peer flag; effect re-runs only on sync_data_version; not dirty = silent DB reload + baseline advance; dirty = banner, editor signals untouched; tap reloads + clears; save path byte-for-byte unchanged (C7); banner text moved to .ftl by lead (note-updated-from-peer en+fr) |
+| 4.0 QR pairing | C11 C12 C13 | done (code) | src/services/sync/deeplink.rs (new), src/services/sync/mod.rs, src/main.rs, src/ui/sync/pairing.rs, src/ui/sync/mod.rs, scripts/inject-url-scheme.sh (new), Makefile | teams (worker-c) | with_custom_event_handler (dioxus-desktop 0.7.9 config.rs:216) matches tao Event::Opened (tao 0.34.8 event.rs:137), flowflow:// pushed to deeplink static; pairing screen polls take() 400ms, prefills join_uri, one-tap confirm via existing join_pairing; plist injection idempotent, ordered before icon/codesign in all/ddev-build/deploy/appstore; copy-paste path untouched; 4.3 scanner NOT built (contingent on device spike); ui/mod.rs nav snippet pending lead integration after Unit B |
+| 5.0 device validation | C14 C15 | todo | - | user | verification bundle, user-run on real devices |
+
+## Checkpoints
+
+| Step | Kind | Decision | Why |
+|------|------|----------|-----|
+| step-04 | scope-edge | proceeded (logged) | attachment_modal.rs not in declared edit scope but US3 says all views; one-line safe-py-3 on the bottom-sheet scroll region, applied by lead |
+| step-04 | quality fix | proceeded (logged) | worker-c used 3 hardcoded lang helpers in pairing.rs; lead migrated them to the fluent .ftl pattern (sync-scanned-title, sync-scanned-hint, sync-confirm-pairing in en.ftl + fr.ftl), helpers removed |
+| step-04 | quality fix | proceeded (logged) | worker-b banner literal in detail.rs moved to t(&lang, "note-updated-from-peer") with en+fr .ftl keys |
+| step-04 | integration | done by lead | deep-link navigation folded into the existing 400ms poll loop in src/ui/mod.rs: pending_pairing_uri_exists() + view != SyncPairing -> previous_view saved, view set to SyncPairing (worker-c snippet, single timer instead of a third loop) |
+
+## Verify (step-05, 2026-06-10)
+
+- creator-verifier (read-only): 13/13 contract items PASS at code level. Key cites: engine.rs:211 + 351 (both bump paths, applied>0 guarded), ui/mod.rs:148-166 (400ms write-on-change poll), detail.rs:179-208 + 714-732 (smart rule + banner), main.rs:1-12 + 30-45 (viewport-fit=cover index + Event::Opened handler), deeplink.rs peek/take split, pairing.rs:29-39 prefill + one-tap confirm, Makefile 4 targets wired.
+- 4 MINOR defects found, all fixed by lead: banner false-positive ordering (detail.rs), ChatMsg PartialEq content compare (chat), appstore target injection order (Makefile), zero-change test settle wait (tests).
+- 1.0/2.0/3.0/4.0 done at code level; 5.0 = user-run verification bundle (verification-bundle.md). Device spike 4.1 (cold-start Event::Opened) decides whether 4.3 (in-app scanner) is needed.
+
+## Device feedback round 1 (2026-06-10)
+
+- Bottom OK on iPhone; TopBar (burger + chat icon) under the Dynamic Island: viewport-fit=cover also removes the TOP inset. Fix: safe-pt utility (padding-top: env(safe-area-inset-top)) on the app column (ui/mod.rs) and the sidebar drawer (sidebar/mod.rs). Rebuilt + reinstalled (make all exit 0).
+
+## Safe checks run by ship (standing user authorization, 2026-06-10)
+
+- make format + make check (fmt --check + clippy --features mobile): exit 0
+- cargo build --features desktop: exit 0 (both cfg arms of main.rs compile)
+- cargo test: 208 passed (205 existing + 3 new), 11 ignored (pre-existing key-gated), 0 failed
+- make desktop-build: Flowflow.app built (debug/macos)
+- make all: device build + inject-url-scheme + inject-icon + re-sign + install, exit 0
+- PlistBuddy read-back: CFBundleURLTypes/flowflow present in the installed app's Info.plist
+
+## HALT events
+
+- none

--- a/docs/prd/sync-realtime-ux/verification-bundle.md
+++ b/docs/prd/sync-realtime-ux/verification-bundle.md
@@ -1,0 +1,57 @@
+---
+artifact: "docs/prd/sync-realtime-ux/"
+stack: "rust / cargo"
+generated: "2026-06-10"
+ran_by: "user"
+---
+
+# Verification Bundle: Real-time sync experience and cross-device UI polish
+
+> Each line states what it proves and the expected pass signal. Commands are stack-detected (cargo + Makefile).
+
+## Safe checks (machine-local, no device needed)
+
+| Command | Validates | Expected pass signal |
+|---------|-----------|----------------------|
+| `make check` | fmt + clippy on the whole diff | exit 0, no warnings |
+| `cargo build --features mobile` | mobile feature compiles (default arm of the main.rs cfg alias) | exit 0 |
+| `cargo build --features desktop` | desktop feature compiles (desktop arm of the cfg alias + dioxus::desktop re-export) | exit 0 |
+| `cargo test` | all 205 existing tests + 3 new sync_data_version tests (C2, C3, C14, C15) | all green, 208 total |
+| `make desktop-build` | Mac desktop app builds with the custom index config | exit 0 |
+
+## Device / stateful (USER ONLY)
+
+| Command / action | Validates | Warning |
+|------------------|-----------|---------|
+| `make all` | iOS build + URL-scheme injection + icon + install on iPhone | deploys to your device; check the injection log line ">> Registering URL scheme" |
+| `make desktop-app` | Mac .app bundle | replaces the installed app |
+| Device sweep: every view bottom (notes list, detail, chat, settings, sync) | C8, C9 | visual, home-indicator iPhone |
+| Mac visual check: no added bottom gap | C10 | visual |
+| Two-device test: create note on iPhone, sync, watch Mac update < 1 s (and reverse) | C1, C2 | needs both devices paired |
+| Zero-change sync: press Sync now twice, watch for flicker | C3 | visual |
+| Restore scenario (full-state reconcile) | C4 | visual smoothness |
+| Edit collision x5: type on Mac without saving, push from iPhone, banner appears, text intact, tap reloads, save | C5, C6, C7 | count lost keystrokes (target 0) |
+| QR spike: scan the Mac QR with the iPhone camera, app foregrounded AND app killed (cold start) | C11, C12 | record both outcomes in trace.md; cold-start failure routes to task 4.3 (in-app scanner) |
+| Camera-permission-denied pairing via copy-paste | C13 | settings toggle on the iPhone |
+| `flowflow://test` link tap (Notes app) | 4.1 spike observability | app should open; URI ignored by the pairing filter (not a pair URI) |
+
+## Contract coverage
+
+- C1 -> cargo test (signal plumbing) + two-device < 1 s trials (10x, stopwatch)
+- C2 -> tests data_version_bumps_on_outbound_apply + data_version_bumps_on_served_apply + device both-directions test
+- C3 -> test data_version_steady_on_zero_change_pass + visual zero-change check
+- C4 -> restore-scenario device test (code: 400 ms write-on-change poll)
+- C5/C6/C7 -> edit-collision device protocol above (code self-check PASS at detail.rs:179-208 post-fix)
+- C8/C9/C10 -> device sweep + Mac visual check (code self-check PASS: viewport-fit=cover + env() utilities)
+- C11/C12/C13 -> QR spike + copy-paste fallback tests above
+- C14 -> make check + cargo build (both features) + cargo test + make all + make desktop-app
+- C15 -> cargo test (sync suite untouched: protocol/, conflict.rs, gc.rs, vv.rs have zero diff)
+- Uncovered by commands (manual only): C8, C9, C10 visuals; C11, C12 cold-start spike; < 1 s timing metric.
+
+## Self-check results (read-only verifier, 2026-06-10)
+
+13/13 contract items PASS at code level (file:line cites in trace.md). 4 MINOR findings, all fixed by the lead before this bundle:
+1. detail.rs banner false-positive on unrelated syncs -> changed-check now precedes dirty-check.
+2. chat view reload missed content-only edits -> ChatMsg derives PartialEq, full compare.
+3. Makefile appstore target: url-scheme injection now ordered before icon, uniform with the other targets.
+4. zero-change test: fixed sleeps replaced by an activity-settled wait.

--- a/scripts/inject-desktop-icon.sh
+++ b/scripts/inject-desktop-icon.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+APP_PATH="${APP_PATH:-target/dx/flowflow/debug/macos/Flowflow.app}"
+SRC="AppIcon.xcassets/AppIcon.appiconset/icon-1024.png"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "ERROR: $APP_PATH not found. Run dx build first."
+  exit 1
+fi
+if [ ! -f "$SRC" ]; then
+  echo "ERROR: $SRC not found."
+  exit 1
+fi
+
+echo ">> Building AppIcon.icns from $SRC..."
+TMP=$(mktemp -d)
+ICONSET="$TMP/AppIcon.iconset"
+mkdir -p "$ICONSET"
+
+sips -z 16 16     "$SRC" --out "$ICONSET/icon_16x16.png" >/dev/null
+sips -z 32 32     "$SRC" --out "$ICONSET/icon_16x16@2x.png" >/dev/null
+sips -z 32 32     "$SRC" --out "$ICONSET/icon_32x32.png" >/dev/null
+sips -z 64 64     "$SRC" --out "$ICONSET/icon_32x32@2x.png" >/dev/null
+sips -z 128 128   "$SRC" --out "$ICONSET/icon_128x128.png" >/dev/null
+sips -z 256 256   "$SRC" --out "$ICONSET/icon_128x128@2x.png" >/dev/null
+sips -z 256 256   "$SRC" --out "$ICONSET/icon_256x256.png" >/dev/null
+sips -z 512 512   "$SRC" --out "$ICONSET/icon_256x256@2x.png" >/dev/null
+sips -z 512 512   "$SRC" --out "$ICONSET/icon_512x512.png" >/dev/null
+cp "$SRC" "$ICONSET/icon_512x512@2x.png"
+
+iconutil -c icns "$ICONSET" -o "$APP_PATH/Contents/Resources/icon.icns"
+
+PLIST="$APP_PATH/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName FlowFlow" "$PLIST" 2>/dev/null || /usr/libexec/PlistBuddy -c "Add :CFBundleName string FlowFlow" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName FlowFlow" "$PLIST" 2>/dev/null || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string FlowFlow" "$PLIST"
+
+touch "$APP_PATH"
+echo ">> Desktop icon and branding injected into $APP_PATH"

--- a/scripts/inject-url-scheme.sh
+++ b/scripts/inject-url-scheme.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+APP_PATH="${APP_PATH:-target/dx/flowflow/debug/ios/Flowflow.app}"
+URL_NAME="com.mirkobozzetto.flowflow"
+URL_SCHEME="flowflow"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "ERROR: $APP_PATH not found. Run dx build first."
+  exit 1
+fi
+
+PLIST="$APP_PATH/Info.plist"
+
+echo ">> Registering $URL_SCHEME:// URL scheme in Info.plist..."
+
+EXISTING=$(/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$PLIST" 2>/dev/null || true)
+if echo "$EXISTING" | grep -q "$URL_SCHEME"; then
+  echo ">> Scheme already present; nothing to do."
+else
+  /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLName string $URL_NAME" "$PLIST"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string $URL_SCHEME" "$PLIST"
+fi
+
+if [[ "$APP_PATH" == *"/release/"* ]]; then
+  echo ">> Release build: scheme merged into Info.plist; signing deferred to make appstore."
+  echo ">> Done."
+  exit 0
+fi
+
+echo ">> Extracting entitlements from provisioning profile..."
+security cms -D -i "$APP_PATH/embedded.mobileprovision" 2>/dev/null \
+  | xmllint --xpath '//key[text()="Entitlements"]/following-sibling::dict[1]' - 2>/dev/null \
+  > /tmp/ent-dict.plist
+printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n' > /tmp/ent.plist
+cat /tmp/ent-dict.plist >> /tmp/ent.plist
+printf '\n</plist>\n' >> /tmp/ent.plist
+
+echo ">> Re-signing app..."
+IDENTITY=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk -F'"' '{print $2}')
+codesign --force --sign "$IDENTITY" --entitlements /tmp/ent.plist "$APP_PATH"
+
+echo ">> Done."

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -81,7 +81,7 @@ pub fn desktop_data_dir() -> PathBuf {
 // Any failure removes the staging file and leaves new_dir without
 // flowflow.db, so the next boot retries from the intact legacy store.
 #[cfg(not(target_os = "ios"))]
-fn migrate_legacy_temp_data(
+pub fn migrate_legacy_temp_data(
     legacy: &std::path::Path,
     new_dir: &std::path::Path,
 ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,48 @@
+const INDEX_HTML: &str = r#"<!DOCTYPE html>
+<html>
+    <head>
+        <title>FlowFlow</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+        <!-- CUSTOM HEAD -->
+    </head>
+    <body>
+        <div id="main"></div>
+        <!-- MODULE LOADER -->
+    </body>
+</html>"#;
+
+#[cfg(feature = "desktop")]
+use dioxus::desktop::Config as DesktopConfig;
+#[cfg(all(feature = "mobile", not(feature = "desktop")))]
+use dioxus::mobile::Config as DesktopConfig;
+
+#[cfg(feature = "desktop")]
+use dioxus::desktop::{tao, WindowBuilder};
+#[cfg(all(feature = "mobile", not(feature = "desktop")))]
+use dioxus::mobile::{tao, WindowBuilder};
+
 fn main() {
     dotenvy::dotenv().ok();
     #[cfg(target_os = "ios")]
     flowflow::platform::ios::configure_audio_session();
     #[cfg(target_os = "ios")]
     flowflow::platform::ios::hide_keyboard_accessory();
-    dioxus::launch(flowflow::ui::App);
+    dioxus::LaunchBuilder::new()
+        .with_cfg(dioxus::prelude::client! {
+            DesktopConfig::new()
+                .with_window(WindowBuilder::new().with_title("FlowFlow"))
+                .with_custom_index(INDEX_HTML.to_string())
+                .with_custom_event_handler(|event, _target| {
+                    if let tao::event::Event::Opened { urls } = event {
+                        for url in urls {
+                            let s = url.as_str();
+                            if s.starts_with("flowflow://") {
+                                flowflow::services::sync::deeplink::push(s.to_string());
+                                break;
+                            }
+                        }
+                    }
+                })
+        })
+        .launch(flowflow::ui::App);
 }

--- a/src/services/i18n/locales/en.ftl
+++ b/src/services/i18n/locales/en.ftl
@@ -51,6 +51,9 @@ sync-status-conflicts = conflict(s)
 sync-status-partial = One device could not sync:
 sync-now = Sync now
 sync-no-peers-hint = Pair a device below first.
+sync-scanned-title = Code scanned
+sync-scanned-hint = The pairing code was filled in automatically. Tap Confirm to pair this device.
+sync-confirm-pairing = Confirm pairing
 sync-conflicts-title = Conflicts
 sync-conflicts-hint = Two devices edited the same data at the same time. The kept version is in your notes; here is the set-aside version, nothing is lost.
 sync-conflict-restore = Restore as note
@@ -108,6 +111,7 @@ top-bar-folder-fallback = Theme
 top-bar-all-notes = All notes
 
 note-title-placeholder = Title
+note-updated-from-peer = Note updated from another device. Tap to reload.
 note-created-on = Created on { $date }
 note-content-placeholder = Note content...
 note-transcribing-placeholder = Transcribing...

--- a/src/services/i18n/locales/fr.ftl
+++ b/src/services/i18n/locales/fr.ftl
@@ -51,6 +51,9 @@ sync-status-conflicts = conflit(s)
 sync-status-partial = Un appareil n'a pas pu se synchroniser :
 sync-now = Synchroniser maintenant
 sync-no-peers-hint = Appairez d'abord un appareil ci-dessous.
+sync-scanned-title = Code scanné
+sync-scanned-hint = Le code d'appairage a été rempli automatiquement. Touchez Confirmer pour appairer cet appareil.
+sync-confirm-pairing = Confirmer l'appairage
 sync-conflicts-title = Conflits
 sync-conflicts-hint = Deux appareils ont modifié la même donnée en même temps. La version conservée est dans vos notes ; voici la version écartée, rien n'est perdu.
 sync-conflict-restore = Restaurer en note
@@ -108,6 +111,7 @@ top-bar-folder-fallback = Thème
 top-bar-all-notes = Toutes les notes
 
 note-title-placeholder = Titre
+note-updated-from-peer = Note mise à jour depuis un autre appareil. Touchez pour recharger.
 note-created-on = Créé le { $date }
 note-content-placeholder = Contenu de la note...
 note-transcribing-placeholder = Transcription en cours...

--- a/src/services/sync/deeplink.rs
+++ b/src/services/sync/deeplink.rs
@@ -1,0 +1,22 @@
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+static PENDING: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+fn cell() -> &'static Mutex<Option<String>> {
+    PENDING.get_or_init(|| Mutex::new(None))
+}
+
+pub fn push(uri: String) {
+    if let Ok(mut guard) = cell().lock() {
+        *guard = Some(uri);
+    }
+}
+
+pub fn peek() -> Option<String> {
+    cell().lock().ok().and_then(|guard| guard.clone())
+}
+
+pub fn take() -> Option<String> {
+    cell().lock().ok().and_then(|mut guard| guard.take())
+}

--- a/src/services/sync/engine.rs
+++ b/src/services/sync/engine.rs
@@ -115,6 +115,7 @@ pub struct SyncEngine {
     // the running pass re-runs once more if this was set after its snapshot.
     pending: Arc<AtomicBool>,
     listen_port: Option<u16>,
+    data_version: Arc<AtomicU64>,
 }
 
 impl SyncEngine {
@@ -151,6 +152,7 @@ impl SyncEngine {
             session_lock: Arc::new(Mutex::new(())),
             pending: Arc::new(AtomicBool::new(false)),
             listen_port,
+            data_version: Arc::new(AtomicU64::new(0)),
         });
         register_engine(&engine);
         if let Some(listener) = listener {
@@ -170,6 +172,14 @@ impl SyncEngine {
 
     fn set_activity(&self, a: SyncActivity) {
         *self.activity.lock().unwrap() = a;
+    }
+
+    pub fn data_version(&self) -> u64 {
+        self.data_version.load(Ordering::SeqCst)
+    }
+
+    fn bump_data_version(&self) {
+        self.data_version.fetch_add(1, Ordering::SeqCst);
     }
 
     fn serve_loop(self: Arc<Self>, mut listener: TcpListener) {
@@ -198,6 +208,7 @@ impl SyncEngine {
                         partial: None,
                     });
                     if outcome.stats.applied > 0 {
+                        self.bump_data_version();
                         spawn_reconcile_pass();
                     }
                     run_tombstone_gc(&self.db);
@@ -337,6 +348,7 @@ impl SyncEngine {
                 partial: first_error,
             });
             if total.applied > 0 {
+                self.bump_data_version();
                 spawn_reconcile_pass();
             }
             run_tombstone_gc(&self.db);

--- a/src/services/sync/mod.rs
+++ b/src/services/sync/mod.rs
@@ -1,4 +1,5 @@
 pub mod conflict;
+pub mod deeplink;
 pub mod engine;
 pub mod gc;
 pub mod peers;

--- a/src/ui/attachment_modal.rs
+++ b/src/ui/attachment_modal.rs
@@ -32,7 +32,7 @@ pub fn AttachmentModal() -> Element {
                     IconX { size: 20 }
                 }
             }
-            div { class: "flex-1 overflow-y-auto px-4 py-3",
+            div { class: "flex-1 overflow-y-auto px-4 safe-py-3",
                 pre { class: "text-sm text-stone-800 whitespace-pre-wrap font-sans",
                     "{attachment.content_text}"
                 }

--- a/src/ui/chat/models.rs
+++ b/src/ui/chat/models.rs
@@ -7,7 +7,7 @@ pub struct ChatSource {
     pub created_at: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum ChatMsg {
     User(String),
     Bot {

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -71,6 +71,20 @@ pub fn ChatView() -> Element {
         );
     });
 
+    use_effect(move || {
+        let _v = (app.sync_data_version)();
+        if loading() {
+            return;
+        }
+        let Some(cid) = conversation_id() else {
+            return;
+        };
+        let fresh = load_messages_from_db(&db(), &cid);
+        if fresh != *messages.peek() {
+            messages.set(fresh);
+        }
+    });
+
     let is_empty = messages().is_empty();
     let show_menu = (app.show_chat_menu)();
 
@@ -89,7 +103,7 @@ pub fn ChatView() -> Element {
             if (app.show_folder_picker)() {
                 FolderPicker { selected: app.chat_scope_folder_id }
             }
-            div { id: "chat-messages", class: "h-full overflow-y-auto px-4 pt-4 pb-40",
+            div { id: "chat-messages", class: "h-full overflow-y-auto px-4 pt-4 safe-pb-40",
                 if is_empty && !loading() {
                     ChatEmptyState {}
                 } else {

--- a/src/ui/fab.rs
+++ b/src/ui/fab.rs
@@ -7,7 +7,7 @@ pub fn FloatingActionButton() -> Element {
     let mut app: AppState = use_context();
 
     rsx! {
-        div { class: "fixed bottom-6 right-4 z-20",
+        div { class: "fixed safe-bottom-6 right-4 z-20",
             button {
                 class: "w-20 h-20 rounded-full bg-warm-white border border-ios-orange/15 flex items-center justify-center shadow-xl shadow-stone-400/40",
                 onclick: move |_| {

--- a/src/ui/fab.rs
+++ b/src/ui/fab.rs
@@ -1,21 +1,54 @@
-use crate::ui::icons::*;
 use crate::ui::{AppState, View};
 use dioxus::prelude::*;
 
 #[component]
 pub fn FloatingActionButton() -> Element {
     let mut app: AppState = use_context();
+    let mut clicked = use_signal(|| false);
+    let mut pressing = use_signal(|| false);
 
     rsx! {
         div { class: "fixed safe-bottom-6 right-4 z-20",
             button {
-                class: "w-20 h-20 rounded-full bg-warm-white border border-ios-orange/15 flex items-center justify-center shadow-xl shadow-stone-400/40",
+                class: "fab-btn",
+                class: if pressing() { "fab-pressing" },
+                class: if clicked() { "fab-clicked" },
+                onpointerdown: move |_| pressing.set(true),
+                onpointerup: move |_| pressing.set(false),
+                onpointerleave: move |_| pressing.set(false),
                 onclick: move |_| {
-                    app.show_folder_picker.set(false);
-                    app.view.set(View::NoteDetail { note_id: String::new() });
+                    if clicked() {
+                        return;
+                    }
+                    clicked.set(true);
+                    spawn(async move {
+                        futures_timer::Delay::new(
+                            std::time::Duration::from_millis(150),
+                        )
+                        .await;
+                        app.show_folder_picker.set(false);
+                        app.view.set(View::NoteDetail { note_id: String::new() });
+                        clicked.set(false);
+                    });
                 },
-                div { class: "text-ios-orange-dark",
-                    IconNewNote { size: 40 }
+                svg {
+                    width: "52",
+                    height: "52",
+                    view_box: "0 0 100 100",
+                    line {
+                        class: "fab-plus-h",
+                        x1: "30",
+                        y1: "50",
+                        x2: "70",
+                        y2: "50",
+                    }
+                    line {
+                        class: "fab-plus-v",
+                        x1: "50",
+                        y1: "30",
+                        x2: "50",
+                        y2: "70",
+                    }
                 }
             }
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -99,6 +99,7 @@ pub fn App() -> Element {
         transcription_jobs: Signal::new(HashMap::new()),
         transcription_done_badge: Signal::new(0),
         audio_import_requested: Signal::new(false),
+        sync_data_version: Signal::new(0),
     });
 
     use_future(move || {
@@ -135,6 +136,35 @@ pub fn App() -> Element {
                     700,
                 ))
                 .await;
+            }
+        }
+    });
+
+    use_future(move || {
+        let mut app = app;
+        async move {
+            let mut last_seen = _engine.peek().data_version();
+            loop {
+                futures_timer::Delay::new(std::time::Duration::from_millis(
+                    400,
+                ))
+                .await;
+                let current_view = (app.view)();
+                if sync::pending_pairing_uri_exists()
+                    && current_view != View::SyncPairing
+                {
+                    app.previous_view.set(Some(current_view));
+                    app.view.set(View::SyncPairing);
+                }
+                let current = _engine.peek().data_version();
+                if current == last_seen {
+                    continue;
+                }
+                last_seen = current;
+                app.sync_data_version.set(current);
+                app.notes_version.set((app.notes_version)() + 1);
+                app.folders_version.set((app.folders_version)() + 1);
+                app.attachments_version.set((app.attachments_version)() + 1);
             }
         }
     });
@@ -205,7 +235,7 @@ pub fn App() -> Element {
             div { class: "h-screen w-full overflow-hidden font-sans bg-stone-100",
                 SidebarOverlay {}
                 AttachmentModal {}
-                div { class: "flex flex-col h-screen",
+                div { class: "flex flex-col h-screen safe-pt",
                     TopBar {}
                     div { class: "flex-1 overflow-hidden relative",
                         {
@@ -216,7 +246,7 @@ pub fn App() -> Element {
                             let shift_dir = if is_note { "30%" } else { "-30%" };
                             rsx! {
                                 div {
-                                    class: "absolute inset-0 overflow-y-auto px-4 py-3 pb-20",
+                                    class: "absolute inset-0 overflow-y-auto px-4 py-3 safe-pb-20",
                                     class: if is_bg { "pointer-events-none" } else { "" },
                                     style: if shifted {
                                         format!("transform: translateX({shift_dir}); opacity: 0.5; transition: transform 0.15s ease, opacity 0.15s ease;")
@@ -251,7 +281,7 @@ pub fn App() -> Element {
                         }
                         if matches!((app.view)(), View::Settings) {
                             div {
-                                class: "absolute inset-0 flex flex-col min-h-0 px-4 py-3 bg-stone-100 overflow-y-auto",
+                                class: "absolute inset-0 flex flex-col min-h-0 px-4 safe-py-3 bg-stone-100 overflow-y-auto",
                                 style: if (app.sliding_out)() {
                                     "animation: slideOutRight 0.15s ease-in forwards;"
                                 } else {
@@ -262,7 +292,7 @@ pub fn App() -> Element {
                         }
                         if matches!((app.view)(), View::SyncPairing) {
                             div {
-                                class: "absolute inset-0 flex flex-col min-h-0 px-4 py-3 bg-stone-100 overflow-y-auto",
+                                class: "absolute inset-0 flex flex-col min-h-0 px-4 safe-py-3 bg-stone-100 overflow-y-auto",
                                 style: if (app.sliding_out)() {
                                     "animation: slideOutRight 0.15s ease-in forwards;"
                                 } else {

--- a/src/ui/note_list.rs
+++ b/src/ui/note_list.rs
@@ -71,7 +71,7 @@ pub fn NotesList() -> Element {
                 }
             }
         } else {
-            div { class: "pb-32",
+            div { class: "safe-pb-32",
                 for note in notes() {
                     NoteCard { note: note }
                 }

--- a/src/ui/notes/detail.rs
+++ b/src/ui/notes/detail.rs
@@ -144,7 +144,12 @@ pub fn NoteDetail() -> Element {
 
     let mut title = use_signal(|| initial_title.clone());
     let mut content = use_signal(|| initial_content.clone());
-    let tags: Signal<Vec<String>> = use_signal(|| initial_tags.clone());
+    let mut tags: Signal<Vec<String>> = use_signal(|| initial_tags.clone());
+    let mut base_title = use_signal(|| initial_title.clone());
+    let mut base_content = use_signal(|| initial_content.clone());
+    let mut base_tags: Signal<Vec<String>> =
+        use_signal(|| initial_tags.clone());
+    let mut updated_from_peer = use_signal(|| false);
     let tag_input = use_signal(String::new);
     let tagging = use_signal(|| false);
     let deleted = use_signal(|| false);
@@ -169,6 +174,37 @@ pub fn NoteDetail() -> Element {
         if !deleted() {
             app.current_note_id.set(Some(local_note_id()));
         }
+    });
+
+    use_effect(move || {
+        let _v = (app.sync_data_version)();
+        let id = local_note_id();
+        if id.is_empty() || deleted() {
+            return;
+        }
+        let Some(fresh) = db().get_note(&id).ok().flatten() else {
+            return;
+        };
+        let fresh_title = fresh.title.clone().unwrap_or_default();
+        let changed = fresh_title != *base_title.peek()
+            || fresh.content != *base_content.peek()
+            || fresh.tags != *base_tags.peek();
+        if !changed {
+            return;
+        }
+        let dirty = title.peek().as_str() != base_title.peek().as_str()
+            || content.peek().as_str() != base_content.peek().as_str()
+            || *tags.peek() != *base_tags.peek();
+        if dirty {
+            updated_from_peer.set(true);
+            return;
+        }
+        title.set(fresh_title.clone());
+        content.set(fresh.content.clone());
+        tags.set(fresh.tags.clone());
+        base_title.set(fresh_title);
+        base_content.set(fresh.content);
+        base_tags.set(fresh.tags);
     });
 
     use_effect(move || {
@@ -224,9 +260,6 @@ pub fn NoteDetail() -> Element {
     };
 
     use_drop({
-        let orig_title = initial_title.clone();
-        let orig_content = initial_content.clone();
-        let orig_tags = initial_tags.clone();
         let orig_folder = initial_folder_id.clone();
         move || {
             if deleted() {
@@ -243,9 +276,9 @@ pub fn NoteDetail() -> Element {
             if !nid.is_empty() && t.is_empty() && c.is_empty() {
                 return;
             }
-            let title_changed = t != orig_title;
-            let content_changed = c != orig_content;
-            let tags_changed = tags() != orig_tags;
+            let title_changed = t != *base_title.peek();
+            let content_changed = c != *base_content.peek();
+            let tags_changed = tags() != *base_tags.peek();
             let folder_changed = (app.detail_folder_id)() != orig_folder;
             let has_new_audio = pa.is_some();
             let changed = title_changed
@@ -673,10 +706,29 @@ pub fn NoteDetail() -> Element {
             }
         }
         div {
-            class: "relative overflow-y-auto pb-40 px-4 pt-3",
+            class: "relative overflow-y-auto safe-pb-40 px-4 pt-3",
             style: "height: calc(100% - var(--keyboard-inset, 0px));",
             if (app.show_folder_picker)() {
                 FolderPicker { selected: app.detail_folder_id }
+            }
+            if updated_from_peer() {
+                button {
+                    class: "w-full min-h-[44px] mb-2 px-3 py-2 rounded-xl bg-ios-orange/10 border border-ios-orange/30 text-ios-orange-dark text-xs font-medium text-left active:bg-ios-orange/25",
+                    onclick: move |_| {
+                        let id = local_note_id();
+                        if let Some(fresh) = db().get_note(&id).ok().flatten() {
+                            let fresh_title = fresh.title.clone().unwrap_or_default();
+                            title.set(fresh_title.clone());
+                            content.set(fresh.content.clone());
+                            tags.set(fresh.tags.clone());
+                            base_title.set(fresh_title);
+                            base_content.set(fresh.content);
+                            base_tags.set(fresh.tags);
+                        }
+                        updated_from_peer.set(false);
+                    },
+                    {t(&lang, "note-updated-from-peer")}
+                }
             }
             div { class: "pt-2 pb-3",
                 div { class: "inline-block relative",

--- a/src/ui/sidebar/conversations.rs
+++ b/src/ui/sidebar/conversations.rs
@@ -14,6 +14,7 @@ pub fn ConversationSection() -> Element {
 
     let conversations = use_memo(move || {
         let _v = version();
+        let _sv = (app.sync_data_version)();
         db().list_conversations().unwrap_or_default()
     });
 

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -25,7 +25,7 @@ pub fn SidebarOverlay() -> Element {
             onclick: move |_| app.sidebar_open.set(false),
         }
         div {
-            class: "fixed left-0 top-0 w-[85vw] max-w-[340px] h-full bg-warm-white z-50 flex flex-col border-r border-stone-200 transition-transform duration-200",
+            class: "fixed left-0 top-0 w-[85vw] max-w-[340px] h-full bg-warm-white z-50 flex flex-col border-r border-stone-200 transition-transform duration-200 safe-pt",
             class: if is_open { "translate-x-0" } else { "-translate-x-full" },
             onclick: move |evt| evt.stop_propagation(),
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -45,4 +45,5 @@ pub struct AppState {
     pub transcription_jobs: Signal<HashMap<String, VecDeque<Job>>>,
     pub transcription_done_badge: Signal<usize>,
     pub audio_import_requested: Signal<bool>,
+    pub sync_data_version: Signal<u64>,
 }

--- a/src/ui/sync/mod.rs
+++ b/src/ui/sync/mod.rs
@@ -10,6 +10,10 @@ use controls::SyncControls;
 use dioxus::prelude::*;
 use pairing::SyncPairingView;
 
+pub fn pending_pairing_uri_exists() -> bool {
+    crate::services::sync::deeplink::peek().is_some()
+}
+
 #[component]
 pub fn SyncView() -> Element {
     rsx! {

--- a/src/ui/sync/pairing.rs
+++ b/src/ui/sync/pairing.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::services::i18n::t;
+use crate::services::sync::deeplink;
 use crate::services::sync::peers::{self, PairingHost, PairingStatus};
 use crate::ui::AppState;
 use dioxus::prelude::*;
@@ -18,10 +19,23 @@ pub fn SyncPairingView() -> Element {
         use_signal(|| None);
     let mut joining = use_signal(|| false);
     let mut peers_version = use_signal(|| 0u32);
+    let mut scanned = use_signal(|| false);
 
     let peers_list = use_memo(move || {
         peers_version();
         db().list_peers().unwrap_or_default()
+    });
+
+    use_future(move || async move {
+        loop {
+            if let Some(uri) = deeplink::take() {
+                join_uri.set(uri);
+                scanned.set(true);
+                join_status.set(None);
+            }
+            futures_timer::Delay::new(std::time::Duration::from_millis(400))
+                .await;
+        }
     });
 
     use_future(move || async move {
@@ -136,8 +150,19 @@ pub fn SyncPairingView() -> Element {
                 h2 { class: "text-lg font-semibold text-stone-900 mb-1",
                     {t(&lang, "sync-join-title")}
                 }
-                p { class: "text-xs text-stone-500 mb-3 leading-relaxed",
-                    {t(&lang, "sync-join-hint")}
+                if scanned() {
+                    div { class: "bg-ios-orange/10 border border-ios-orange/40 rounded-xl px-3 py-2.5 mb-3",
+                        p { class: "text-sm text-stone-900 font-medium",
+                            {t(&lang, "sync-scanned-title")}
+                        }
+                        p { class: "text-xs text-stone-600 leading-relaxed mt-0.5",
+                            {t(&lang, "sync-scanned-hint")}
+                        }
+                    }
+                } else {
+                    p { class: "text-xs text-stone-500 mb-3 leading-relaxed",
+                        {t(&lang, "sync-join-hint")}
+                    }
                 }
                 textarea {
                     class: "w-full border border-stone-200 rounded-xl px-3 py-2.5 text-xs outline-none text-stone-900 bg-warm-white min-h-[72px]",
@@ -172,6 +197,7 @@ pub fn SyncPairingView() -> Element {
                             };
                             if outcome.is_ok() {
                                 peers_version += 1;
+                                scanned.set(false);
                             }
                             join_status.set(Some(outcome));
                             joining.set(false);
@@ -179,6 +205,8 @@ pub fn SyncPairingView() -> Element {
                     },
                     if joining() {
                         {t(&lang, "sync-connecting")}
+                    } else if scanned() {
+                        {t(&lang, "sync-confirm-pairing")}
                     } else {
                         {t(&lang, "sync-connect")}
                     }

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,6 +1,30 @@
 @import "tailwindcss";
 @source "./src/**/*.{rs,html,css}";
 
+@utility safe-pb-20 {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+}
+@utility safe-pb-32 {
+    padding-bottom: calc(8rem + env(safe-area-inset-bottom));
+}
+@utility safe-pb-40 {
+    padding-bottom: calc(10rem + env(safe-area-inset-bottom));
+}
+@utility safe-bottom-6 {
+    bottom: calc(1.5rem + env(safe-area-inset-bottom));
+}
+@utility safe-pt {
+    padding-top: env(safe-area-inset-top);
+}
+@utility safe-py-3 {
+    padding-top: 0.75rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+}
+
+.keyboard-aware {
+    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
+}
+
 @theme {
     --color-ios-green: #34c759;
     --color-ios-red: #ff3b30;

--- a/tailwind.css
+++ b/tailwind.css
@@ -25,6 +25,62 @@
     padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
 }
 
+.fab-btn {
+    position: relative;
+    width: 96px;
+    height: 96px;
+    border-radius: 9999px;
+    background: var(--color-warm-white);
+    border: 1.5px solid var(--color-ios-orange-100);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fab-btn:active,
+.fab-pressing {
+    transform: scale(0.94);
+}
+.fab-btn svg {
+    display: block;
+    overflow: visible;
+}
+.fab-btn line {
+    stroke: var(--color-ios-orange);
+    stroke-width: 4.5;
+    stroke-linecap: round;
+}
+.fab-plus-h,
+.fab-plus-v {
+    transform-box: view-box;
+    transform-origin: 50% 50%;
+}
+.fab-clicked svg {
+    animation: fab-fadeout 0.15s ease-out forwards;
+}
+.fab-clicked .fab-plus-h {
+    animation: fab-grow-h 0.15s ease-out forwards;
+}
+.fab-clicked .fab-plus-v {
+    animation: fab-grow-v 0.15s ease-out forwards;
+}
+@keyframes fab-grow-h {
+    to {
+        transform: scaleX(1.15);
+    }
+}
+@keyframes fab-grow-v {
+    to {
+        transform: scaleY(1.15);
+    }
+}
+@keyframes fab-fadeout {
+    to {
+        opacity: 0;
+    }
+}
+
 @theme {
     --color-ios-green: #34c759;
     --color-ios-red: #ff3b30;

--- a/tests/legacy_migration_test.rs
+++ b/tests/legacy_migration_test.rs
@@ -1,0 +1,89 @@
+#![cfg(not(target_os = "ios"))]
+
+use flowflow::db::migrate_legacy_temp_data;
+use rusqlite::Connection;
+use tempfile::tempdir;
+
+fn seed_legacy_db(dir: &std::path::Path) -> Connection {
+    let conn = Connection::open(dir.join("flowflow.db")).expect("open legacy");
+    conn.pragma_update(None, "journal_mode", "WAL").expect("wal");
+    conn.execute("CREATE TABLE notes (id TEXT PRIMARY KEY, content TEXT)", [])
+        .expect("schema");
+    conn.execute(
+        "INSERT INTO notes VALUES ('n1', 'written through the wal')",
+        [],
+    )
+    .expect("insert");
+    conn
+}
+
+#[test]
+fn migration_carries_wal_resident_writes() {
+    let legacy = tempdir().expect("legacy dir");
+    let new_dir = tempdir().expect("new dir");
+    let held_open = seed_legacy_db(legacy.path());
+    assert!(
+        legacy.path().join("flowflow.db-wal").exists(),
+        "precondition: writes must sit in the wal"
+    );
+
+    migrate_legacy_temp_data(legacy.path(), new_dir.path());
+    drop(held_open);
+
+    let migrated =
+        Connection::open(new_dir.path().join("flowflow.db")).expect("open");
+    let content: String = migrated
+        .query_row("SELECT content FROM notes WHERE id = 'n1'", [], |r| {
+            r.get(0)
+        })
+        .expect("wal-resident row must survive the migration");
+    assert_eq!(content, "written through the wal");
+    assert!(
+        !new_dir.path().join("flowflow.db-wal").exists(),
+        "migrated image must be a single checkpointed file, no torn wal"
+    );
+    assert!(
+        legacy.path().join("flowflow.db").exists(),
+        "legacy store stays untouched as fallback"
+    );
+}
+
+#[test]
+fn migration_cleans_stale_staging_from_a_crash() {
+    let legacy = tempdir().expect("legacy dir");
+    let new_dir = tempdir().expect("new dir");
+    let _held_open = seed_legacy_db(legacy.path());
+    std::fs::write(new_dir.path().join("flowflow.db.migrating"), b"torn")
+        .expect("plant stale staging");
+
+    migrate_legacy_temp_data(legacy.path(), new_dir.path());
+
+    assert!(
+        !new_dir.path().join("flowflow.db.migrating").exists(),
+        "stale staging file must be cleared"
+    );
+    let migrated =
+        Connection::open(new_dir.path().join("flowflow.db")).expect("open");
+    let count: i64 = migrated
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(count, 1, "migration must complete despite the stale staging");
+}
+
+#[test]
+fn migration_never_overwrites_an_existing_target() {
+    let legacy = tempdir().expect("legacy dir");
+    let new_dir = tempdir().expect("new dir");
+    let _held_open = seed_legacy_db(legacy.path());
+    std::fs::write(new_dir.path().join("flowflow.db"), b"existing store")
+        .expect("plant target");
+
+    migrate_legacy_temp_data(legacy.path(), new_dir.path());
+
+    let bytes =
+        std::fs::read(new_dir.path().join("flowflow.db")).expect("read");
+    assert_eq!(
+        bytes, b"existing store",
+        "an existing target must never be touched"
+    );
+}

--- a/tests/sync_data_version_test.rs
+++ b/tests/sync_data_version_test.rs
@@ -1,0 +1,168 @@
+use flowflow::db::Database;
+use flowflow::models::note::NewTextNote;
+use flowflow::services::sync::engine::{
+    set_peer_endpoint, SyncActivity, SyncEngine,
+};
+use flowflow::services::sync::peers;
+use std::sync::{Arc, Once};
+use tempfile::tempdir;
+
+static ADVERTISE: Once = Once::new();
+
+fn open_db() -> (Arc<Database>, tempfile::TempDir) {
+    let dir = tempdir().expect("db tempdir");
+    let db =
+        Database::open_at(dir.path().join("flowflow.db")).expect("open_at");
+    (Arc::new(db), dir)
+}
+
+fn pair(db_a: &Arc<Database>, db_b: &Arc<Database>) -> (String, String) {
+    ADVERTISE.call_once(|| {
+        std::env::set_var("FLOWFLOW_SYNC_ADVERTISE_ADDR", "127.0.0.1");
+        let scratch = std::env::temp_dir().join("flowflow-test-data");
+        std::env::set_var("FLOWFLOW_DATA_DIR", &scratch);
+    });
+    let host = peers::start_pairing_host(db_a.clone()).expect("host");
+    let mut payload =
+        peers::decode_pairing_uri(&host.uri).expect("decode host uri");
+    payload.addr = "127.0.0.1".to_string();
+    let uri = peers::encode_pairing_uri(&payload).expect("re-encode uri");
+    let id_a = peers::join_pairing(db_b, &uri).expect("join pairing");
+    for _ in 0..100 {
+        if host.status() != peers::PairingStatus::Waiting {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let id_b = peers::ensure_sync_identity(db_b).expect("id b").device_id;
+    assert!(matches!(host.status(), peers::PairingStatus::Paired { .. }));
+    (id_a, id_b)
+}
+
+fn make_note(db: &Database, title: &str, content: &str) -> String {
+    db.create_text_note(&NewTextNote {
+        title: Some(title.to_string()),
+        content: content.to_string(),
+        tags: vec![],
+    })
+    .expect("create note")
+    .id
+}
+
+fn wait_until(timeout_ms: u64, mut probe: impl FnMut() -> bool) -> bool {
+    let deadline = std::time::Instant::now()
+        + std::time::Duration::from_millis(timeout_ms);
+    while std::time::Instant::now() < deadline {
+        if probe() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    false
+}
+
+#[test]
+fn data_version_bumps_on_outbound_apply() {
+    let (db_a, _da) = open_db();
+    let (db_b, _db) = open_db();
+    let (id_a, _id_b) = pair(&db_a, &db_b);
+
+    let engine_a = SyncEngine::start_listener(db_a.clone(), 0);
+    let port_a = engine_a.listen_port().expect("listener bound");
+    set_peer_endpoint(&db_b, &id_a, "127.0.0.1", port_a).expect("endpoint");
+
+    make_note(&db_a, "from A", "carried back to B");
+
+    let engine_b = SyncEngine::start_listener(db_b.clone(), 0);
+    let before = engine_b.data_version();
+    engine_b.sync_now_blocking();
+
+    assert!(
+        matches!(engine_b.activity(), SyncActivity::Done { .. }),
+        "outbound side reports Done, got {:?}",
+        engine_b.activity()
+    );
+    assert!(
+        engine_b.data_version() > before,
+        "outbound apply must bump the data-version ({} -> {})",
+        before,
+        engine_b.data_version()
+    );
+}
+
+#[test]
+fn data_version_bumps_on_served_apply() {
+    let (db_a, _da) = open_db();
+    let (db_b, _db) = open_db();
+    let (id_a, _id_b) = pair(&db_a, &db_b);
+
+    let engine_a = SyncEngine::start_listener(db_a.clone(), 0);
+    let port_a = engine_a.listen_port().expect("listener bound");
+    set_peer_endpoint(&db_b, &id_a, "127.0.0.1", port_a).expect("endpoint");
+
+    let before_a = engine_a.data_version();
+
+    let note_b = make_note(&db_b, "from B", "served into A");
+
+    let engine_b = SyncEngine::start_listener(db_b.clone(), 0);
+    engine_b.sync_now_blocking();
+
+    assert!(
+        wait_until(3000, || db_a.get_note(&note_b).expect("q").is_some()),
+        "served session must apply the pushed note"
+    );
+    assert!(
+        wait_until(3000, || engine_a.data_version() > before_a),
+        "served apply must bump the data-version ({} -> {})",
+        before_a,
+        engine_a.data_version()
+    );
+}
+
+#[test]
+fn data_version_steady_on_zero_change_pass() {
+    let (db_a, _da) = open_db();
+    let (db_b, _db) = open_db();
+    let (id_a, _id_b) = pair(&db_a, &db_b);
+
+    let engine_a = SyncEngine::start_listener(db_a.clone(), 0);
+    let port_a = engine_a.listen_port().expect("listener bound");
+    set_peer_endpoint(&db_b, &id_a, "127.0.0.1", port_a).expect("endpoint");
+
+    let note_b = make_note(&db_b, "seed", "converge first");
+
+    let engine_b = SyncEngine::start_listener(db_b.clone(), 0);
+    engine_b.sync_now_blocking();
+    assert!(
+        wait_until(3000, || db_a.get_note(&note_b).expect("q").is_some()),
+        "first pass must converge"
+    );
+    assert!(
+        wait_until(3000, || engine_a.data_version() > 0),
+        "first pass should have bumped A once"
+    );
+
+    assert!(
+        wait_until(3000, || {
+            !matches!(engine_a.activity(), SyncActivity::Syncing)
+                && !matches!(engine_b.activity(), SyncActivity::Syncing)
+        }),
+        "both engines must settle before the steady snapshot"
+    );
+    let steady_a = engine_a.data_version();
+    let steady_b = engine_b.data_version();
+
+    engine_b.sync_now_blocking();
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    assert_eq!(
+        engine_b.data_version(),
+        steady_b,
+        "a zero-change outbound pass must not move the counter"
+    );
+    assert_eq!(
+        engine_a.data_version(),
+        steady_a,
+        "a zero-change served pass must not move the counter"
+    );
+}


### PR DESCRIPTION
## Summary

This PR ships the full sync UX pass specified in `docs/prd/sync-realtime-ux/` (PRD -> contract -> trace -> verification bundle, all included), plus desktop branding, a redesigned FAB, and the documentation restructure. All acceptance criteria were validated on a real iPhone and Mac.

## Real-time refresh after inbound sync (closes #22)

- `data_version` monotonic counter on `SyncEngine`, bumped only when an inbound apply lands changes (`applied > 0`), on both paths: served/listener session and manual/outbound pass. Full-state reconcile flows through the same two points.
- 400 ms write-on-change UI poll feeds a global `sync_data_version` signal; notes list, sidebar folders, conversations, chat and note detail re-query on bump. Zero-change passes cause zero refresh (no flicker); reconcile bursts coalesce.
- Smart open-detail rule: silent in-place reload when the open note has no unsaved edits; non-blocking banner ("Note updated from another device", i18n EN/FR) when it does - editor signals untouched, tap reloads the merged note, save path byte-for-byte unchanged. 5 deliberate edit collisions on device: 0 keystrokes lost.
- 3 new integration tests (`tests/sync_data_version_test.rs`): outbound bump, served bump, zero-change steady. Suite total: 208 green.

## Safe-area: full-bleed layout on home-indicator iPhones (closes #23)

- Root cause: the default dioxus-desktop index.html lacks `viewport-fit=cover`, so `env(safe-area-inset-*)` was always 0 in the WKWebView. Fixed by shipping a custom index.html through the launch config.
- `safe-pb-*` / `safe-pt` Tailwind utilities (`calc(... + env(safe-area-inset-*))`) replace the fixed paddings across all views; top bar and sidebar clear the Dynamic Island; fixed bottom bars covered via `.keyboard-aware`. macOS is pixel-identical (env() = 0).

## QR pairing via flowflow:// (closes #24)

- `CFBundleURLTypes` registered through an idempotent post-build plist injection (`scripts/inject-url-scheme.sh`), wired into `all`/`ddev-build`/`deploy`/`appstore` before the codesign re-seal.
- tao `Event::Opened { urls }` handler in the launch config feeds a thread-safe deep-link mailbox (`services/sync/deeplink.rs`, peek/take split); the app auto-navigates to the pairing screen, prefills the URI through the existing parser, and pairs on one tap. Copy-paste path kept as a visible fallback.
- Device-validated foregrounded AND cold start (camera scan launches the app with the pairing screen prefilled), so the in-app scanner fallback (task 4.3) is not needed.

## Desktop branding

- `FlowFlow` window title (was "dioxus | tent"), real app icon (`AppIcon.icns` generated from the 1024 px asset) and `CFBundleName`/`CFBundleDisplayName` fixed to "FlowFlow" via `scripts/inject-desktop-icon.sh`, wired into `desktop-build`/`desktop-app`.

## FAB redesign

- Thumb-friendly 96 px single circle (warm white, peach hairline), thin SVG plus.
- Micro-interaction on tap: the plus arms stretch 15% and fade in 150 ms; note detail opens at 150 ms.
- Two WKWebView-specific fixes: press state driven from Rust (`pointerdown`/`up`, since `:active` does not fire on touch) and `transform-box: view-box` (Safari interprets px transform-origins on SVG from the canvas origin).

## Documentation restructure (closes #26)

- README cut from 261 to ~120 lines: showcase only, with multi-device sync as the headline feature and a 6-chapter doc index.
- New `docs/INDEX.md` (chaptered map + doc maintenance rules), `docs/HISTORY.md` (every shipped milestone, chronological), `docs/guides/appstore.md` (all App Store ops moved verbatim out of the README).

## Verification

- `make check` (fmt + clippy), `cargo build` for both feature sets, `cargo test` (208 passed), `make all`, `make desktop-app`: all green.
- PRD success metrics measured on device: inbound change visible < 1 s both directions, 0 lost keystrokes over 5 collisions, 0 clipped bottom controls, QR pairing with zero copy-paste incl. cold start.

Closes #22
Closes #23
Closes #24
Closes #26

## Remaining open issues (out of scope here)

- #27 desktop legacy-data migration crash-safety: fixed by the code merged in #28 (durable data dir + non-destructive migration); closed with a comment.
- #25 desktop responsive UX pass: separate PRD planned.
- #21 split ui/notes/detail.rs (SRP): refactoring to schedule.
