### PR TITLE
refactor(sync): split apply.rs god-file into apply/ (6 SRP modules)

### DIFF
--- a/src/infrastructure/sync/protocol/apply/archive.rs
+++ b/src/infrastructure/sync/protocol/apply/archive.rs
@@ -1,0 +1,34 @@
+use super::super::collect::load_chunks;
+use super::super::wire::ChunkPayload;
+use crate::infrastructure::sync::conflict::ArchivedChunk;
+use crate::infrastructure::sync::SyncError;
+use rusqlite::Connection;
+
+// The losing version's chunks, ready for the conflict archive. From the
+// pushed payload when the REMOTE version loses; read back from the local
+// chunks table (inside the apply tx, before the winner overwrites them) when
+// the LOCAL version loses.
+pub(super) fn archived_from_payload(
+    chunks: &[ChunkPayload],
+) -> Vec<ArchivedChunk> {
+    chunks
+        .iter()
+        .map(|c| ArchivedChunk {
+            chunk_index: c.chunk_index,
+            vector_b64: c.vector_b64.clone(),
+            content_hash: c.content_hash.clone(),
+            chunk_text: c.chunk_text.clone(),
+            title: c.title.clone(),
+            tags: c.tags.clone(),
+            created_at: c.created_at.clone(),
+        })
+        .collect()
+}
+
+pub(super) fn archived_from_local(
+    conn: &Connection,
+    entity_id: &str,
+    kind: &str,
+) -> Result<Vec<ArchivedChunk>, SyncError> {
+    Ok(archived_from_payload(&load_chunks(conn, entity_id, kind)?))
+}

--- a/src/infrastructure/sync/protocol/apply/entity.rs
+++ b/src/infrastructure/sync/protocol/apply/entity.rs
@@ -1,7 +1,7 @@
 use super::super::catalog::{entity_key_params, KindSpec};
 use super::super::wire::ChunkPayload;
 use super::super::{log, proto_err, sql_err};
-use super::cancel_twin_reminder;
+use super::reminders::cancel_twin_reminder;
 use crate::infrastructure::sync::SyncError;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;

