### PR TITLE
refactor(rag): split rag.rs into single-responsibility modules

### DIFF
--- a/src/application/rag/config.rs
+++ b/src/application/rag/config.rs
@@ -1,0 +1,20 @@
+use crate::application::constants::DEFAULT_RAG_MAX_SOURCES;
+use crate::infrastructure::persistence::Database;
+
+pub(super) fn web_search_config() -> (bool, String) {
+    let Ok(db) = Database::open() else {
+        return (false, String::new());
+    };
+    let enabled =
+        db.get_setting("web_search_enabled").as_deref() == Some("true");
+    let key = crate::application::web_search::exa_api_key(&db);
+    (enabled, key)
+}
+
+pub(super) fn read_max_sources() -> usize {
+    Database::open()
+        .ok()
+        .and_then(|d| d.get_setting("rag_max_sources"))
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_RAG_MAX_SOURCES)
+}

--- a/src/application/rag/context.rs
+++ b/src/application/rag/context.rs
@@ -1,0 +1,14 @@
+use crate::infrastructure::vectordb::SearchResult;
+
+pub fn build_context(results: &[SearchResult]) -> String {
+    let mut ctx = String::from("--- User notes ---\n\n");
+    for (i, r) in results.iter().enumerate() {
+        ctx.push_str(&format!(
+            "[Source {}] Note: \"{}\"\n{}\n\n",
+            i + 1,
+            r.title,
+            r.chunk_text
+        ));
+    }
+    ctx
+}

--- a/src/application/rag/fusion.rs
+++ b/src/application/rag/fusion.rs
@@ -1,0 +1,58 @@
+use crate::application::constants::RAG_DISTANCE_THRESHOLD;
+use crate::application::web_search::WebResult;
+use crate::infrastructure::vectordb::{SearchResult, SourceType};
+use std::collections::HashSet;
+
+fn web_to_search_result(w: WebResult) -> SearchResult {
+    SearchResult {
+        chunk_text: w.snippet,
+        note_id: String::new(),
+        title: w.title,
+        distance: 0.0,
+        created_at: w.published_date.unwrap_or_default(),
+        source_type: SourceType::Web,
+        url: Some(w.url),
+    }
+}
+
+pub fn rrf_merge(
+    local: Vec<SearchResult>,
+    web: Vec<WebResult>,
+    k: f32,
+    local_weight: f32,
+    web_weight: f32,
+) -> Vec<SearchResult> {
+    let mut scored: Vec<(SearchResult, f32)> =
+        Vec::with_capacity(local.len() + web.len());
+    for (rank, r) in local.into_iter().enumerate() {
+        scored.push((r, local_weight / (k + rank as f32 + 1.0)));
+    }
+    for (rank, w) in web.into_iter().enumerate() {
+        scored.push((
+            web_to_search_result(w),
+            web_weight / (k + rank as f32 + 1.0),
+        ));
+    }
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    scored.into_iter().map(|(r, _)| r).collect()
+}
+
+pub(super) fn dedup_merged(results: Vec<SearchResult>) -> Vec<SearchResult> {
+    let mut seen_notes = HashSet::new();
+    let mut seen_web = HashSet::new();
+    results
+        .into_iter()
+        .filter(|r| match r.source_type {
+            SourceType::Local => {
+                r.distance <= RAG_DISTANCE_THRESHOLD
+                    && seen_notes.insert(r.note_id.clone())
+            }
+            SourceType::Web => {
+                let key: String = r.chunk_text.chars().take(200).collect();
+                seen_web.insert(key)
+            }
+        })
+        .collect()
+}

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -1,7 +1,7 @@
 use crate::application::constants::{
     DEFAULT_RAG_MAX_SOURCES, RAG_AGENT_SYSTEM_PROMPT,
-    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K, RAG_INITIAL_K, RERANK_PROMPT,
-    RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
+    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K, RAG_INITIAL_K, RRF_K,
+    RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
 use crate::infrastructure::llm::LlmClient;
@@ -19,6 +19,9 @@ use temporal::{apply_date_filter, detect_temporal_llm, detect_temporal_regex};
 
 mod scoring;
 use scoring::{apply_temporal_boost, compute_source_count, filter_and_dedup};
+
+mod rerank;
+use rerank::llm_rerank;
 
 pub use crate::domain::ChatScope;
 
@@ -50,64 +53,6 @@ pub fn build_context(results: &[SearchResult]) -> String {
         ));
     }
     ctx
