### PR TITLE
fix(threads): collapse threads in folder and subfolder views (#56)

### DIFF
--- a/src/db/note_repo.rs
+++ b/src/db/note_repo.rs
@@ -175,6 +175,31 @@ impl Database {
         Ok(notes)
     }
 
+    pub fn list_root_notes_in_folder(
+        &self,
+        folder_id: &str,
+    ) -> Result<Vec<Note>, String> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT n.* FROM notes n
+                 JOIN notes_folders nf ON nf.note_id = n.id
+                 WHERE nf.folder_id = ?1
+                   AND (n.thread_id IS NULL
+                        OR (SELECT COUNT(*) FROM notes m WHERE m.thread_id = n.thread_id) < 2)
+                 ORDER BY n.created_at DESC",
+            )
+            .map_err(|e| format!("Prepare: {e}"))?;
+        let rows = stmt
+            .query_map([folder_id], row_to_note)
+            .map_err(|e| format!("Query: {e}"))?;
+        let mut notes = Vec::new();
+        for row in rows {
+            notes.push(row.map_err(|e| format!("Row: {e}"))?);
+        }
+        Ok(notes)
+    }
+
     pub fn update_note(
         &self,
         id: &str,

--- a/src/db/thread_repo.rs
+++ b/src/db/thread_repo.rs
@@ -79,6 +79,35 @@ impl Database {
         Ok(threads)
     }
 
+    // Same >= 2 global rule, scoped to a folder: a thread surfaces in a folder
+    // when at least one of its members lives there.
+    pub fn list_feed_threads_in_folder(
+        &self,
+        folder_id: &str,
+    ) -> Result<Vec<Thread>, String> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT t.* FROM threads t
+                 WHERE (SELECT COUNT(*) FROM notes n WHERE n.thread_id = t.id) >= 2
+                   AND EXISTS (
+                       SELECT 1 FROM notes n
+                       JOIN notes_folders nf ON nf.note_id = n.id
+                       WHERE n.thread_id = t.id AND nf.folder_id = ?1
+                   )
+                 ORDER BY t.modified_at DESC",
+            )
+            .map_err(|e| format!("Prepare: {e}"))?;
+        let rows = stmt
+            .query_map([folder_id], row_to_thread)
+            .map_err(|e| format!("Query: {e}"))?;
+        let mut threads = Vec::new();
+        for row in rows {
+            threads.push(row.map_err(|e| format!("Row: {e}"))?);
+        }
+        Ok(threads)
+    }
+
     // A thread with fewer than 2 members is not a thread: delete it, returning
     // any lone member to a flat note. Run at boot and on leaving a thread.
     pub fn collapse_singleton_threads(&self) -> Result<(), String> {

--- a/src/ui/note_list.rs
+++ b/src/ui/note_list.rs
@@ -43,31 +43,28 @@ pub fn NotesList() -> Element {
         let _s = (app.sync_data_version)();
         let db = db();
         let q = (app.search_query)().to_lowercase();
-        match (app.selected_folder_id)() {
-            Some(fid) => db
-                .list_notes_in_folder(&fid)
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|n| note_matches(n, &q))
-                .map(FeedItem::Note)
-                .collect::<Vec<_>>(),
-            None => {
-                let mut items: Vec<FeedItem> = db
-                    .list_root_notes()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|n| note_matches(n, &q))
-                    .map(FeedItem::Note)
-                    .collect();
-                for th in db.list_feed_threads().unwrap_or_default() {
-                    if q.is_empty() || th.title.to_lowercase().contains(&q) {
-                        items.push(FeedItem::Thread(th));
-                    }
-                }
-                items.sort_by(|a, b| b.recency().cmp(a.recency()));
-                items
+        let (root_notes, feed_threads) = match (app.selected_folder_id)() {
+            Some(fid) => (
+                db.list_root_notes_in_folder(&fid).unwrap_or_default(),
+                db.list_feed_threads_in_folder(&fid).unwrap_or_default(),
+            ),
+            None => (
+                db.list_root_notes().unwrap_or_default(),
+                db.list_feed_threads().unwrap_or_default(),
+            ),
+        };
+        let mut items: Vec<FeedItem> = root_notes
+            .into_iter()
+            .filter(|n| note_matches(n, &q))
+            .map(FeedItem::Note)
+            .collect();
+        for th in feed_threads {
+            if q.is_empty() || th.title.to_lowercase().contains(&q) {
+                items.push(FeedItem::Thread(th));
             }
         }
+        items.sort_by(|a, b| b.recency().cmp(a.recency()));
+        items
     });
 
     use_effect(move || {

--- a/tests/thread_test.rs
+++ b/tests/thread_test.rs
@@ -199,6 +199,116 @@ fn list_root_notes_excludes_members_includes_dangling() {
 }
 
 #[test]
+fn folder_feed_collapses_thread_and_hides_members() {
+    let (db, _dir) = open_test_db();
+    let folder = db
+        .create_folder(&flowflow::models::NewFolder {
+            name: "F".into(),
+            description: None,
+            parent_id: None,
+        })
+        .unwrap();
+
+    let flat = make_note(&db, "flat");
+    db.add_note_to_folder(&flat, &folder.id).unwrap();
+
+    let thread = db
+        .create_thread(&NewThread {
+            title: "T".into(),
+            folder_id: Some(folder.id.clone()),
+        })
+        .unwrap();
+    let m1 = make_note(&db, "m1");
+    let m2 = make_note(&db, "m2");
+    db.add_note_to_thread(&m1, &thread.id).unwrap();
+    db.add_note_to_thread(&m2, &thread.id).unwrap();
+    db.add_note_to_folder(&m1, &folder.id).unwrap();
+    db.add_note_to_folder(&m2, &folder.id).unwrap();
+
+    let root: Vec<String> = db
+        .list_root_notes_in_folder(&folder.id)
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+    assert!(root.contains(&flat), "flat note visible in folder");
+    assert!(
+        !root.contains(&m1) && !root.contains(&m2),
+        "thread members hidden in folder feed"
+    );
+
+    let threads = db.list_feed_threads_in_folder(&folder.id).unwrap();
+    assert_eq!(threads.len(), 1, "thread collapses into one card in its folder");
+    assert_eq!(threads[0].id, thread.id);
+}
+
+#[test]
+fn folder_feed_hides_member_even_when_alone_and_reverts_on_remove() {
+    let (db, _dir) = open_test_db();
+    let f = db
+        .create_folder(&flowflow::models::NewFolder {
+            name: "F".into(),
+            description: None,
+            parent_id: None,
+        })
+        .unwrap();
+    let g = db
+        .create_folder(&flowflow::models::NewFolder {
+            name: "G".into(),
+            description: None,
+            parent_id: None,
+        })
+        .unwrap();
+
+    let thread = db
+        .create_thread(&NewThread {
+            title: "T".into(),
+            folder_id: None,
+        })
+        .unwrap();
+    let m1 = make_note(&db, "m1");
+    let m2 = make_note(&db, "m2");
+    db.add_note_to_thread(&m1, &thread.id).unwrap();
+    db.add_note_to_thread(&m2, &thread.id).unwrap();
+    db.add_note_to_folder(&m1, &f.id).unwrap();
+    db.add_note_to_folder(&m2, &g.id).unwrap();
+
+    let root_f: Vec<String> = db
+        .list_root_notes_in_folder(&f.id)
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+    assert!(
+        !root_f.contains(&m1),
+        "member stays hidden even when alone in its folder"
+    );
+    assert_eq!(
+        db.list_feed_threads_in_folder(&f.id).unwrap().len(),
+        1,
+        "thread surfaces in every folder that holds a member"
+    );
+    assert_eq!(db.list_feed_threads_in_folder(&g.id).unwrap().len(), 1);
+
+    db.remove_note_from_thread(&m1).unwrap();
+
+    assert!(
+        db.list_feed_threads_in_folder(&f.id).unwrap().is_empty(),
+        "below 2 members the thread is no longer a thread"
+    );
+    let root_f2: Vec<String> = db
+        .list_root_notes_in_folder(&f.id)
+        .unwrap()
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+    assert!(
+        root_f2.contains(&m1),
+        "removed member returns as a flat note in its folder"
+    );
+}
+
+#[test]
 fn thread_needs_two_members_to_be_a_thread() {
     let (db, _dir) = open_test_db();
     let thread = db


### PR DESCRIPTION
## What
Threads now collapse in folder and subfolder views, not only in "All notes".

Before, opening a folder that held a thread rendered its member notes as separate
individual cards. A thread must behave as one unit everywhere; members are reachable
only by opening the thread.

## Root cause
`note_list.rs` had two divergent feed paths. The all-notes branch fetched
`list_root_notes()` + `list_feed_threads()` and collapsed threads; the folder branch
called `list_notes_in_folder()` and mapped everything to a flat note card, never
querying threads.

## Fix
- `note_repo`: `list_root_notes_in_folder(folder_id)` - folder notes where `thread_id IS NULL`
  OR the thread has fewer than 2 members (global count).
- `thread_repo`: `list_feed_threads_in_folder(folder_id)` - threads with >=2 members that
  have at least one member in the folder.
- `note_list.rs`: the memo now fetches `(root_notes, feed_threads)` either folder-scoped or
  global, then runs a single symmetric build path.
- RAG untouched: `list_notes_in_folder` still feeds chat/summarize/rag, which need every member.

Display-layer only. No migration. Notes stay in SQLite + LanceDB.

## Tests
- 2 new tests in `thread_test.rs`: folder collapse + member hidden even when alone in its
  folder + revert on remove-from-thread.
- Full suite: 287 passed, 11 ignored.

## Device-tested
Thread inside a folder shows one pile; members hidden; open thread to see them; remove-from-thread
restores the flat note; chat still finds member content.

Closes #56