--- a/src/infrastructure/sync/protocol/apply/entity.rs
+++ b/src/infrastructure/sync/protocol/apply/entity.rs
@@ -1,0 +1,147 @@
+use super::super::catalog::{entity_key_params, KindSpec};
+use super::super::wire::ChunkPayload;
+use super::super::{log, proto_err, sql_err};
+use super::cancel_twin_reminder;
+use crate::infrastructure::sync::SyncError;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use rusqlite::Connection;
+use serde_json::Value;
+
+pub(super) fn delete_entity(
+    conn: &Connection,
+    spec: &KindSpec,
+    entity_id: &str,
+    payload: Option<&Value>,
+) -> Result<(), SyncError> {
+    // Reminders: state is authoritative (RFC MAJOR 16). While the parent note
+    // lives, a remote tombstone flips state='tombstone' (keeps the row so the
+    // local OS-handle cleanup can see it and the reminder stops firing); the
+    // row is only physically removed when its note is gone too.
+    if spec.kind == "note_reminder" {
+        let flipped = conn
+            .execute(
+                "UPDATE note_reminders SET state = 'tombstone'
+             WHERE id = ?1 AND EXISTS
+                (SELECT 1 FROM notes WHERE notes.id = note_reminders.note_id)",
+                [entity_id],
+            )
+            .map_err(|e| sql_err("tombstone reminder", e))?;
+        let removed = conn
+            .execute(
+                "DELETE FROM note_reminders
+             WHERE id = ?1 AND NOT EXISTS
+                (SELECT 1 FROM notes WHERE notes.id = note_reminders.note_id)",
+                [entity_id],
+            )
+            .map_err(|e| sql_err("delete orphan reminder", e))?;
+        if flipped + removed == 0 {
+            cancel_twin_reminder(conn, entity_id, payload)?;
+        }
+        return Ok(());
+    }
+    let (where_clause, params) = entity_key_params(spec, entity_id)?;
+    let sql = format!("DELETE FROM {} WHERE {}", spec.table, where_clause);
+    let params: Vec<&dyn rusqlite::ToSql> =
+        params.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
+    conn.execute(&sql, params.as_slice())
+        .map_err(|e| sql_err("delete entity", e))?;
+    if spec.chunk_owner {
+        conn.execute(
+            "DELETE FROM chunks WHERE owner_id = ?1 AND owner_kind = ?2",
+            rusqlite::params![entity_id, spec.kind],
+        )
+        .map_err(|e| sql_err("delete entity chunks", e))?;
+    }
+    Ok(())
+}
+
+pub(super) fn json_to_sql(v: Option<&Value>) -> rusqlite::types::Value {
+    match v {
+        None | Some(Value::Null) => rusqlite::types::Value::Null,
+        Some(Value::Bool(b)) => rusqlite::types::Value::Integer(*b as i64),
+        Some(Value::Number(n)) => {
+            if let Some(i) = n.as_i64() {
+                rusqlite::types::Value::Integer(i)
+            } else {
+                rusqlite::types::Value::Real(n.as_f64().unwrap_or(0.0))
+            }
+        }
+        Some(Value::String(s)) => rusqlite::types::Value::Text(s.clone()),
+        Some(other) => rusqlite::types::Value::Text(other.to_string()),
+    }
+}
+
+pub(super) fn upsert_entity(
+    conn: &Connection,
+    spec: &KindSpec,
+    payload: &Value,
+) -> Result<(), SyncError> {
+    let obj = payload
+        .as_object()
+        .ok_or_else(|| proto_err("payload is not an object"))?;
+    let placeholders: Vec<String> =
+        (1..=spec.cols.len()).map(|i| format!("?{i}")).collect();
+    let sql = format!(
+        "INSERT OR REPLACE INTO {} ({}) VALUES ({})",
+        spec.table,
+        spec.cols.join(", "),
+        placeholders.join(", ")
+    );
+    let values: Vec<rusqlite::types::Value> =
+        spec.cols.iter().map(|c| json_to_sql(obj.get(*c))).collect();
+    let params: Vec<&dyn rusqlite::ToSql> =
+        values.iter().map(|v| v as &dyn rusqlite::ToSql).collect();
+    conn.execute(&sql, params.as_slice())
+        .map_err(|e| sql_err("upsert entity", e))?;
+    Ok(())
+}
+
+pub(super) fn replace_chunks_from_payload(
+    conn: &Connection,
+    owner_id: &str,
+    owner_kind: &str,
+    chunks: &[ChunkPayload],
+) -> Result<(), SyncError> {
+    conn.execute(
+        "DELETE FROM chunks WHERE owner_id = ?1 AND owner_kind = ?2",
+        rusqlite::params![owner_id, owner_kind],
+    )
+    .map_err(|e| sql_err("clear chunks", e))?;
+    for c in chunks {
+        let blob = URL_SAFE_NO_PAD
+            .decode(&c.vector_b64)
+            .map_err(|e| proto_err(format!("decode chunk blob: {e}")))?;
+        // Same guard as reconcile: a malformed BLOB must never reach the
+        // vector store (chunks_to_batch would panic on a bad dimension).
+        if blob.len() != crate::application::constants::EMBEDDING_DIMS * 4 {
+            log(&format!(
+                "skip malformed chunk {} ({} bytes)",
+                c.id,
+                blob.len()
+            ));
+            continue;
+        }
+        conn.execute(
+            "INSERT OR REPLACE INTO chunks
+                (id, owner_id, owner_kind, chunk_index, dim, vector,
+                 content_hash, chunk_text, title, tags, created_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
+            rusqlite::params![
+                c.id,
+                owner_id,
+                owner_kind,
+                c.chunk_index,
+                (blob.len() / 4) as i64,
+                blob,
+                c.content_hash,
+                c.chunk_text,
+                c.title,
+                c.tags,
+                c.created_at,
+            ],
+        )
+        .map_err(|e| sql_err("insert chunk", e))?;
+    }
+    Ok(())
+}

--- a/src/infrastructure/sync/protocol/apply/hlc_guard.rs
+++ b/src/infrastructure/sync/protocol/apply/hlc_guard.rs
@@ -1,0 +1,60 @@
+use super::super::log;
+use super::super::wire::SyncRow;
+use super::LocalMeta;
+use crate::infrastructure::sync::conflict::MergeOutcome;
+use crate::infrastructure::sync::vv::{parse_vv, vv_cmp, vv_join};
+
+fn hlc_after(candidate: Option<&str>, baseline: Option<&str>) -> bool {
+    match (candidate, baseline) {
+        (Some(c), Some(b)) => c > b,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+pub(super) fn hlc_guard(
+    outcome: MergeOutcome,
+    local: &LocalMeta,
+    row: &SyncRow,
+) -> MergeOutcome {
+    let dominated_but_newer = match &outcome {
+        MergeOutcome::AlreadyCurrent => {
+            hlc_after(row.updated_hlc.as_deref(), local.updated_hlc.as_deref())
+        }
+        MergeOutcome::TakeRemote => {
+            hlc_after(local.updated_hlc.as_deref(), row.updated_hlc.as_deref())
+        }
+        MergeOutcome::Concurrent { .. } => false,
+    };
+    if !dominated_but_newer {
+        return outcome;
+    }
+    let (local_vv, corrupt_local) = parse_vv(&local.version_vector);
+    let (remote_vv, corrupt_remote) = parse_vv(&row.version_vector);
+    if corrupt_local || corrupt_remote {
+        return outcome;
+    }
+    if matches!(
+        vv_cmp(&local_vv, &remote_vv),
+        crate::infrastructure::sync::vv::Dominance::Equal
+    ) {
+        return outcome;
+    }
+    let remote_newer =
+        hlc_after(row.updated_hlc.as_deref(), local.updated_hlc.as_deref());
+    log(&format!(
+        "hlc guard: dominated-but-newer on {}:{} -> Concurrent (archive + \
+         tie-break) instead of silent {}",
+        row.entity_kind,
+        row.entity_id,
+        if remote_newer { "skip" } else { "overwrite" }
+    ));
+    MergeOutcome::Concurrent {
+        remote_wins: remote_newer
+            || (row.updated_hlc.as_deref(), row.origin_device.as_str())
+                > (local.updated_hlc.as_deref(), local.origin_device.as_str()),
+        joined: vv_join(&local_vv, &remote_vv),
+        corrupt_local: false,
+        corrupt_remote: false,
+    }
+}

--- a/src/infrastructure/sync/protocol/apply/meta.rs
+++ b/src/infrastructure/sync/protocol/apply/meta.rs
@@ -1,0 +1,82 @@
+use super::super::sql_err;
+use super::super::wire::SyncRow;
+use crate::infrastructure::sync::SyncError;
+use rusqlite::Connection;
+
+pub(super) struct LocalMeta {
+    pub(super) version_vector: String,
+    pub(super) origin_device: String,
+    pub(super) deleted: i64,
+    pub(super) updated_hlc: Option<String>,
+}
+
+pub(super) fn load_local_meta(
+    conn: &Connection,
+    kind: &str,
+    entity_id: &str,
+) -> Result<Option<LocalMeta>, SyncError> {
+    let result = conn.query_row(
+        "SELECT version_vector, origin_device, deleted, updated_hlc
+         FROM sync_row_meta WHERE entity_kind = ?1 AND entity_id = ?2",
+        rusqlite::params![kind, entity_id],
+        |row| {
+            Ok(LocalMeta {
+                version_vector: row.get(0)?,
+                origin_device: row.get(1)?,
+                deleted: row.get(2)?,
+                updated_hlc: row.get(3)?,
+            })
+        },
+    );
+    match result {
+        Ok(m) => Ok(Some(m)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(sql_err("load local meta", e)),
+    }
+}
+
+pub(super) fn upsert_meta_verbatim(
+    conn: &Connection,
+    row: &SyncRow,
+) -> Result<(), SyncError> {
+    conn.execute(
+        "INSERT INTO sync_row_meta
+            (entity_kind, entity_id, version_vector, origin_device,
+             origin_seq, deleted, updated_hlc)
+         VALUES (?1,?2,?3,?4,?5,?6,?7)
+         ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
+            version_vector = excluded.version_vector,
+            origin_device = excluded.origin_device,
+            origin_seq = excluded.origin_seq,
+            deleted = excluded.deleted,
+            updated_hlc = excluded.updated_hlc",
+        rusqlite::params![
+            row.entity_kind,
+            row.entity_id,
+            row.version_vector,
+            row.origin_device,
+            row.origin_seq,
+            row.deleted,
+            row.updated_hlc,
+        ],
+    )
+    .map_err(|e| sql_err("upsert meta", e))?;
+    Ok(())
+}
+
+pub(super) fn meta_hlc(
+    conn: &Connection,
+    kind: &str,
+    entity_id: &str,
+) -> Result<Option<String>, SyncError> {
+    conn.query_row(
+        "SELECT updated_hlc FROM sync_row_meta
+         WHERE entity_kind = ?1 AND entity_id = ?2",
+        rusqlite::params![kind, entity_id],
+        |r| r.get(0),
+    )
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        e => Err(sql_err("meta hlc", e)),
+    })
+}

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -1,12 +1,11 @@
 use super::catalog::{entity_key_params, spec_for, KindSpec};
-use super::collect::{load_chunks, load_payload};
-use super::wire::{ChunkPayload, SyncRow, SyncStats};
+use super::collect::load_payload;
+use super::wire::{SyncRow, SyncStats};
 use super::{log, proto_err, sql_err};
 use crate::infrastructure::persistence::sync_meta;
 use crate::infrastructure::persistence::Database;
 use crate::infrastructure::sync::conflict::{
-    archive_conflict, decide, write_merged_meta, ArchivedChunk, MergeOutcome,
-    VersionInfo,
+    archive_conflict, decide, write_merged_meta, MergeOutcome, VersionInfo,
 };
 use crate::infrastructure::sync::vv::{parse_vv, vv_join};
 use crate::infrastructure::sync::SyncError;
@@ -16,7 +15,9 @@ use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
+mod archive;
 mod hlc_guard;
+use archive::{archived_from_local, archived_from_payload};
 use hlc_guard::hlc_guard;
 
 const MAX_CHUNKS_PER_ROW: usize = 1024;
@@ -99,33 +100,6 @@ fn upsert_meta_verbatim(
     )
     .map_err(|e| sql_err("upsert meta", e))?;
     Ok(())
-}
-
-// The losing version's chunks, ready for the conflict archive. From the
-// pushed payload when the REMOTE version loses; read back from the local
-// chunks table (inside the apply tx, before the winner overwrites them) when
-// the LOCAL version loses.
-fn archived_from_payload(chunks: &[ChunkPayload]) -> Vec<ArchivedChunk> {
-    chunks
-        .iter()
-        .map(|c| ArchivedChunk {
-            chunk_index: c.chunk_index,
-            vector_b64: c.vector_b64.clone(),
-            content_hash: c.content_hash.clone(),
-            chunk_text: c.chunk_text.clone(),
-            title: c.title.clone(),
-            tags: c.tags.clone(),
-            created_at: c.created_at.clone(),
-        })
-        .collect()
-}
-
-fn archived_from_local(
-    conn: &Connection,
-    entity_id: &str,
-    kind: &str,
-) -> Result<Vec<ArchivedChunk>, SyncError> {
-    Ok(archived_from_payload(&load_chunks(conn, entity_id, kind)?))
 }
 
 fn delete_entity(

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -8,13 +8,16 @@ use crate::infrastructure::sync::conflict::{
     archive_conflict, decide, write_merged_meta, ArchivedChunk, MergeOutcome,
     VersionInfo,
 };
-use crate::infrastructure::sync::vv::{parse_vv, vv_cmp, vv_join};
+use crate::infrastructure::sync::vv::{parse_vv, vv_join};
 use crate::infrastructure::sync::SyncError;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::BTreeMap;
+
+mod hlc_guard;
+use hlc_guard::hlc_guard;
 
 const MAX_CHUNKS_PER_ROW: usize = 1024;
 
@@ -848,61 +851,6 @@ fn apply_row(
         }
     }
     Ok(())
-}
-
-fn hlc_after(candidate: Option<&str>, baseline: Option<&str>) -> bool {
-    match (candidate, baseline) {
-        (Some(c), Some(b)) => c > b,
-        (Some(_), None) => true,
-        _ => false,
-    }
-}
-
-fn hlc_guard(
-    outcome: MergeOutcome,
-    local: &LocalMeta,
-    row: &SyncRow,
-) -> MergeOutcome {
-    let dominated_but_newer = match &outcome {
-        MergeOutcome::AlreadyCurrent => {
-            hlc_after(row.updated_hlc.as_deref(), local.updated_hlc.as_deref())
-        }
-        MergeOutcome::TakeRemote => {
-            hlc_after(local.updated_hlc.as_deref(), row.updated_hlc.as_deref())
-        }
-        MergeOutcome::Concurrent { .. } => false,
-    };
-    if !dominated_but_newer {
-        return outcome;
-    }
-    let (local_vv, corrupt_local) = parse_vv(&local.version_vector);
-    let (remote_vv, corrupt_remote) = parse_vv(&row.version_vector);
-    if corrupt_local || corrupt_remote {
-        return outcome;
-    }
-    if matches!(
-        vv_cmp(&local_vv, &remote_vv),
-        crate::infrastructure::sync::vv::Dominance::Equal
-    ) {
-        return outcome;
-    }
-    let remote_newer =
-        hlc_after(row.updated_hlc.as_deref(), local.updated_hlc.as_deref());
-    log(&format!(
-        "hlc guard: dominated-but-newer on {}:{} -> Concurrent (archive + \
-         tie-break) instead of silent {}",
-        row.entity_kind,
-        row.entity_id,
-        if remote_newer { "skip" } else { "overwrite" }
-    ));
-    MergeOutcome::Concurrent {
-        remote_wins: remote_newer
-            || (row.updated_hlc.as_deref(), row.origin_device.as_str())
-                > (local.updated_hlc.as_deref(), local.origin_device.as_str()),
-        joined: vv_join(&local_vv, &remote_vv),
-        corrupt_local: false,
-        corrupt_remote: false,
-    }
 }
 
 pub(super) fn current_watermark(

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -1,4 +1,4 @@
-use super::catalog::{entity_key_params, spec_for, KindSpec};
+use super::catalog::{spec_for, KindSpec};
 use super::collect::load_payload;
 use super::wire::{SyncRow, SyncStats};
 use super::{log, proto_err, sql_err};
@@ -9,22 +9,24 @@ use crate::infrastructure::sync::conflict::{
 };
 use crate::infrastructure::sync::vv::{parse_vv, vv_join};
 use crate::infrastructure::sync::SyncError;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine as _;
 use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
 mod archive;
+mod entity;
 mod hlc_guard;
 mod meta;
 use archive::{archived_from_local, archived_from_payload};
+use entity::{
+    delete_entity, json_to_sql, replace_chunks_from_payload, upsert_entity,
+};
 use hlc_guard::hlc_guard;
 use meta::{load_local_meta, meta_hlc, upsert_meta_verbatim, LocalMeta};
 
 const MAX_CHUNKS_PER_ROW: usize = 1024;
 
-// Session facts the row-level merge needs (T19). Snapshotted at HELLO time by
+// Session facts the row-level merge needs. Snapshotted at HELLO time by
 // session.rs and constant for the whole session.
 // - peer_acked_of_mine: how far the peer has consumed MY seq space. A local
 //   child row above it is an addition the peer has never seen -> concurrent
@@ -32,7 +34,7 @@ const MAX_CHUNKS_PER_ROW: usize = 1024;
 // - authority: I am the intact side of a full-state session (the peer was
 //   restored or missed GC'd tombstones). I was never restored, so I hold a
 //   meta row for everything I ever knew: an alive peer row I have NO meta
-//   for is missing-locally = deleted (RFC 0004 reconciliation rule), and is
+//   for is missing-locally = deleted, and is
 //   archived before being re-deleted so it stays recoverable.
 pub(super) struct ApplyCtx {
     pub full_state: bool,
@@ -41,144 +43,6 @@ pub(super) struct ApplyCtx {
     pub restored_session: bool,
     pub exempt_floor: Option<i64>,
     pub peer_device: String,
-}
-
-fn delete_entity(
-    conn: &Connection,
-    spec: &KindSpec,
-    entity_id: &str,
-    payload: Option<&Value>,
-) -> Result<(), SyncError> {
-    // Reminders: state is authoritative (RFC MAJOR 16). While the parent note
-    // lives, a remote tombstone flips state='tombstone' (keeps the row so the
-    // local OS-handle cleanup can see it and the reminder stops firing); the
-    // row is only physically removed when its note is gone too.
-    if spec.kind == "note_reminder" {
-        let flipped = conn
-            .execute(
-                "UPDATE note_reminders SET state = 'tombstone'
-             WHERE id = ?1 AND EXISTS
-                (SELECT 1 FROM notes WHERE notes.id = note_reminders.note_id)",
-                [entity_id],
-            )
-            .map_err(|e| sql_err("tombstone reminder", e))?;
-        let removed = conn
-            .execute(
-                "DELETE FROM note_reminders
-             WHERE id = ?1 AND NOT EXISTS
-                (SELECT 1 FROM notes WHERE notes.id = note_reminders.note_id)",
-                [entity_id],
-            )
-            .map_err(|e| sql_err("delete orphan reminder", e))?;
-        if flipped + removed == 0 {
-            cancel_twin_reminder(conn, entity_id, payload)?;
-        }
-        return Ok(());
-    }
-    let (where_clause, params) = entity_key_params(spec, entity_id)?;
-    let sql = format!("DELETE FROM {} WHERE {}", spec.table, where_clause);
-    let params: Vec<&dyn rusqlite::ToSql> =
-        params.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
-    conn.execute(&sql, params.as_slice())
-        .map_err(|e| sql_err("delete entity", e))?;
-    if spec.chunk_owner {
-        conn.execute(
-            "DELETE FROM chunks WHERE owner_id = ?1 AND owner_kind = ?2",
-            rusqlite::params![entity_id, spec.kind],
-        )
-        .map_err(|e| sql_err("delete entity chunks", e))?;
-    }
-    Ok(())
-}
-
-fn json_to_sql(v: Option<&Value>) -> rusqlite::types::Value {
-    match v {
-        None | Some(Value::Null) => rusqlite::types::Value::Null,
-        Some(Value::Bool(b)) => rusqlite::types::Value::Integer(*b as i64),
-        Some(Value::Number(n)) => {
-            if let Some(i) = n.as_i64() {
-                rusqlite::types::Value::Integer(i)
-            } else {
-                rusqlite::types::Value::Real(n.as_f64().unwrap_or(0.0))
-            }
-        }
-        Some(Value::String(s)) => rusqlite::types::Value::Text(s.clone()),
-        Some(other) => rusqlite::types::Value::Text(other.to_string()),
-    }
-}
-
-fn upsert_entity(
-    conn: &Connection,
-    spec: &KindSpec,
-    payload: &Value,
-) -> Result<(), SyncError> {
-    let obj = payload
-        .as_object()
-        .ok_or_else(|| proto_err("payload is not an object"))?;
-    let placeholders: Vec<String> =
-        (1..=spec.cols.len()).map(|i| format!("?{i}")).collect();
-    let sql = format!(
-        "INSERT OR REPLACE INTO {} ({}) VALUES ({})",
-        spec.table,
-        spec.cols.join(", "),
-        placeholders.join(", ")
-    );
-    let values: Vec<rusqlite::types::Value> =
-        spec.cols.iter().map(|c| json_to_sql(obj.get(*c))).collect();
-    let params: Vec<&dyn rusqlite::ToSql> =
-        values.iter().map(|v| v as &dyn rusqlite::ToSql).collect();
-    conn.execute(&sql, params.as_slice())
-        .map_err(|e| sql_err("upsert entity", e))?;
-    Ok(())
-}
-
-fn replace_chunks_from_payload(
-    conn: &Connection,
-    owner_id: &str,
-    owner_kind: &str,
-    chunks: &[super::wire::ChunkPayload],
-) -> Result<(), SyncError> {
-    conn.execute(
-        "DELETE FROM chunks WHERE owner_id = ?1 AND owner_kind = ?2",
-        rusqlite::params![owner_id, owner_kind],
-    )
-    .map_err(|e| sql_err("clear chunks", e))?;
-    for c in chunks {
-        let blob = URL_SAFE_NO_PAD
-            .decode(&c.vector_b64)
-            .map_err(|e| proto_err(format!("decode chunk blob: {e}")))?;
-        // Same guard as reconcile: a malformed BLOB must never reach the
-        // vector store (chunks_to_batch would panic on a bad dimension).
-        if blob.len() != crate::application::constants::EMBEDDING_DIMS * 4 {
-            log(&format!(
-                "skip malformed chunk {} ({} bytes)",
-                c.id,
-                blob.len()
-            ));
-            continue;
-        }
-        conn.execute(
-            "INSERT OR REPLACE INTO chunks
-                (id, owner_id, owner_kind, chunk_index, dim, vector,
-                 content_hash, chunk_text, title, tags, created_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
-            rusqlite::params![
-                c.id,
-                owner_id,
-                owner_kind,
-                c.chunk_index,
-                (blob.len() / 4) as i64,
-                blob,
-                c.content_hash,
-                c.chunk_text,
-                c.title,
-                c.tags,
-                c.created_at,
-            ],
-        )
-        .map_err(|e| sql_err("insert chunk", e))?;
-    }
-    Ok(())
 }
 
 fn payload_intent(payload: Option<&Value>) -> Option<(String, String)> {

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -17,12 +17,14 @@ mod archive;
 mod entity;
 mod hlc_guard;
 mod meta;
+mod reminders;
 use archive::{archived_from_local, archived_from_payload};
-use entity::{
-    delete_entity, json_to_sql, replace_chunks_from_payload, upsert_entity,
-};
+use entity::{delete_entity, replace_chunks_from_payload, upsert_entity};
 use hlc_guard::hlc_guard;
-use meta::{load_local_meta, meta_hlc, upsert_meta_verbatim, LocalMeta};
+use meta::{load_local_meta, upsert_meta_verbatim, LocalMeta};
+use reminders::{
+    merge_reminder_intent, reactivate_twin_reminder, ReminderMerge,
+};
 
 const MAX_CHUNKS_PER_ROW: usize = 1024;
 
@@ -45,66 +47,6 @@ pub(super) struct ApplyCtx {
     pub peer_device: String,
 }
 
-fn payload_intent(payload: Option<&Value>) -> Option<(String, String)> {
-    let obj = payload?.as_object()?;
-    Some((
-        obj.get("note_id")?.as_str()?.to_string(),
-        obj.get("intent_hash")?.as_str()?.to_string(),
-    ))
-}
-
-fn find_twin_reminder(
-    conn: &Connection,
-    entity_id: &str,
-    note_id: &str,
-    intent_hash: &str,
-) -> Result<Option<(String, String)>, SyncError> {
-    conn.query_row(
-        "SELECT id, state FROM note_reminders
-         WHERE note_id = ?1 AND intent_hash = ?2 AND id != ?3",
-        rusqlite::params![note_id, intent_hash, entity_id],
-        |r| Ok((r.get(0)?, r.get(1)?)),
-    )
-    .map(Some)
-    .or_else(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => Ok(None),
-        e => Err(sql_err("reminder twin lookup", e)),
-    })
-}
-
-// T23 cross-id cancel: a reminder tombstone whose id is unknown here may
-// still target the SAME intent as a local row created independently (twin).
-// A cancel anywhere kills the intent everywhere: flip the local twin to
-// tombstone and author the change locally (the triggers are silenced during
-// apply) so the cancel propagates back to every other device.
-fn cancel_twin_reminder(
-    conn: &Connection,
-    entity_id: &str,
-    payload: Option<&Value>,
-) -> Result<(), SyncError> {
-    let Some((note_id, intent_hash)) = payload_intent(payload) else {
-        return Ok(());
-    };
-    let twin = find_twin_reminder(conn, entity_id, &note_id, &intent_hash)?;
-    let Some((twin_id, state)) = twin else {
-        return Ok(());
-    };
-    if state != "active" {
-        return Ok(());
-    }
-    conn.execute(
-        "UPDATE note_reminders SET state = 'tombstone' WHERE id = ?1",
-        [&twin_id],
-    )
-    .map_err(|e| sql_err("cancel twin reminder", e))?;
-    sync_meta::tombstone_entity(conn, "note_reminder", &twin_id)
-        .map_err(SyncError::Protocol)?;
-    log(&format!(
-        "reminder cancel {entity_id} -> local twin {twin_id} (same intent)"
-    ));
-    Ok(())
-}
-
 // A version vector that strictly dominates the remote one: join + one local
 // increment. Used wherever this device overrides a remote version with a
 // locally-authored decision (full-state re-delete, twin cancel-wins), so the
@@ -114,84 +56,6 @@ fn dominating_vv(remote_vv: &str, my_device: &str) -> BTreeMap<String, i64> {
     let (mut vv, _) = parse_vv(remote_vv);
     *vv.entry(my_device.to_string()).or_insert(0) += 1;
     vv
-}
-
-// What to do with an incoming ALIVE reminder given the local twin landscape
-// (T23, RFC MAJOR 10/16). The intent is the synced unit; the OS handle stays
-// device-local, so a twin row keeps ITS id and ITS handle.
-enum ReminderMerge {
-    NoTwin,
-    // An active local row already carries this intent: the remote row is the
-    // same reminder under another id. Keep ours, skip theirs.
-    KeepActiveTwin,
-    // The local twin was cancelled, but the remote ALIVE version is NEWER
-    // (the user re-created the intent after the cancel): reactivate ours.
-    ReactivateTwin(String),
-    // The local cancel is newer than the remote alive version: the cancel
-    // wins; author a dominating tombstone for the remote id so the cancel
-    // reaches the peer instead of its zombie reactivating ours forever.
-    CancelRemote,
-}
-
-fn merge_reminder_intent(
-    conn: &Connection,
-    row: &SyncRow,
-    payload: &Value,
-) -> Result<ReminderMerge, SyncError> {
-    let Some((note_id, intent_hash)) = payload_intent(Some(payload)) else {
-        return Ok(ReminderMerge::NoTwin);
-    };
-    let twin =
-        find_twin_reminder(conn, &row.entity_id, &note_id, &intent_hash)?;
-    let Some((twin_id, state)) = twin else {
-        return Ok(ReminderMerge::NoTwin);
-    };
-    if state == "active" {
-        return Ok(ReminderMerge::KeepActiveTwin);
-    }
-    let cancel_hlc = meta_hlc(conn, "note_reminder", &twin_id)?;
-    let remote_newer = match (&row.updated_hlc, &cancel_hlc) {
-        (Some(remote), Some(local)) => remote > local,
-        // Unknown ordering: bias toward the cancel (never resurrect a
-        // notification the user explicitly killed).
-        _ => false,
-    };
-    if remote_newer {
-        Ok(ReminderMerge::ReactivateTwin(twin_id))
-    } else {
-        Ok(ReminderMerge::CancelRemote)
-    }
-}
-
-fn reactivate_twin_reminder(
-    conn: &Connection,
-    twin_id: &str,
-    payload: &Value,
-) -> Result<(), SyncError> {
-    let get = |k: &str| payload.get(k).cloned().unwrap_or(Value::Null);
-    conn.execute(
-        "UPDATE note_reminders SET
-            state = 'active',
-            due_year = ?2, due_month = ?3, due_day = ?4,
-            due_hour = ?5, due_minute = ?6, is_all_day = ?7,
-            tz_id = ?8, recurrence = ?9
-         WHERE id = ?1",
-        rusqlite::params![
-            twin_id,
-            json_to_sql(Some(&get("due_year"))),
-            json_to_sql(Some(&get("due_month"))),
-            json_to_sql(Some(&get("due_day"))),
-            json_to_sql(Some(&get("due_hour"))),
-            json_to_sql(Some(&get("due_minute"))),
-            json_to_sql(Some(&get("is_all_day"))),
-            json_to_sql(Some(&get("tz_id"))),
-            json_to_sql(Some(&get("recurrence"))),
-        ],
-    )
-    .map_err(|e| sql_err("reactivate twin reminder", e))?;
-    sync_meta::mark_entity_updated(conn, "note_reminder", twin_id)
-        .map_err(SyncError::Protocol)?;
-    Ok(())
 }
 
 // How the row's CONTENT landed. The CALLER still records the row's meta for

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -17,8 +17,10 @@ use std::collections::BTreeMap;
 
 mod archive;
 mod hlc_guard;
+mod meta;
 use archive::{archived_from_local, archived_from_payload};
 use hlc_guard::hlc_guard;
+use meta::{load_local_meta, meta_hlc, upsert_meta_verbatim, LocalMeta};
 
 const MAX_CHUNKS_PER_ROW: usize = 1024;
 
@@ -39,67 +41,6 @@ pub(super) struct ApplyCtx {
     pub restored_session: bool,
     pub exempt_floor: Option<i64>,
     pub peer_device: String,
-}
-
-struct LocalMeta {
-    version_vector: String,
-    origin_device: String,
-    deleted: i64,
-    updated_hlc: Option<String>,
-}
-
-fn load_local_meta(
-    conn: &Connection,
-    kind: &str,
-    entity_id: &str,
-) -> Result<Option<LocalMeta>, SyncError> {
-    let result = conn.query_row(
-        "SELECT version_vector, origin_device, deleted, updated_hlc
-         FROM sync_row_meta WHERE entity_kind = ?1 AND entity_id = ?2",
-        rusqlite::params![kind, entity_id],
-        |row| {
-            Ok(LocalMeta {
-                version_vector: row.get(0)?,
-                origin_device: row.get(1)?,
-                deleted: row.get(2)?,
-                updated_hlc: row.get(3)?,
-            })
-        },
-    );
-    match result {
-        Ok(m) => Ok(Some(m)),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-        Err(e) => Err(sql_err("load local meta", e)),
-    }
-}
-
-fn upsert_meta_verbatim(
-    conn: &Connection,
-    row: &SyncRow,
-) -> Result<(), SyncError> {
-    conn.execute(
-        "INSERT INTO sync_row_meta
-            (entity_kind, entity_id, version_vector, origin_device,
-             origin_seq, deleted, updated_hlc)
-         VALUES (?1,?2,?3,?4,?5,?6,?7)
-         ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
-            version_vector = excluded.version_vector,
-            origin_device = excluded.origin_device,
-            origin_seq = excluded.origin_seq,
-            deleted = excluded.deleted,
-            updated_hlc = excluded.updated_hlc",
-        rusqlite::params![
-            row.entity_kind,
-            row.entity_id,
-            row.version_vector,
-            row.origin_device,
-            row.origin_seq,
-            row.deleted,
-            row.updated_hlc,
-        ],
-    )
-    .map_err(|e| sql_err("upsert meta", e))?;
-    Ok(())
 }
 
 fn delete_entity(
@@ -309,23 +250,6 @@ fn dominating_vv(remote_vv: &str, my_device: &str) -> BTreeMap<String, i64> {
     let (mut vv, _) = parse_vv(remote_vv);
     *vv.entry(my_device.to_string()).or_insert(0) += 1;
     vv
-}
-
-fn meta_hlc(
-    conn: &Connection,
-    kind: &str,
-    entity_id: &str,
-) -> Result<Option<String>, SyncError> {
-    conn.query_row(
-        "SELECT updated_hlc FROM sync_row_meta
-         WHERE entity_kind = ?1 AND entity_id = ?2",
-        rusqlite::params![kind, entity_id],
-        |r| r.get(0),
-    )
-    .or_else(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => Ok(None),
-        e => Err(sql_err("meta hlc", e)),
-    })
 }
 
 // What to do with an incoming ALIVE reminder given the local twin landscape

--- a/src/infrastructure/sync/protocol/apply/reminders.rs
+++ b/src/infrastructure/sync/protocol/apply/reminders.rs
@@ -1,0 +1,146 @@
+use super::super::wire::SyncRow;
+use super::super::{log, sql_err};
+use super::entity::json_to_sql;
+use super::meta::meta_hlc;
+use crate::infrastructure::persistence::sync_meta;
+use crate::infrastructure::sync::SyncError;
+use rusqlite::Connection;
+use serde_json::Value;
+
+fn payload_intent(payload: Option<&Value>) -> Option<(String, String)> {
+    let obj = payload?.as_object()?;
+    Some((
+        obj.get("note_id")?.as_str()?.to_string(),
+        obj.get("intent_hash")?.as_str()?.to_string(),
+    ))
+}
+
+fn find_twin_reminder(
+    conn: &Connection,
+    entity_id: &str,
+    note_id: &str,
+    intent_hash: &str,
+) -> Result<Option<(String, String)>, SyncError> {
+    conn.query_row(
+        "SELECT id, state FROM note_reminders
+         WHERE note_id = ?1 AND intent_hash = ?2 AND id != ?3",
+        rusqlite::params![note_id, intent_hash, entity_id],
+        |r| Ok((r.get(0)?, r.get(1)?)),
+    )
+    .map(Some)
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        e => Err(sql_err("reminder twin lookup", e)),
+    })
+}
+
+// T23 cross-id cancel: a reminder tombstone whose id is unknown here may
+// still target the SAME intent as a local row created independently (twin).
+// A cancel anywhere kills the intent everywhere: flip the local twin to
+// tombstone and author the change locally (the triggers are silenced during
+// apply) so the cancel propagates back to every other device.
+pub(super) fn cancel_twin_reminder(
+    conn: &Connection,
+    entity_id: &str,
+    payload: Option<&Value>,
+) -> Result<(), SyncError> {
+    let Some((note_id, intent_hash)) = payload_intent(payload) else {
+        return Ok(());
+    };
+    let twin = find_twin_reminder(conn, entity_id, &note_id, &intent_hash)?;
+    let Some((twin_id, state)) = twin else {
+        return Ok(());
+    };
+    if state != "active" {
+        return Ok(());
+    }
+    conn.execute(
+        "UPDATE note_reminders SET state = 'tombstone' WHERE id = ?1",
+        [&twin_id],
+    )
+    .map_err(|e| sql_err("cancel twin reminder", e))?;
+    sync_meta::tombstone_entity(conn, "note_reminder", &twin_id)
+        .map_err(SyncError::Protocol)?;
+    log(&format!(
+        "reminder cancel {entity_id} -> local twin {twin_id} (same intent)"
+    ));
+    Ok(())
+}
+
+// What to do with an incoming ALIVE reminder given the local twin landscape
+// (T23, RFC MAJOR 10/16). The intent is the synced unit; the OS handle stays
+// device-local, so a twin row keeps ITS id and ITS handle.
+pub(super) enum ReminderMerge {
+    NoTwin,
+    // An active local row already carries this intent: the remote row is the
+    // same reminder under another id. Keep ours, skip theirs.
+    KeepActiveTwin,
+    // The local twin was cancelled, but the remote ALIVE version is NEWER
+    // (the user re-created the intent after the cancel): reactivate ours.
+    ReactivateTwin(String),
+    // The local cancel is newer than the remote alive version: the cancel
+    // wins; author a dominating tombstone for the remote id so the cancel
+    // reaches the peer instead of its zombie reactivating ours forever.
+    CancelRemote,
+}
+
+pub(super) fn merge_reminder_intent(
+    conn: &Connection,
+    row: &SyncRow,
+    payload: &Value,
+) -> Result<ReminderMerge, SyncError> {
+    let Some((note_id, intent_hash)) = payload_intent(Some(payload)) else {
+        return Ok(ReminderMerge::NoTwin);
+    };
+    let twin =
+        find_twin_reminder(conn, &row.entity_id, &note_id, &intent_hash)?;
+    let Some((twin_id, state)) = twin else {
+        return Ok(ReminderMerge::NoTwin);
+    };
+    if state == "active" {
+        return Ok(ReminderMerge::KeepActiveTwin);
+    }
+    let cancel_hlc = meta_hlc(conn, "note_reminder", &twin_id)?;
+    let remote_newer = match (&row.updated_hlc, &cancel_hlc) {
+        (Some(remote), Some(local)) => remote > local,
+        // Unknown ordering: bias toward the cancel (never resurrect a
+        // notification the user explicitly killed).
+        _ => false,
+    };
+    if remote_newer {
+        Ok(ReminderMerge::ReactivateTwin(twin_id))
+    } else {
+        Ok(ReminderMerge::CancelRemote)
+    }
+}
+
+pub(super) fn reactivate_twin_reminder(
+    conn: &Connection,
+    twin_id: &str,
+    payload: &Value,
+) -> Result<(), SyncError> {
+    let get = |k: &str| payload.get(k).cloned().unwrap_or(Value::Null);
+    conn.execute(
+        "UPDATE note_reminders SET
+            state = 'active',
+            due_year = ?2, due_month = ?3, due_day = ?4,
+            due_hour = ?5, due_minute = ?6, is_all_day = ?7,
+            tz_id = ?8, recurrence = ?9
+         WHERE id = ?1",
+        rusqlite::params![
+            twin_id,
+            json_to_sql(Some(&get("due_year"))),
+            json_to_sql(Some(&get("due_month"))),
+            json_to_sql(Some(&get("due_day"))),
+            json_to_sql(Some(&get("due_hour"))),
+            json_to_sql(Some(&get("due_minute"))),
+            json_to_sql(Some(&get("is_all_day"))),
+            json_to_sql(Some(&get("tz_id"))),
+            json_to_sql(Some(&get("recurrence"))),
+        ],
+    )
+    .map_err(|e| sql_err("reactivate twin reminder", e))?;
+    sync_meta::mark_entity_updated(conn, "note_reminder", twin_id)
+        .map_err(SyncError::Protocol)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Behavior-preserving SRP split of `src/infrastructure/sync/protocol/apply.rs`
(1004-line god-file) into a 6-module `apply/` tree. Pure moves plus visibility
adjustments, zero logic change. Also carries two earlier refactor commits
already on `development` (llm + embed extractions).

## apply.rs split (5 commits)

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `apply/mod.rs` | 578 | merge core: apply_row, apply_row_content, concurrent_child_adds, apply_batch, ApplyGuard, current_watermark, dominating_vv |
| `apply/entity.rs` | 147 | entity + chunk SQL writes |
| `apply/reminders.rs` | 146 | reminder-twin reconciliation (T23) |
| `apply/meta.rs` | 82 | sync_row_meta accessors + LocalMeta |
| `apply/hlc_guard.rs` | 60 | HLC dominated-but-newer guard |
| `apply/archive.rs` | 34 | losing-version chunk archival |

`apply_row` (239 lines) is kept whole in `mod.rs`: it is the cohesive CRDT
merge algorithm, a single responsibility. Splitting it on a hypothetical axis
with no change pressure would be needless complexity.

## Also included (pre-existing on development)

- `44fda62` refactor(llm): move tagging/titling/reminders use-cases out of infrastructure into application
- `af430c5` refactor(embed): extract chunk-blob store + sync-meta coordination into embed/chunk_store.rs

## Verification

- `cargo check --lib`: clean
- `cargo clippy --lib`: no issues
- 50 sync tests pass (sync_protocol, sync_conflict, note_reminder, reminders_extract, sync_meta)

https://claude.ai/code/session_01FbSG5cgfAgTFoGSFCMXp2B