-}
-
-fn parse_rerank_indices(response: &str, max: usize) -> Vec<usize> {
-    response
-        .split(',')
-        .filter_map(|s| s.trim().parse::<usize>().ok())
-        .filter(|&i| i >= 1 && i <= max)
-        .map(|i| i - 1)
-        .collect()
-}
-
-async fn llm_rerank(
-    llm: &LlmClient,
-    question: &str,
-    results: Vec<SearchResult>,
-    final_k: usize,
-) -> Vec<SearchResult> {
-    if results.len() <= final_k {
-        return results;
-    }
-
-    let passages: String = results
-        .iter()
-        .enumerate()
-        .map(|(i, r)| {
-            let preview =
-                crate::application::ai::char_prefix(&r.chunk_text, 200);
-            format!("[{}] {}: {}", i + 1, r.title, preview)
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n");
-
-    let user_msg = format!(
-        "Question: {question}\
-         \n\nPassages:\n{passages}\
-         \n\nReturn top {final_k} indices, most relevant first."
-    );
-
-    let response = match llm.chat(RERANK_PROMPT, &user_msg).await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("[rag] rerank failed, using RRF order: {e}");
-            return results.into_iter().take(final_k).collect();
-        }
-    };
-
-    let indices = parse_rerank_indices(&response, results.len());
-    if indices.is_empty() {
-        eprintln!("[rag] rerank parse empty, using RRF order");
-        return results.into_iter().take(final_k).collect();
-    }
-
-    let mut reranked: Vec<SearchResult> = indices
-        .into_iter()
-        .filter_map(|i| results.get(i).cloned())
-        .collect();
-    reranked.truncate(final_k);
-    reranked
 }
 
 fn web_search_config() -> (bool, String) {

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -2,13 +2,11 @@ use crate::application::constants::{
     DEFAULT_RAG_MAX_SOURCES, RAG_AGENT_SYSTEM_PROMPT,
     RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_DISTANCE_THRESHOLD, RAG_FINAL_K,
     RAG_INITIAL_K, RERANK_PROMPT, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
-    TEMPORAL_DETECT_PROMPT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::persistence::Database;
 use crate::infrastructure::vectordb::{SearchResult, SourceType, VectorStore};
-use chrono::{Datelike, Local, NaiveDate};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -16,6 +14,9 @@ use tokio::sync::mpsc;
 mod fusion;
 use fusion::dedup_merged;
 pub use fusion::rrf_merge;
+
+mod temporal;
+use temporal::{apply_date_filter, detect_temporal_llm, detect_temporal_regex};
 
 pub use crate::domain::ChatScope;
 
@@ -171,143 +172,6 @@ fn compute_source_count(results: &[SearchResult], user_max: usize) -> usize {
         12
     };
     adaptive.min(user_max).min(results.len())
-}
-
-struct DateRange {
-    from: NaiveDate,
-    to: NaiveDate,
-}
-
-fn detect_temporal_regex(question: &str) -> Option<DateRange> {
-    let today = Local::now().date_naive();
-    let q = question.to_lowercase();
-
-    if q.contains("aujourd'hui") || q.contains("aujourd'hui") {
-        return Some(DateRange {
-            from: today,
-            to: today,
-        });
-    }
-    if q.contains("hier") {
-        let d = today - chrono::Duration::days(1);
-        return Some(DateRange { from: d, to: d });
-    }
-    if q.contains("cette semaine") {
-        let weekday = today.weekday().num_days_from_monday();
-        let monday = today - chrono::Duration::days(weekday as i64);
-        return Some(DateRange {
-            from: monday,
-            to: today,
-        });
-    }
-    if q.contains("semaine dernière") || q.contains("semaine passée") {
-        let weekday = today.weekday().num_days_from_monday();
-        let this_monday = today - chrono::Duration::days(weekday as i64);
-        let last_monday = this_monday - chrono::Duration::days(7);
-        let last_sunday = this_monday - chrono::Duration::days(1);
-        return Some(DateRange {
-            from: last_monday,
-            to: last_sunday,
-        });
-    }
-    if q.contains("ce mois") || q.contains("ce mois-ci") {
-        let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
-        return Some(DateRange {
-            from: first,
-            to: today,
-        });
-    }
-    if q.contains("mois dernier") || q.contains("mois passé") {
-        let first_this =
-            NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
-        let last_day_prev = first_this - chrono::Duration::days(1);
-        let first_prev = NaiveDate::from_ymd_opt(
-            last_day_prev.year(),
-            last_day_prev.month(),
-            1,
-        )?;
-        return Some(DateRange {
-            from: first_prev,
-            to: last_day_prev,
-        });
-    }
-
-    let fr_months = [
-        ("janvier", 1),
-        ("février", 2),
-        ("fevrier", 2),
-        ("mars", 3),
-        ("avril", 4),
-        ("mai", 5),
-        ("juin", 6),
-        ("juillet", 7),
-        ("août", 8),
-        ("aout", 8),
-        ("septembre", 9),
-        ("octobre", 10),
-        ("novembre", 11),
-        ("décembre", 12),
-        ("decembre", 12),
-    ];
-    for (name, month) in fr_months {
-        if q.contains(name) {
-            let year = today.year();
-            let first = NaiveDate::from_ymd_opt(year, month, 1)?;
-            let next_month = if month == 12 {
-                NaiveDate::from_ymd_opt(year + 1, 1, 1)?
-            } else {
-                NaiveDate::from_ymd_opt(year, month + 1, 1)?
-            };
-            let last = next_month - chrono::Duration::days(1);
-            return Some(DateRange {
-                from: first,
-                to: last,
-            });
-        }
-    }
-
-    None
-}
-
-async fn detect_temporal_llm(
-    llm: &LlmClient,
-    question: &str,
-) -> Option<DateRange> {
-    let today = Local::now().date_naive();
-    let user_msg = format!("Today: {today}\nQuestion: {question}");
-    let response = match llm.chat(TEMPORAL_DETECT_PROMPT, &user_msg).await {
-        Ok(r) => r,
-        Err(_) => return None,
-    };
-    let trimmed = response.trim();
-    if trimmed == "null" || trimmed.is_empty() {
-        return None;
-    }
-    let parsed: serde_json::Value = serde_json::from_str(trimmed).ok()?;
-    let from_str = parsed.get("from")?.as_str()?;
-    let to_str = parsed.get("to")?.as_str()?;
-    let from = NaiveDate::parse_from_str(from_str, "%Y-%m-%d").ok()?;
-    let to = NaiveDate::parse_from_str(to_str, "%Y-%m-%d").ok()?;
-    Some(DateRange { from, to })
-}
-
-fn apply_date_filter(
-    results: Vec<SearchResult>,
-    range: &DateRange,
-) -> Vec<SearchResult> {
-    let from_str = range.from.format("%Y-%m-%d").to_string();
-    let to_str = range.to.format("%Y-%m-%d").to_string();
-    results
-        .into_iter()
-        .filter(|r| {
-            let date_part = if r.created_at.len() >= 10 {
-                &r.created_at[..10]
-            } else {
-                &r.created_at
-            };
-            date_part >= from_str.as_str() && date_part <= to_str.as_str()
-        })
-        .collect()
 }
 
 pub async fn query(

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -25,6 +25,9 @@ use rerank::llm_rerank;
 mod config;
 use config::{read_max_sources, web_search_config};
 
+mod context;
+pub use context::build_context;
+
 pub use crate::domain::ChatScope;
 
 #[derive(Clone)]
@@ -42,19 +45,6 @@ pub struct RagSource {
 pub struct RagResponse {
     pub answer: String,
     pub sources: Vec<RagSource>,
-}
-
-pub fn build_context(results: &[SearchResult]) -> String {
-    let mut ctx = String::from("--- User notes ---\n\n");
-    for (i, r) in results.iter().enumerate() {
-        ctx.push_str(&format!(
-            "[Source {}] Note: \"{}\"\n{}\n\n",
-            i + 1,
-            r.title,
-            r.chunk_text
-        ));
-    }
-    ctx
 }
 
 pub async fn query(

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -1,7 +1,6 @@
 use crate::application::constants::{
-    DEFAULT_RAG_MAX_SOURCES, RAG_AGENT_SYSTEM_PROMPT,
-    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K, RAG_INITIAL_K, RRF_K,
-    RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
+    RAG_AGENT_SYSTEM_PROMPT, RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K,
+    RAG_INITIAL_K, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
 use crate::infrastructure::llm::LlmClient;
@@ -22,6 +21,9 @@ use scoring::{apply_temporal_boost, compute_source_count, filter_and_dedup};
 
 mod rerank;
 use rerank::llm_rerank;
+
+mod config;
+use config::{read_max_sources, web_search_config};
 
 pub use crate::domain::ChatScope;
 
@@ -53,24 +55,6 @@ pub fn build_context(results: &[SearchResult]) -> String {
         ));
     }
     ctx
-}
-
-fn web_search_config() -> (bool, String) {
-    let Ok(db) = Database::open() else {
-        return (false, String::new());
-    };
-    let enabled =
-        db.get_setting("web_search_enabled").as_deref() == Some("true");
-    let key = crate::application::web_search::exa_api_key(&db);
-    (enabled, key)
-}
-
-fn read_max_sources() -> usize {
-    Database::open()
-        .ok()
-        .and_then(|d| d.get_setting("rag_max_sources"))
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_RAG_MAX_SOURCES)
 }
 
 pub async fn query(

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -1,13 +1,12 @@
 use crate::application::constants::{
     DEFAULT_RAG_MAX_SOURCES, RAG_AGENT_SYSTEM_PROMPT,
-    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_DISTANCE_THRESHOLD, RAG_FINAL_K,
-    RAG_INITIAL_K, RERANK_PROMPT, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
+    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K, RAG_INITIAL_K, RERANK_PROMPT,
+    RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::persistence::Database;
 use crate::infrastructure::vectordb::{SearchResult, SourceType, VectorStore};
-use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -17,6 +16,9 @@ pub use fusion::rrf_merge;
 
 mod temporal;
 use temporal::{apply_date_filter, detect_temporal_llm, detect_temporal_regex};
+
+mod scoring;
+use scoring::{apply_temporal_boost, compute_source_count, filter_and_dedup};
 
 pub use crate::domain::ChatScope;
 
@@ -108,38 +110,6 @@ async fn llm_rerank(
     reranked
 }
 
-fn apply_temporal_boost(results: &mut [SearchResult]) {
-    let now = chrono::Utc::now();
-    for r in results.iter_mut() {
-        let days_ago = chrono::DateTime::parse_from_rfc3339(&r.created_at)
-            .or_else(|_| {
-                chrono::NaiveDateTime::parse_from_str(
-                    &r.created_at,
-                    "%Y-%m-%dT%H:%M:%S",
-                )
-                .map(|dt| dt.and_utc().fixed_offset())
-            })
-            .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days())
-            .unwrap_or(365) as f32;
-        let boost = 1.0 / (1.0 + days_ago / 30.0);
-        r.distance *= 1.0 - (boost * 0.3);
-    }
-    results.sort_by(|a, b| {
-        a.distance
-            .partial_cmp(&b.distance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-}
-
-fn filter_and_dedup(results: Vec<SearchResult>) -> Vec<SearchResult> {
-    let mut seen = HashSet::new();
-    results
-        .into_iter()
-        .filter(|r| r.distance <= RAG_DISTANCE_THRESHOLD)
-        .filter(|r| seen.insert(r.note_id.clone()))
-        .collect()
-}
-
 fn web_search_config() -> (bool, String) {
     let Ok(db) = Database::open() else {
         return (false, String::new());
@@ -156,22 +126,6 @@ fn read_max_sources() -> usize {
         .and_then(|d| d.get_setting("rag_max_sources"))
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(DEFAULT_RAG_MAX_SOURCES)
-}
-
-fn compute_source_count(results: &[SearchResult], user_max: usize) -> usize {
-    if results.is_empty() {
-        return 0;
-    }
-    let avg_distance: f32 =
-        results.iter().map(|r| r.distance).sum::<f32>() / results.len() as f32;
-    let adaptive = if avg_distance < 0.3 {
-        5
-    } else if avg_distance < 0.5 {
-        8
-    } else {
-        12
-    };
-    adaptive.min(user_max).min(results.len())
 }
 
 pub async fn query(

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -5,7 +5,6 @@ use crate::application::constants::{
     TEMPORAL_DETECT_PROMPT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
-use crate::application::web_search::WebResult;
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::persistence::Database;
 use crate::infrastructure::vectordb::{SearchResult, SourceType, VectorStore};
@@ -13,6 +12,10 @@ use chrono::{Datelike, Local, NaiveDate};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+
+mod fusion;
+use fusion::dedup_merged;
+pub use fusion::rrf_merge;
 
 pub use crate::domain::ChatScope;
 
@@ -31,42 +34,6 @@ pub struct RagSource {
 pub struct RagResponse {
     pub answer: String,
     pub sources: Vec<RagSource>,
-}
-
-fn web_to_search_result(w: WebResult) -> SearchResult {
-    SearchResult {
-        chunk_text: w.snippet,
-        note_id: String::new(),
-        title: w.title,
-        distance: 0.0,
-        created_at: w.published_date.unwrap_or_default(),
-        source_type: SourceType::Web,
-        url: Some(w.url),
-    }
-}
-
-pub fn rrf_merge(
-    local: Vec<SearchResult>,
-    web: Vec<WebResult>,
-    k: f32,
-    local_weight: f32,
-    web_weight: f32,
-) -> Vec<SearchResult> {
-    let mut scored: Vec<(SearchResult, f32)> =
-        Vec::with_capacity(local.len() + web.len());
-    for (rank, r) in local.into_iter().enumerate() {
-        scored.push((r, local_weight / (k + rank as f32 + 1.0)));
-    }
-    for (rank, w) in web.into_iter().enumerate() {
-        scored.push((
-            web_to_search_result(w),
-            web_weight / (k + rank as f32 + 1.0),
-        ));
-    }
-    scored.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
-    });
-    scored.into_iter().map(|(r, _)| r).collect()
 }
 
 pub fn build_context(results: &[SearchResult]) -> String {
@@ -169,24 +136,6 @@ fn filter_and_dedup(results: Vec<SearchResult>) -> Vec<SearchResult> {
         .into_iter()
         .filter(|r| r.distance <= RAG_DISTANCE_THRESHOLD)
         .filter(|r| seen.insert(r.note_id.clone()))
-        .collect()
-}
-
-fn dedup_merged(results: Vec<SearchResult>) -> Vec<SearchResult> {
-    let mut seen_notes = HashSet::new();
-    let mut seen_web = HashSet::new();
-    results
-        .into_iter()
-        .filter(|r| match r.source_type {
-            SourceType::Local => {
-                r.distance <= RAG_DISTANCE_THRESHOLD
-                    && seen_notes.insert(r.note_id.clone())
-            }
-            SourceType::Web => {
-                let key: String = r.chunk_text.chars().take(200).collect();
-                seen_web.insert(key)
-            }
-        })
         .collect()
 }
 
@@ -562,67 +511,4 @@ pub async fn run_action(
         answer,
         sources: vec![],
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn local(title: &str, distance: f32) -> SearchResult {
-        SearchResult {
-            chunk_text: format!("text-{title}"),
-            note_id: format!("id-{title}"),
-            title: title.into(),
-            distance,
-            created_at: "2026-01-01T00:00:00".into(),
-            source_type: SourceType::Local,
-            url: None,
-        }
-    }
-
-    fn web(title: &str) -> WebResult {
-        WebResult {
-            title: title.into(),
-            url: format!("https://{title}"),
-            snippet: format!("snip-{title}"),
-            published_date: None,
-        }
-    }
-
-    fn titles(rs: &[SearchResult]) -> Vec<String> {
-        rs.iter().map(|r| r.title.clone()).collect()
-    }
-
-    #[test]
-    fn empty_web_is_identity() {
-        let l = vec![local("a", 0.1), local("b", 0.2), local("c", 0.3)];
-        let merged = rrf_merge(l, vec![], 60.0, 1.2, 1.0);
-        assert_eq!(titles(&merged), ["a", "b", "c"]);
-        assert_eq!(merged[0].distance, 0.1);
-        assert!(merged.iter().all(|r| r.source_type == SourceType::Local));
-    }
-
-    #[test]
-    fn empty_local_keeps_web_order() {
-        let merged =
-            rrf_merge(vec![], vec![web("w1"), web("w2")], 60.0, 1.2, 1.0);
-        assert_eq!(titles(&merged), ["w1", "w2"]);
-        assert!(merged
-            .iter()
-            .all(|r| r.source_type == SourceType::Web && r.url.is_some()));
-    }
-
-    #[test]
-    fn local_outranks_web_at_same_rank() {
-        let merged =
-            rrf_merge(vec![local("L0", 0.1)], vec![web("W0")], 60.0, 1.2, 1.0);
-        assert_eq!(titles(&merged), ["L0", "W0"]);
-    }
-
-    #[test]
-    fn web_top_interleaves_below_first_local() {
-        let locals = vec![local("L0", 0.1), local("L1", 0.2), local("L2", 0.3)];
-        let merged = rrf_merge(locals, vec![web("W0")], 1.0, 1.2, 1.0);
-        assert_eq!(titles(&merged), ["L0", "W0", "L1", "L2"]);
-    }
 }

--- a/src/application/rag/rerank.rs
+++ b/src/application/rag/rerank.rs
@@ -1,0 +1,61 @@
+use crate::application::constants::RERANK_PROMPT;
+use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::vectordb::SearchResult;
+
+fn parse_rerank_indices(response: &str, max: usize) -> Vec<usize> {
+    response
+        .split(',')
+        .filter_map(|s| s.trim().parse::<usize>().ok())
+        .filter(|&i| i >= 1 && i <= max)
+        .map(|i| i - 1)
+        .collect()
+}
+
+pub(super) async fn llm_rerank(
+    llm: &LlmClient,
+    question: &str,
+    results: Vec<SearchResult>,
+    final_k: usize,
+) -> Vec<SearchResult> {
+    if results.len() <= final_k {
+        return results;
+    }
+
+    let passages: String = results
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let preview =
+                crate::application::ai::char_prefix(&r.chunk_text, 200);
+            format!("[{}] {}: {}", i + 1, r.title, preview)
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let user_msg = format!(
+        "Question: {question}\
+         \n\nPassages:\n{passages}\
+         \n\nReturn top {final_k} indices, most relevant first."
+    );
+
+    let response = match llm.chat(RERANK_PROMPT, &user_msg).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[rag] rerank failed, using RRF order: {e}");
+            return results.into_iter().take(final_k).collect();
+        }
+    };
+
+    let indices = parse_rerank_indices(&response, results.len());
+    if indices.is_empty() {
+        eprintln!("[rag] rerank parse empty, using RRF order");
+        return results.into_iter().take(final_k).collect();
+    }
+
+    let mut reranked: Vec<SearchResult> = indices
+        .into_iter()
+        .filter_map(|i| results.get(i).cloned())
+        .collect();
+    reranked.truncate(final_k);
+    reranked
+}

--- a/src/application/rag/scoring.rs
+++ b/src/application/rag/scoring.rs
@@ -1,0 +1,56 @@
+use crate::application::constants::RAG_DISTANCE_THRESHOLD;
+use crate::infrastructure::vectordb::SearchResult;
+use std::collections::HashSet;
+
+pub(super) fn apply_temporal_boost(results: &mut [SearchResult]) {
+    let now = chrono::Utc::now();
+    for r in results.iter_mut() {
+        let days_ago = chrono::DateTime::parse_from_rfc3339(&r.created_at)
+            .or_else(|_| {
+                chrono::NaiveDateTime::parse_from_str(
+                    &r.created_at,
+                    "%Y-%m-%dT%H:%M:%S",
+                )
+                .map(|dt| dt.and_utc().fixed_offset())
+            })
+            .map(|dt| (now - dt.with_timezone(&chrono::Utc)).num_days())
+            .unwrap_or(365) as f32;
+        let boost = 1.0 / (1.0 + days_ago / 30.0);
+        r.distance *= 1.0 - (boost * 0.3);
+    }
+    results.sort_by(|a, b| {
+        a.distance
+            .partial_cmp(&b.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+}
+
+pub(super) fn filter_and_dedup(
+    results: Vec<SearchResult>,
+) -> Vec<SearchResult> {
+    let mut seen = HashSet::new();
+    results
+        .into_iter()
+        .filter(|r| r.distance <= RAG_DISTANCE_THRESHOLD)
+        .filter(|r| seen.insert(r.note_id.clone()))
+        .collect()
+}
+
+pub(super) fn compute_source_count(
+    results: &[SearchResult],
+    user_max: usize,
+) -> usize {
+    if results.is_empty() {
+        return 0;
+    }
+    let avg_distance: f32 =
+        results.iter().map(|r| r.distance).sum::<f32>() / results.len() as f32;
+    let adaptive = if avg_distance < 0.3 {
+        5
+    } else if avg_distance < 0.5 {
+        8
+    } else {
+        12
+    };
+    adaptive.min(user_max).min(results.len())
+}

--- a/src/application/rag/temporal.rs
+++ b/src/application/rag/temporal.rs
@@ -1,0 +1,141 @@
+use crate::application::constants::TEMPORAL_DETECT_PROMPT;
+use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::vectordb::SearchResult;
+use chrono::{Datelike, Local, NaiveDate};
+
+pub(super) struct DateRange {
+    pub(super) from: NaiveDate,
+    pub(super) to: NaiveDate,
+}
+
+pub(super) fn detect_temporal_regex(question: &str) -> Option<DateRange> {
+    let today = Local::now().date_naive();
+    let q = question.to_lowercase();
+
+    if q.contains("aujourd'hui") || q.contains("aujourd'hui") {
+        return Some(DateRange {
+            from: today,
+            to: today,
+        });
+    }
+    if q.contains("hier") {
+        let d = today - chrono::Duration::days(1);
+        return Some(DateRange { from: d, to: d });
+    }
+    if q.contains("cette semaine") {
+        let weekday = today.weekday().num_days_from_monday();
+        let monday = today - chrono::Duration::days(weekday as i64);
+        return Some(DateRange {
+            from: monday,
+            to: today,
+        });
+    }
+    if q.contains("semaine dernière") || q.contains("semaine passée") {
+        let weekday = today.weekday().num_days_from_monday();
+        let this_monday = today - chrono::Duration::days(weekday as i64);
+        let last_monday = this_monday - chrono::Duration::days(7);
+        let last_sunday = this_monday - chrono::Duration::days(1);
+        return Some(DateRange {
+            from: last_monday,
+            to: last_sunday,
+        });
+    }
+    if q.contains("ce mois") || q.contains("ce mois-ci") {
+        let first = NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
+        return Some(DateRange {
+            from: first,
+            to: today,
+        });
+    }
+    if q.contains("mois dernier") || q.contains("mois passé") {
+        let first_this =
+            NaiveDate::from_ymd_opt(today.year(), today.month(), 1)?;
+        let last_day_prev = first_this - chrono::Duration::days(1);
+        let first_prev = NaiveDate::from_ymd_opt(
+            last_day_prev.year(),
+            last_day_prev.month(),
+            1,
+        )?;
+        return Some(DateRange {
+            from: first_prev,
+            to: last_day_prev,
+        });
+    }
+
+    let fr_months = [
+        ("janvier", 1),
+        ("février", 2),
+        ("fevrier", 2),
+        ("mars", 3),
+        ("avril", 4),
+        ("mai", 5),
+        ("juin", 6),
+        ("juillet", 7),
+        ("août", 8),
+        ("aout", 8),
+        ("septembre", 9),
+        ("octobre", 10),
+        ("novembre", 11),
+        ("décembre", 12),
+        ("decembre", 12),
+    ];
+    for (name, month) in fr_months {
+        if q.contains(name) {
+            let year = today.year();
+            let first = NaiveDate::from_ymd_opt(year, month, 1)?;
+            let next_month = if month == 12 {
+                NaiveDate::from_ymd_opt(year + 1, 1, 1)?
+            } else {
+                NaiveDate::from_ymd_opt(year, month + 1, 1)?
+            };
+            let last = next_month - chrono::Duration::days(1);
+            return Some(DateRange {
+                from: first,
+                to: last,
+            });
+        }
+    }
+
+    None
+}
+
+pub(super) async fn detect_temporal_llm(
+    llm: &LlmClient,
+    question: &str,
+) -> Option<DateRange> {
+    let today = Local::now().date_naive();
+    let user_msg = format!("Today: {today}\nQuestion: {question}");
+    let response = match llm.chat(TEMPORAL_DETECT_PROMPT, &user_msg).await {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+    let trimmed = response.trim();
+    if trimmed == "null" || trimmed.is_empty() {
+        return None;
+    }
+    let parsed: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    let from_str = parsed.get("from")?.as_str()?;
+    let to_str = parsed.get("to")?.as_str()?;
+    let from = NaiveDate::parse_from_str(from_str, "%Y-%m-%d").ok()?;
+    let to = NaiveDate::parse_from_str(to_str, "%Y-%m-%d").ok()?;
+    Some(DateRange { from, to })
+}
+
+pub(super) fn apply_date_filter(
+    results: Vec<SearchResult>,
+    range: &DateRange,
+) -> Vec<SearchResult> {
+    let from_str = range.from.format("%Y-%m-%d").to_string();
+    let to_str = range.to.format("%Y-%m-%d").to_string();
+    results
+        .into_iter()
+        .filter(|r| {
+            let date_part = if r.created_at.len() >= 10 {
+                &r.created_at[..10]
+            } else {
+                &r.created_at
+            };
+            date_part >= from_str.as_str() && date_part <= to_str.as_str()
+        })
+        .collect()
+}

--- a/tests/rag_fusion_test.rs
+++ b/tests/rag_fusion_test.rs
@@ -1,0 +1,60 @@
+use flowflow::application::rag::rrf_merge;
+use flowflow::application::web_search::WebResult;
+use flowflow::infrastructure::vectordb::{SearchResult, SourceType};
+
+fn local(title: &str, distance: f32) -> SearchResult {
+    SearchResult {
+        chunk_text: format!("text-{title}"),
+        note_id: format!("id-{title}"),
+        title: title.into(),
+        distance,
+        created_at: "2026-01-01T00:00:00".into(),
+        source_type: SourceType::Local,
+        url: None,
+    }
+}
+
+fn web(title: &str) -> WebResult {
+    WebResult {
+        title: title.into(),
+        url: format!("https://{title}"),
+        snippet: format!("snip-{title}"),
+        published_date: None,
+    }
+}
+
+fn titles(rs: &[SearchResult]) -> Vec<String> {
+    rs.iter().map(|r| r.title.clone()).collect()
+}
+
+#[test]
+fn empty_web_is_identity() {
+    let l = vec![local("a", 0.1), local("b", 0.2), local("c", 0.3)];
+    let merged = rrf_merge(l, vec![], 60.0, 1.2, 1.0);
+    assert_eq!(titles(&merged), ["a", "b", "c"]);
+    assert_eq!(merged[0].distance, 0.1);
+    assert!(merged.iter().all(|r| r.source_type == SourceType::Local));
+}
+
+#[test]
+fn empty_local_keeps_web_order() {
+    let merged = rrf_merge(vec![], vec![web("w1"), web("w2")], 60.0, 1.2, 1.0);
+    assert_eq!(titles(&merged), ["w1", "w2"]);
+    assert!(merged
+        .iter()
+        .all(|r| r.source_type == SourceType::Web && r.url.is_some()));
+}
+
+#[test]
+fn local_outranks_web_at_same_rank() {
+    let merged =
+        rrf_merge(vec![local("L0", 0.1)], vec![web("W0")], 60.0, 1.2, 1.0);
+    assert_eq!(titles(&merged), ["L0", "W0"]);
+}
+
+#[test]
+fn web_top_interleaves_below_first_local() {
+    let locals = vec![local("L0", 0.1), local("L1", 0.2), local("L2", 0.3)];
+    let merged = rrf_merge(locals, vec![web("W0")], 1.0, 1.2, 1.0);
+    assert_eq!(titles(&merged), ["L0", "W0", "L1", "L2"]);
+}


### PR DESCRIPTION
## What

Behavior-preserving SRP split of `src/application/rag.rs` (628 lines, mixed
responsibilities) into a `rag/` module folder. The path `application::rag`
is unchanged, so callers stay untouched.

```
application/rag/
  mod.rs      query, run_action, RagSource, RagResponse, ChatScope re-export
  fusion.rs   web_to_search_result, rrf_merge, dedup_merged
  temporal.rs DateRange, detect_temporal_regex, detect_temporal_llm, apply_date_filter
  scoring.rs  apply_temporal_boost, filter_and_dedup, compute_source_count
  rerank.rs   parse_rerank_indices, llm_rerank
  context.rs  build_context
  config.rs   web_search_config, read_max_sources
```

## Commits (one cut each, green between every cut)

1. extract RRF fusion into `rag/fusion.rs`
2. extract temporal detection into `rag/temporal.rs`
3. extract local-result scoring into `rag/scoring.rs`
4. extract LLM rerank into `rag/rerank.rs`
5. extract settings reads into `rag/config.rs`
6. extract context builder into `rag/context.rs`

## Guarantees

- Pure move: every function body is byte-identical to the original. No literal,
  operator, branch, signature, struct field, or prompt constant changed.
- Public surface preserved: `query`, `run_action`, `RagResponse`, `RagSource`,
  `ChatScope` stay defined/re-exported; `rrf_merge` and `build_context` re-exported
  via `pub use`. Cross-module helpers are `pub(super)`.
- Inline `#[cfg(test)]` rrf_merge tests relocated to `tests/rag_fusion_test.rs`
  (tests-in-`tests/` convention). Bodies unchanged.

## Verification

- `cargo clippy --features mobile`: zero warnings after each cut.
- `cargo test --features mobile --no-run`: all test targets compile (every external
  `application::rag::*` path resolves).
- `tests/rag_test` + `tests/rag_fusion_test`: 14 passing (`build_context` + `rrf_merge`
  behavior intact).
- Adversarial per-module review (8 reviewers + completeness critic): unanimous
  behavior-preserved, zero blockers.

https://claude.ai/code/session_01FbSG5cgfAgTFoGSFCMXp2B
