### PR TITLE
fix(ui): burger tap opens sidebar + swipe drawer batch + sync peers SRP

### DIFF
--- a/src/ui/hooks/swipe.js
+++ b/src/ui/hooks/swipe.js
@@ -92,9 +92,7 @@
         return;
       active = true;
       opening = true;
-      engaged = true;
-      cur = sign * w;
-      schedule();
+      engaged = false;
     } else {
       active = true;
       opening = false;
@@ -112,8 +110,12 @@
     const dx = e.clientX - startX;
     const dy = e.clientY - startY;
     if (!engaged) {
-      const towardClose = CFG.side === "left" ? dx < -8 : dx > 8;
-      if (towardClose && Math.abs(dx) > Math.abs(dy)) {
+      let toward;
+      if (opening)
+        toward = CFG.side === "left" ? dx > 8 : dx < -8;
+      else
+        toward = CFG.side === "left" ? dx < -8 : dx > 8;
+      if (toward && Math.abs(dx) > Math.abs(dy)) {
         engaged = true;
       } else if (Math.abs(dy) > 8) {
         active = false;

--- a/src/ui/hooks/swipe.ts
+++ b/src/ui/hooks/swipe.ts
@@ -109,13 +109,12 @@
           ? e.clientX <= CFG.edgePx
           : e.clientX >= window.innerWidth - CFG.edgePx;
       if (!atEdge) return;
-      // Engage immediately so a gentle edge drag follows the finger from the
-      // first pixel (the edge strip's touch-action: none stops scroll-steal).
+      // Mark intent only; engage after a real drag (onMove). A pure tap landing
+      // in the edge zone (the burger overlaps it) stays unengaged, so its click
+      // is not swallowed and the burger opens normally.
       active = true;
       opening = true;
-      engaged = true;
-      cur = sign * w;
-      schedule();
+      engaged = false;
     } else {
       active = true;
       opening = false;
@@ -132,9 +131,12 @@
     const dx = e.clientX - startX;
     const dy = e.clientY - startY;
     if (!engaged) {
-      // Only the close drag engages here (open engaged immediately on down).
-      const towardClose = CFG.side === "left" ? dx < -8 : dx > 8;
-      if (towardClose && Math.abs(dx) > Math.abs(dy)) {
+      // Engage on the first real horizontal drag, in the direction matching the
+      // intent set on pointerdown (open: toward center; close: toward edge).
+      let toward: boolean;
+      if (opening) toward = CFG.side === "left" ? dx > 8 : dx < -8;
+      else toward = CFG.side === "left" ? dx < -8 : dx > 8;
+      if (toward && Math.abs(dx) > Math.abs(dy)) {
         engaged = true;
       } else if (Math.abs(dy) > 8) {
         active = false;


### PR DESCRIPTION
## Summary

Batch of UI swipe work plus a regression fix, and the sync `peers/` SRP split.

### Burger-tap fix (this session)
Since the edge-swipe drawer landed, tapping the burger sometimes failed to open the sidebar and felt slower.

Root cause: the swipe controller engaged the open drawer on `pointerdown` for any touch inside the left edge zone (`edge_px = 30`). That zone overlaps the left ~third of the burger button (`px-4` + `min-w-[44px]`), so a tap there was treated as a swipe: its synthesized click was swallowed and `settle(false)` snapped the drawer closed. A follow-up open could also race the `settle` cleanup, delaying the animation.

Fix: engage the open direction on the first real horizontal drag (`dx > 8`) instead of on `pointerdown`, mirroring how the close drag already engages. A pure tap never engages, so the burger's `onclick` runs and opens the drawer; a real edge drag still follows the finger after an imperceptible 8px threshold. No geometric dead-zone needed.

Source of truth `swipe.ts`; `swipe.js` regenerated via `make js`.

### Also in this branch
- Swipe-to-open sidebar drawer, 60fps waveform, desktop FAB.
- Reusable `use_swipe_drawer` hook extraction.
- Right-edge swipe to open a folder-scoped chat.
- `sync` refactor: `peers.rs` split into focused `peers/` modules (lan, codec, account_join, identity, peer_store, host, join).

## Test
- Device-validated: burger tap opens reliably (including the left edge of the icon), repeated open/close has no lag, edge-swipe still tracks and opens, swipe-left still closes.
- `cargo test --test swipe_test` green (3); `tsc --noEmit` green.

https://claude.ai/code/session_01FbSG5cgfAgTFoGSFCMXp2B
