### PR TITLE
Composer + menu (per-chat web, @ mentions) + note connectors hub + gesture UX + sync SRP split + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,62 +84,56 @@ Mirko Bozzetto — freelance full-stack developer, Brussels.
 | 6 | Chat UI + RAG pipeline (search → context → response) | Done |
 | 7 | Chat history persistence (SQLite, sidebar tabs, CRUD) | Done |
 
-## Architecture (Clean Architecture, SRP — 42 modules)
+## Architecture (Clean Architecture, SRP — 202 modules, 4 layers)
+
+Layered clean architecture. Dependencies point inward only:
+`ui` / `infrastructure` -> `application` -> `domain`. `domain` imports nothing
+outward; a view never orchestrates (it delegates to `application`).
 
 LlmClient dispatches on `Provider` enum: OpenAI (embeddings + chat/agent) or Anthropic (chat/agent only, embeddings always OpenAI). Provider, OpenAI key, and Anthropic key persisted in SQLite via Settings UI.
-
 
 ```
 src/
   main.rs                  entry point (dotenvy + dioxus::launch)
-  lib.rs                   pub mod exports (enables integration tests)
-  models/                  domain entities
-    note.rs                Note, NewTextNote, UpdateNote, NoteType
-    folder.rs              Folder, NewFolder, UpdateFolder
-    conversation.rs        Conversation, ConversationMessage
-    attachment.rs          Attachment, NewAttachment
-  db/                      persistence layer
-    mod.rs                 Database struct, open, open_at, conn, migrate
-    schema.rs              SQL schemas, MIGRATIONS (V1 + V2 + V3)
-    note_repo.rs           CRUD notes
-    folder_repo.rs         CRUD folders
-    settings_repo.rs       get/set settings (key-value store)
-    conversation_repo.rs   CRUD conversations + messages
-    attachment_repo.rs     CRUD attachments (create, get, list_for_note, delete, delete_for_note)
-  services/                business logic
-    constants.rs           AI config (OpenAI + Anthropic models, dims, chunks, RAG_AGENT_SYSTEM_PROMPT, SUMMARIZE_FOLDER_PROMPT, tags prompt)
-    ai.rs                  chunk_text (sliding-window chunker)
-    llm.rs                 LlmClient + Provider enum (OpenAi/Anthropic dispatch: embed, chat, generate_tags, prompt_with_agent, parse_tags)
-    error.rs               LlmError enum (NotConfigured, Embedding, Completion, TagParsing)
-    tools.rs               SearchNotes, CreateNote, SummarizeFolder (rig Tool trait) + prompt_agent_with_tools
-    vectordb.rs            VectorStore (LanceDB: store, search, delete, delete_attachment_chunks)
-    embed.rs               embed_note, embed_attachment, delete_note_embeddings, delete_attachment_embeddings (background)
-    rag.rs                 RAG pipeline (embed query → vector search → context → agent with tools)
+  lib.rs                   pub mod exports (enables integration tests in tests/)
+  prelude.rs               shared re-exports
+
+  domain/                  entities + pure rules (no IO, no outward deps)
+    note.rs, folder.rs, thread.rs, conversation.rs, attachment.rs, reminder.rs
+    agent_manifest.rs, governance.rs, orchestration.rs   agent/marketplace contracts
+
+  application/             use cases + orchestration (composes domain + infra)
+    constants.rs           AI config + prompts (RAG_AGENT_SYSTEM_PROMPT, RAG_AGENT_WEB_SYSTEM_PROMPT, NOTE_ACTION_PROMPT, SUMMARIZE_FOLDER_PROMPT, tags)
+    rag/                   RAG pipeline: mod.rs (query: scope gate -> hybrid search -> context -> agent), fusion (RRF), temporal, scoring, rerank, config, context
+    web_search.rs          Exa web search (exa_search) merged via RRF when web_on
+    tools/                 rig Tool trait (search, create, summarize) + prompt_agent_with_tools
+    embed/                 embed_note/attachment + chunk_store (background)
+    transcription_manager/ STT job orchestration (job, append, processing)
+    backup/                backup/export/restore (archive, snapshot, stage, swap, validate, manifest, paths)
+    tagging.rs, titling.rs, intent.rs, reminders.rs, chain.rs, agent_builder.rs, connector_module.rs, note_persistence.rs, ai.rs, i18n/, error.rs
+
+  infrastructure/          IO: SQLite, LLM, MCP, vector DB, sync, platform
+    llm.rs                 LlmClient + Provider enum (embed, chat, run_mcp_agent generic primitive)
+    vectordb.rs            VectorStore (LanceDB: hybrid_search, store, delete, fts index)
+    persistence/           Database + repos (note, folder, thread, conversation, attachment, settings, peer, chunk, reminder, schema/migrations)
+    mcp/                   MCP client
+    backend/               backend HTTP client (accounts, entitlements, signed agent fetch)
+    transcription/         Soniox cloud + local Whisper (client, provider, whisper, models, hesitations)
+    sync/                  P2P sync: engine, protocol/{collect,apply/,session,wire,catalog}, peers/{lan,codec,account_join,identity,peer_store,host,join}, vv, reconcile, transport, conflict, gc
+    platform/              iOS/macOS FFI (ios/{picker,player,share,reminders,live_activity,sync_ffi}, parsers, pdf)
     audio.rs               AudioRecorder (cpal, WAV capture)
-    transcription/         STT layer (RFC 0005)
-      client.rs            SonioxClient (upload, poll, transcribe) - cloud path, untouched
-      provider.rs          SttProvider enum + TranscriptionClient facade (from_db dispatch Soniox/WhisperLocal)
-      whisper.rs           WhisperLocal (whisper-rs, spawn_blocking, Semaphore(1), WAV→mono 16k) + bench
-      models.rs            ggml model manager (5-model catalog, download .part+sha256+rename, disk guardrail 2x)
-      hesitations.rs       clean_hesitations post-processing
-  platform/                OS-specific
-    ios.rs                 AVAudioSession, documents_dir, open_file_picker (UIDocumentPickerViewController), read_file_as_text (txt/md/csv/pdf/docx)
+
   ui/                      Dioxus components (1 component = 1 file)
-    mod.rs                 App root component + view routing + keyboard handler
-    state.rs               AppState, View enum (NotesList, NoteDetail, Chat, Settings)
-    top_bar.rs             TopBar (navigation, back to previous_view, chat icon)
-    sidebar.rs             SidebarOverlay, tabs (Notes/Chats), ConversationItem, FolderItem
-    fab.rs                 FloatingActionButton (new note)
-    note_list.rs           NotesList
-    note_card.rs           NoteCard (with tag chips)
-    note_detail.rs         NoteDetail (tags UI, auto-tag, attachment cards, import, auto-embed on save)
-    attachment_modal.rs    AttachmentModal (bottom sheet, filename + date + full text)
-    folder_picker.rs       FolderPicker (dropdown)
-    recording_bar.rs       RecordingBar (voice recording in notes)
-    settings.rs            SettingsView (provider picker OpenAI/Anthropic, API keys form, DB persistence)
-    chat.rs                ChatView (persistent conversations, markdown, sources)
-    chat_input.rs          ChatInputBar (mic, textarea, send, transcription)
-    icons.rs               Phosphor SVG icons
+    app/                   root + routing (mod, router, nav, top_bar, fab, boot, consent, watchers, right_nav, restore_lock, animations, contexts)
+    chat/                  ChatView + RAG chat (view, chat_input, actions, action_card, bubbles, sources_accordion, menu, typing_indicator, empty_state, models)
+    notes/                 list + detail (note_list, note_card, detail/ + detail/hooks/, attachments, tags, reminders, folder_picker, audio_player, menu)
+    sidebar/               drawer (mod, folders, conversations) + use_swipe_drawer
+    thread/                folder-scoped thread chat (card, detail, entry_button, header_menu)
+    recording/             recording bar + 60fps waveform (bar, controls, waveform)
+    settings/              tabs (general, intelligence, transcription, connections, account, backup, privacy, storage, shortcuts)
+    sync/                  pairing + conflicts UI (controls, pairing, conflicts)
+    hooks/                 reusable hooks (swipe.rs = use_swipe_drawer / use_swipe_right_nav, +.ts source -> .js via `make js`)
+    keyboard/, state.rs, kit.rs, icons.rs, clipboard.rs
 ```
 
 ## Data Entities
@@ -315,7 +309,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4198 symbols, 9786 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4302 symbols, 9968 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ No manual searching. No folders to dig through. Just talk, and find it later.
 - **Multi-device sync** - encrypted LAN P2P between iPhone and Mac (Noise protocol, no server, no cloud), QR pairing, real-time UI refresh, zero data loss by design
 - **Backup & restore** - export everything (notes, audio, vectors) as one archive via the share sheet, API keys and pairing secrets never leave the device; import is a validated, crash-safe atomic replace, and sync reconverges without resurrecting deleted notes
 - **RAG chat** - powered by [rig](https://github.com/0xPlaygrounds/rig): ask questions about your notes, get answers with tappable sources; hybrid search (BM25 + vector + RRF + LLM rerank), temporal queries, agent tools, and a per-conversation theme scope that is remembered when you come back
-- **Web search in chat** - flip a toggle and the chat queries the web via [Exa](https://exa.ai) in parallel with your notes; the two ranked lists are fused by Reciprocal Rank Fusion (rank, not score), so fresh web facts and your own notes land in one answer, with web sources in their own section that open in your browser
-- **External connectors** - link a service like Google Sheets and arm the assistant to one or several of your spreadsheets (pick from the list or paste a link); every tool call passes a governed permission gate, enforced on-device *and* re-checked server-side, so the model only acts on the sheets you armed and only as the connector's contract allows (account-based, premium)
+- **Web search in chat** - open the composer's **+** menu and turn web search on for that chat (per conversation, off by default); it queries the web via [Exa](https://exa.ai) in parallel with your notes, the two ranked lists fused by Reciprocal Rank Fusion (rank, not score), so fresh web facts and your own notes land in one answer, with web sources in their own section that open in your browser
+- **Composer tools (+ and @)** - a **+** menu gathers tools and connectors per chat (and on notes): a bottom-sheet you drag down to dismiss on iPhone, a popover with a hover tooltip on Mac; type **@** to scope a question to a specific note
+- **External connectors** - link a service like Google Sheets and arm the assistant to one or several of your spreadsheets (pick from the list or paste a link); every tool call passes a governed permission gate, enforced on-device *and* re-checked server-side, so the model only acts on the sheets you armed and only as the connector's contract allows (account-based, premium). This is the groundwork for an agent marketplace - signed agents, account roles, and server-governed tools - in progress
 - **Save from chat** - keep any answer or a whole thread as a note: AI-titled, embedded for search, filed in the chat's own folder, with its web sources preserved and openable; saved notes render as clean markdown
 - **Note to chat** - jump from any note straight into the chat, already scoped to that note's theme, then one tap on the back arrow returns you to the exact note; the round trip works on iPhone and Mac
 - **Note threads** - group related notes into one titled, chronological thread you read top to bottom and append to in place; a thread needs at least two notes (a lone one stays a plain note), chat can be scoped to a single thread, and threads sync and back up like everything else
@@ -40,7 +41,7 @@ No manual searching. No folders to dig through. Just talk, and find it later.
 - **Document import** - PDF (native OCR for scans), DOCX, TXT, MD, CSV via the native pickers on iOS and macOS, auto-embedded for chat
 - **Audio playback** - play, pause, delete recordings from any note, on both platforms; filler words (euh, um) auto-stripped from transcripts
 - **A real Mac app** - keyboard-first: ⌘N new note, ⇧⌘Enter new chat, ⌘F search, ⌘⌘ switch Notes/Chats, ⌃⌃ theme picker with arrow-key navigation, ⌘←/→ view history, double-Esc home; instant page switches, hover states, native file dialogs (full list in Settings > Keyboard shortcuts)
-- **Polished by design** - one design system: anchored context menus, confirm-before-delete everywhere, inline rename with Enter/Esc, copy any note or chat answer in one tap, incremental list rendering that stays smooth past hundreds of notes
+- **Polished by design** - one design system: edge-swipe drawers and drag-to-dismiss sheets, a 60fps waveform, anchored context menus, confirm-before-delete everywhere, inline rename with Enter/Esc, copy any note or chat answer in one tap, incremental list rendering that stays smooth past hundreds of notes
 - **Bilingual** - English + French UI, auto-detected, switchable in Settings; even error messages are localized
 - **Local-first** - SQLite for metadata, LanceDB for vectors, your data stays on your devices
 
@@ -54,7 +55,7 @@ No manual searching. No folders to dig through. Just talk, and find it later.
 | Styling       | [Tailwind CSS V4](https://tailwindcss.com)                                                     |
 | LLM           | [rig-core 0.36](https://github.com/0xPlaygrounds/rig) (OpenAI, Anthropic)                      |
 | Embeddings    | OpenAI text-embedding-3-small (1536 dims)                                                      |
-| Web search    | [Exa](https://exa.ai) REST API (optional, toggle in Settings)                                  |
+| Web search    | [Exa](https://exa.ai) REST API (optional, per-chat via the + menu)                             |
 | Vector DB     | [LanceDB 0.27.2](https://lancedb.com) (local, cosine)                                          |
 | Database      | SQLite ([rusqlite](https://github.com/rusqlite/rusqlite) 0.34, bundled, WAL mode)              |
 | Sync          | LAN P2P, [snow](https://github.com/mcginty/snow) (Noise XXpsk3), version vectors, tombstones   |

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -65,3 +65,23 @@ A round-trip path between a note and the chat. A round chat-bubble button sits n
 ## 2026-06 - Note threads (RFC 0006, #54)
 
 A thread is a first-class, titled, chronological stream of related notes you read top to bottom and append to in place. New `threads` table plus a nullable `notes.thread_id` (SQLite V13); a note belongs to at most one thread, ordered by `created_at`. A thread only counts as a thread at two or more members - a lone member renders as a plain note and a thread that drops below two collapses back (on leaving it and at boot), so entering one by mistake never strands you. The notes list mixes flat notes and stacked thread cards (a thread reuses the note card with its members' aggregated audio/web/reminder icons, just layered); the thread detail is a vertical timeline. Chat can be scoped to a thread, reusing #42's `allowed_note_ids` allow-list through a single `ChatScope` enum (Folder or Thread) that replaced the previous folder-only signal, with an explicit empty-scope answer instead of a silent zero-source reply. Threads register as one new sync kind and `thread_id` travels in the note payload (version vectors, tombstones, RFC 0004); thread delete re-stamps each member so a peer converges its members back to flat even though apply runs FK-off with triggers silenced. Backup counts threads; the V13 trigger installs on upgrade. Entry point is a stacked-cards button in the note bottom bar (start a thread or add to an existing one); the Mac notes list also switched from CSS multi-column to a row-major equal-height grid so notes read left to right like a comic strip. Adversarial 3-reviewer design pass on the RFC caught three sync blockers, all fixed before code. See [rfcs/0006-note-threads/](rfcs/0006-note-threads/).
+
+## 2026-06 - Local Whisper transcription (RFC 0005, Track H)
+
+Pluggable STT: a second provider runs Whisper fully on-device (whisper-rs, Metal). Download a ggml model (tiny to large-v3-turbo) in Settings with a size confirm, sha256 verification, and `.part`+rename; transcription then works in airplane mode (WAV -> mono 16 kHz -> whisper.cpp -> filler cleanup), audio never leaving the device. Provider and model id persist in Settings and travel in backup; model files stay device-local.
+
+## 2026-06 - Platform & agents groundwork (RFC 0012, 0014)
+
+The base for a vetted agent marketplace. A 100% Rust backend with accounts, passkey/WebAuthn auth, roles, and entitlements; a device fetches a signed agent manifest and verifies it against a pinned key before activation; every connector tool call passes a governance gate enforced on-device and re-checked server-side. Accounts cluster up to three paired devices; premium is admin-granted (B2B, no IAP). Consumer-facing marketplace UX is still ahead. See [rfcs/0012-console-agent-lifecycle/](rfcs/0012-console-agent-lifecycle/) and [rfcs/0014-platform-web-app-accounts-roles-agent-management/](rfcs/0014-platform-web-app-accounts-roles-agent-management/).
+
+## 2026-06 - SRP module split sprint (PRs #78-#81)
+
+Behavior-preserving decomposition of the remaining god-files into one-responsibility modules: RAG (`rag/` -> fusion, temporal, scoring, rerank, config, context), sync apply + peers (`apply/`, `peers/` -> ~13 modules: lan, codec, account_join, identity, peer_store, host, join, ...), backup (export, snapshot, stage, validate, swap), embed, and the LLM use-cases (tagging/titling/reminders) moved out of infrastructure into application. Clean-arch boundaries enforced (ui/infra -> application -> domain); tests kept green throughout.
+
+## 2026-06 - Gesture UX (PRs #80-#82)
+
+Finger-following gestures from a small native pointer controller (rAF + CSS translate, committed back to Dioxus on release): an edge-swipe drawer for the sidebar and a right-edge swipe to open a folder-scoped chat, both extracted into a reusable `use_swipe_drawer` hook. Plus a 60fps waveform (GPU `scaleY`), a desktop FAB, and a burger tap that reliably opens the sidebar.
+
+## 2026-06 - Composer tools menu, per-chat web, @ mentions
+
+Web search moves from a single global Settings toggle to a per-chat control inside a composer **+** menu (a tools + connectors hub) - a drag-to-dismiss bottom-sheet on iPhone, a popover with a hover tooltip on Mac, the switch in the brand orange and off by default, persisted per conversation (settings-KV, like the chat scope). Typing **@** opens a mention menu that scopes a message's RAG to a chosen note. The same **+** hub appears on notes. RAG `query()` now takes the per-chat web flag and mention note ids; a scoped chat answers from its notes unless web is explicitly on. See [prd/composer-tools-menu/](prd/composer-tools-menu/).

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@
 - Build and run: see [README - Setup](../README.md#setup) and [README - Commands](../README.md#commands)
 - Physical device setup (one-time pairing, certificates): [CLAUDE.md - Physical Device Setup](../CLAUDE.md)
 - [Desktop release guide](guides/desktop-release.md) - `make dmg` / `make release`, Gatekeeper, Developer ID + notarization
-- Tests: `cargo test` (269 tests), `cargo test -- --ignored` for API-key-gated ones
+- Tests: `cargo test` (364 tests), `cargo test -- --ignored` for API-key-gated ones
 
 ## 04 App Store
 
@@ -28,8 +28,8 @@
 
 ## 05 Specs
 
-- [RFCs](rfcs/) - technical designs: 0001 data backup/export, 0004 multidevice sync
-- [PRDs](prd/) - product specs: multidevice-sync, sync-realtime-ux, data-backup-export
+- [RFCs](rfcs/) - technical designs: 0001 backup/export, 0003 smart reminders, 0004 multidevice sync, 0005 pluggable STT, 0006 note threads, 0012 console agent lifecycle, 0013 shared contract crate, 0014 platform web app (accounts/roles/agents)
+- [PRDs](prd/) - product specs: composer-tools-menu, multidevice-sync, sync-realtime-ux, data-backup-export
 
 ## 06 History
 

--- a/src/application/i18n/locales/en.ftl
+++ b/src/application/i18n/locales/en.ftl
@@ -15,8 +15,7 @@ sources-one = 1 source
 sources-many = { $count } sources
 settings-search-title = Search
 settings-max-sources = Max sources
-settings-web-search-label = Web search
-settings-web-search-hint = Searches the web (via Exa) alongside your notes. Requires an Exa key.
+settings-web-search-moved = Web search is now controlled per chat: open the + menu in a conversation. An Exa key is still required.
 settings-save = Save
 settings-saved = Saved ✓
 settings-storage-title = Storage
@@ -231,6 +230,24 @@ chat-tool-web = Searching the web...
 chat-tool-working = Agent working...
 chat-error = Error
 chat-connector-error = A connected service failed - open Connections in Settings and reconnect if needed
+
+chat-tools-section-tools = Tools
+chat-tools-section-connectors = Connectors
+chat-tools-web = Web search
+chat-tools-web-desc = Find real-time information
+chat-tools-web-needs-key = Add an Exa key in Settings to enable it
+chat-tools-deep = Deep search
+chat-tools-deep-desc = Deeper multi-source analysis
+chat-tools-connected = Connected
+chat-tools-connect = Connect
+chat-tools-soon = Soon
+chat-tools-gmail-desc = Read and triage emails
+chat-tools-calendar-desc = Create and read events
+chat-conn-calendar = Google Calendar
+chat-tools-mention-hint = Type @ to mention a tool or a note
+chat-tools-tooltip = Add tools and connectors
+chat-mention-section-notes = Notes
+chat-mention-no-notes = No matching note
 
 recording-dictate = Dictate
 

--- a/src/application/i18n/locales/fr.ftl
+++ b/src/application/i18n/locales/fr.ftl
@@ -15,8 +15,7 @@ sources-one = 1 source
 sources-many = { $count } sources
 settings-search-title = Recherche
 settings-max-sources = Max sources
-settings-web-search-label = Recherche web
-settings-web-search-hint = Cherche sur le web (via Exa) en parallèle de tes notes. Nécessite une clé Exa.
+settings-web-search-moved = La recherche web se contrôle maintenant par chat : ouvre le menu + dans une conversation. Une clé Exa reste nécessaire.
 settings-save = Enregistrer
 settings-saved = Enregistré ✓
 settings-storage-title = Stockage
@@ -231,6 +230,24 @@ chat-tool-web = Recherche web...
 chat-tool-working = L'agent travaille...
 chat-error = Erreur
 chat-connector-error = Un service connecté a échoué - ouvrez Connexions dans les Réglages et reconnectez si besoin
+
+chat-tools-section-tools = Outils
+chat-tools-section-connectors = Connecteurs
+chat-tools-web = Recherche web
+chat-tools-web-desc = Trouver des infos en temps réel
+chat-tools-web-needs-key = Ajoute une clé Exa dans les Réglages pour l'activer
+chat-tools-deep = Recherche approfondie
+chat-tools-deep-desc = Analyse multi-sources plus poussée
+chat-tools-connected = Connecté
+chat-tools-connect = Connecter
+chat-tools-soon = Bientôt
+chat-tools-gmail-desc = Lire et trier les emails
+chat-tools-calendar-desc = Créer et lire des évènements
+chat-conn-calendar = Google Agenda
+chat-tools-mention-hint = Tapez @ pour mentionner un outil ou une note
+chat-tools-tooltip = Ajouter des outils et connecteurs
+chat-mention-section-notes = Notes
+chat-mention-no-notes = Aucune note correspondante
 
 recording-dictate = Dicter
 

--- a/src/application/rag/config.rs
+++ b/src/application/rag/config.rs
@@ -1,14 +1,32 @@
 use crate::application::constants::DEFAULT_RAG_MAX_SOURCES;
 use crate::infrastructure::persistence::Database;
 
-pub(super) fn web_search_config() -> (bool, String) {
+pub(super) fn exa_key() -> String {
     let Ok(db) = Database::open() else {
-        return (false, String::new());
+        return String::new();
     };
-    let enabled =
-        db.get_setting("web_search_enabled").as_deref() == Some("true");
-    let key = crate::application::web_search::exa_api_key(&db);
-    (enabled, key)
+    crate::application::web_search::exa_api_key(&db)
+}
+
+// The web fires only when THIS chat asked for it and an Exa key exists. The
+// per-chat flag replaces the old global setting: a chat is silent on the web
+// until its own toggle is on, so a folder/thread chat answers from its notes by
+// default and never gets its scoped hits diluted by an unscoped web merge.
+pub fn resolve_web_on(chat_web: bool, exa_key: &str) -> bool {
+    chat_web && !exa_key.trim().is_empty()
+}
+
+// "@note" mentions narrow this message to exactly those notes, overriding the
+// chat scope. No mentions -> the scope's note set (or None for a global chat).
+pub fn resolve_allowed_ids(
+    scope_ids: Option<Vec<String>>,
+    mention_ids: Vec<String>,
+) -> Option<Vec<String>> {
+    if mention_ids.is_empty() {
+        scope_ids
+    } else {
+        Some(mention_ids)
+    }
 }
 
 pub(super) fn read_max_sources() -> usize {

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -23,7 +23,8 @@ mod rerank;
 use rerank::llm_rerank;
 
 mod config;
-use config::{read_max_sources, web_search_config};
+use config::{exa_key, read_max_sources};
+pub use config::{resolve_allowed_ids, resolve_web_on};
 
 mod context;
 pub use context::build_context;
@@ -51,12 +52,14 @@ pub async fn query(
     question: &str,
     status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
     scope: Option<ChatScope>,
+    web: bool,
+    mention_note_ids: Vec<String>,
     lang: &str,
 ) -> Result<RagResponse, String> {
     let ai = Arc::new(LlmClient::from_env()?);
     let store = VectorStore::open().await?;
 
-    let allowed_note_ids: Option<Vec<String>> = match scope {
+    let scope_ids: Option<Vec<String>> = match scope {
         Some(ChatScope::Thread(tid)) => Database::open().ok().map(|db| {
             db.list_thread_notes(&tid)
                 .unwrap_or_default()
@@ -73,8 +76,14 @@ pub async fn query(
         }),
         None => None,
     };
+    let allowed_note_ids = resolve_allowed_ids(scope_ids, mention_note_ids);
 
-    if matches!(allowed_note_ids, Some(ref ids) if ids.is_empty()) {
+    let exa = exa_key();
+    let web_on = resolve_web_on(web, &exa);
+
+    // An empty scope only dead-ends when there is no web to fall back on; with web
+    // on, the chat still answers from the web even if the scoped note set is empty.
+    if !web_on && matches!(allowed_note_ids, Some(ref ids) if ids.is_empty()) {
         return Ok(RagResponse {
             answer: crate::application::i18n::t(lang, "chat-empty-scope"),
             sources: vec![],
@@ -103,8 +112,6 @@ pub async fn query(
     } else {
         RAG_INITIAL_K
     };
-    let (web_enabled, exa_key) = web_search_config();
-    let web_on = web_enabled && !exa_key.trim().is_empty();
 
     let results: Vec<SearchResult> = if web_on {
         if let Some(ref tx) = status_tx {
@@ -117,7 +124,7 @@ pub async fn query(
                 fetch_k,
                 allowed_note_ids.as_deref(),
             ),
-            crate::application::web_search::exa_search(question, &exa_key),
+            crate::application::web_search::exa_search(question, &exa),
         );
         if let Some(ref tx) = status_tx {
             let _ = tx.send(ToolEvent::Finished("web_search".into()));

--- a/src/infrastructure/persistence/conversation_repo.rs
+++ b/src/infrastructure/persistence/conversation_repo.rs
@@ -6,6 +6,10 @@ fn chat_scope_key(conversation_id: &str) -> String {
     format!("chat_scope:{conversation_id}")
 }
 
+fn chat_web_key(conversation_id: &str) -> String {
+    format!("chat_web:{conversation_id}")
+}
+
 fn parse_scope(raw: &str) -> ChatScope {
     if let Some(id) = raw.strip_prefix("thread:") {
         ChatScope::Thread(id.to_string())
@@ -37,6 +41,24 @@ impl Database {
         scope: Option<&ChatScope>,
     ) -> Result<(), String> {
         self.set_setting(&chat_scope_key(conversation_id), &scope_value(scope))
+    }
+
+    // Per-chat web-search preference, stored like chat_scope (settings KV keyed
+    // by conversation, no schema change). Default OFF: a chat stays off the web
+    // until its own "+" toggle turns it on.
+    pub fn chat_web(&self, conversation_id: &str) -> bool {
+        self.get_setting(&chat_web_key(conversation_id)).as_deref() == Some("1")
+    }
+
+    pub fn set_chat_web(
+        &self,
+        conversation_id: &str,
+        on: bool,
+    ) -> Result<(), String> {
+        self.set_setting(
+            &chat_web_key(conversation_id),
+            if on { "1" } else { "0" },
+        )
     }
 
     pub fn create_conversation(
@@ -104,6 +126,8 @@ impl Database {
             .map_err(|e| format!("Delete conversation: {e}"))?;
         tx.execute("DELETE FROM settings WHERE key = ?1", [chat_scope_key(id)])
             .map_err(|e| format!("Delete conversation scope: {e}"))?;
+        tx.execute("DELETE FROM settings WHERE key = ?1", [chat_web_key(id)])
+            .map_err(|e| format!("Delete conversation web flag: {e}"))?;
         tx.commit()
             .map_err(|e| format!("Delete conversation commit: {e}"))?;
         Ok(())

--- a/src/ui/chat/actions.rs
+++ b/src/ui/chat/actions.rs
@@ -172,6 +172,8 @@ pub fn send_question(
     conversation_id: Signal<Option<String>>,
     db: Signal<Arc<Database>>,
     scope: Option<rag::ChatScope>,
+    web: bool,
+    mention_ids: Vec<String>,
     lang: String,
 ) {
     messages.write().push(ChatMsg::User(question.clone()));
@@ -213,7 +215,15 @@ pub fn send_question(
         {
             rag::run_action(&question, Some(tx)).await
         } else {
-            rag::query(&question, Some(tx), scope, &lang_for_query).await
+            rag::query(
+                &question,
+                Some(tx),
+                scope,
+                web,
+                mention_ids,
+                &lang_for_query,
+            )
+            .await
         };
         match result {
             Ok(r) => {

--- a/src/ui/chat/chat_input.rs
+++ b/src/ui/chat/chat_input.rs
@@ -1,33 +1,61 @@
 use crate::application::i18n::t;
 use crate::infrastructure::audio::{AudioRecorder, RecordingState};
+use crate::ui::chat::mention_menu::{MentionMenu, MentionedNote};
+use crate::ui::chat::tools_menu::ToolsMenu;
 use crate::ui::icons::*;
 use crate::ui::recording::{start_recording, RecordingControls};
 use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::{Arc, Mutex};
 
+// A mention is the trailing "@frag" at the very end of the input (start of input
+// or after whitespace, no space yet). Returns the fragment after "@" to filter on.
+fn mention_fragment(s: &str) -> Option<String> {
+    let at = s.rfind('@')?;
+    if at > 0 {
+        let prev = s[..at].chars().next_back()?;
+        if !prev.is_whitespace() {
+            return None;
+        }
+    }
+    let frag = &s[at + 1..];
+    if frag.chars().any(char::is_whitespace) {
+        return None;
+    }
+    Some(frag.to_string())
+}
+
 #[component]
 pub fn ChatInputBar(
     input: Signal<String>,
+    mentions: Signal<Vec<MentionedNote>>,
     disabled: bool,
     on_send: EventHandler<String>,
 ) -> Element {
-    let app: AppState = use_context();
+    let mut app: AppState = use_context();
     let recorder: Signal<Arc<Mutex<AudioRecorder>>> = use_context();
     let lang = (app.current_lang)();
     let placeholder = t(&lang, "chat-input-placeholder");
     let dummy_pending_audio: Signal<Option<(String, f64)>> =
         use_signal(|| None);
+    let mut mention_query = use_signal(String::new);
+    let mut plus_hover = use_signal(|| false);
 
     let recording_state = (app.recording_state)();
     let is_idle = recording_state == RecordingState::Idle
         || matches!(recording_state, RecordingState::Error(_))
         || matches!(recording_state, RecordingState::Transcribed(_));
 
+    let show_tools = (app.show_tools_menu)();
+    let show_mention = (app.show_mention_menu)();
+    let is_desktop = !cfg!(target_os = "ios");
+
     let mut do_send = move || {
         let q = input().trim().to_string();
         if !q.is_empty() && !disabled {
             input.set(String::new());
+            app.show_tools_menu.set(false);
+            app.show_mention_menu.set(false);
             dioxus::document::eval(
                 r#"
                 var ta = document.querySelector('.chat-textarea');
@@ -42,7 +70,41 @@ pub fn ChatInputBar(
         div { class: "fixed bottom-0 left-0 right-0 px-4 py-2 bg-warm-white border-t border-stone-200 z-30 keyboard-aware lg:left-72",
             div { class: "lg:max-w-3xl lg:mx-auto",
             if is_idle {
-                div { class: "flex items-end gap-2",
+                div { class: "relative flex items-end gap-2",
+                    if show_mention {
+                        MentionMenu {
+                            input: input,
+                            mentions: mentions,
+                            query: mention_query(),
+                        }
+                    }
+                    div { class: "relative shrink-0",
+                        button {
+                            class: "w-10 h-10 lg:w-12 lg:h-12 rounded-full bg-warm-white border border-stone-200 flex items-center justify-center text-stone-600 hover:bg-stone-100 transition-colors duration-150",
+                            disabled: disabled,
+                            onmouseenter: move |_| plus_hover.set(true),
+                            onmouseleave: move |_| plus_hover.set(false),
+                            onclick: move |_| {
+                                app.show_mention_menu.set(false);
+                                app.show_tools_menu.set(!(app.show_tools_menu)());
+                            },
+                            onkeydown: move |evt| {
+                                if evt.key() == Key::Escape {
+                                    app.show_tools_menu.set(false);
+                                }
+                            },
+                            IconPlus { size: 20 }
+                        }
+                        if show_tools {
+                            ToolsMenu {}
+                        }
+                        if is_desktop && plus_hover() && !show_tools {
+                            div { class: "absolute bottom-full left-0 mb-2 z-40 pointer-events-none flex items-center gap-2 whitespace-nowrap bg-stone-800 text-white text-xs font-medium px-2.5 py-1.5 rounded-lg shadow tooltip-fade",
+                                span { {t(&lang, "chat-tools-tooltip")} }
+                                span { class: "px-1.5 py-0.5 rounded bg-stone-700 border border-stone-600 font-mono text-[11px]", "@" }
+                            }
+                        }
+                    }
                     button {
                         class: "w-10 h-10 lg:w-12 lg:h-12 shrink-0 rounded-full bg-warm-white border border-ios-orange/15 flex items-center justify-center text-ios-orange-dark hover:bg-ios-orange-50 transition-colors duration-150",
                         disabled: disabled,
@@ -56,7 +118,17 @@ pub fn ChatInputBar(
                         placeholder: "{placeholder}",
                         value: "{input}",
                         oninput: move |evt| {
-                            input.set(evt.value());
+                            let val = evt.value();
+                            input.set(val.clone());
+                            mentions.write().retain(|m| val.contains(&format!("@{}", m.title)));
+                            match mention_fragment(&val) {
+                                Some(frag) => {
+                                    mention_query.set(frag);
+                                    app.show_tools_menu.set(false);
+                                    app.show_mention_menu.set(true);
+                                }
+                                None => app.show_mention_menu.set(false),
+                            }
                             dioxus::document::eval(
                                 r#"
                                 var ta = document.querySelector('.chat-textarea');
@@ -65,6 +137,10 @@ pub fn ChatInputBar(
                             );
                         },
                         onkeydown: move |evt| {
+                            if evt.key() == Key::Escape {
+                                app.show_tools_menu.set(false);
+                                app.show_mention_menu.set(false);
+                            }
                             if cfg!(target_os = "ios") {
                                 return;
                             }

--- a/src/ui/chat/mention_menu.rs
+++ b/src/ui/chat/mention_menu.rs
@@ -61,10 +61,13 @@ pub fn MentionMenu(
                 span { class: LEAD_ICON, IconGlobeSimple { size: 22 } }
                 span { class: ROW_TITLE, {t(&lang, "chat-tools-web")} }
             }
+            // Parked until implemented (icon + i18n kept): deep search.
+            /*
             div { class: "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg opacity-50",
                 span { class: LEAD_ICON, IconMagnifyingGlass { size: 22 } }
                 span { class: ROW_TITLE, {t(&lang, "chat-tools-deep")} }
             }
+            */
             div { class: SEP }
             div { class: SECTION, {t(&lang, "chat-mention-section-notes")} }
             if notes.is_empty() {

--- a/src/ui/chat/mention_menu.rs
+++ b/src/ui/chat/mention_menu.rs
@@ -1,0 +1,103 @@
+use crate::application::i18n::t;
+use crate::infrastructure::persistence::Database;
+use crate::ui::chat::tools_menu::{LEAD_ICON, ROW, ROW_TITLE, SECTION, SEP};
+use crate::ui::icons::*;
+use crate::ui::AppState;
+use dioxus::prelude::*;
+use std::sync::Arc;
+
+#[derive(Clone, PartialEq)]
+pub struct MentionedNote {
+    pub note_id: String,
+    pub title: String,
+}
+
+// Mentions are detected at the end of the input ("... @frag"). Selecting an item
+// replaces that trailing "@frag" with the chosen token (or removes it for a tool).
+fn replace_trailing_at(s: &str, replacement: &str) -> String {
+    match s.rfind('@') {
+        Some(at) => format!("{}{}", &s[..at], replacement),
+        None => format!("{s}{replacement}"),
+    }
+}
+
+#[component]
+pub fn MentionMenu(
+    input: Signal<String>,
+    mentions: Signal<Vec<MentionedNote>>,
+    query: String,
+) -> Element {
+    let mut app: AppState = use_context();
+    let db: Signal<Arc<Database>> = use_context();
+    let lang = (app.current_lang)();
+
+    let q = query.to_lowercase();
+    let notes: Vec<(String, String)> = db()
+        .list_notes()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|n| {
+            let title = n.title.unwrap_or_default();
+            if title.is_empty() {
+                None
+            } else {
+                Some((n.id, title))
+            }
+        })
+        .filter(|(_, title)| q.is_empty() || title.to_lowercase().contains(&q))
+        .take(8)
+        .collect();
+
+    rsx! {
+        div { class: "absolute bottom-full left-2 right-2 lg:left-0 lg:right-auto lg:w-72 mb-2 z-40 max-h-64 overflow-y-auto bg-warm-white border border-stone-200 rounded-xl shadow-lg p-2 popover-pop",
+            div { class: SECTION, {t(&lang, "chat-tools-section-tools")} }
+            button {
+                class: ROW,
+                onclick: move |_| {
+                    app.chat_web.set(true);
+                    input.set(replace_trailing_at(&input(), ""));
+                    app.show_mention_menu.set(false);
+                },
+                span { class: LEAD_ICON, IconGlobeSimple { size: 22 } }
+                span { class: ROW_TITLE, {t(&lang, "chat-tools-web")} }
+            }
+            div { class: "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg opacity-50",
+                span { class: LEAD_ICON, IconMagnifyingGlass { size: 22 } }
+                span { class: ROW_TITLE, {t(&lang, "chat-tools-deep")} }
+            }
+            div { class: SEP }
+            div { class: SECTION, {t(&lang, "chat-mention-section-notes")} }
+            if notes.is_empty() {
+                div { class: "px-3 py-2 text-sm text-stone-400",
+                    {t(&lang, "chat-mention-no-notes")}
+                }
+            } else {
+                for (id, title) in notes {
+                    button {
+                        key: "{id}",
+                        class: ROW,
+                        onclick: {
+                            let id = id.clone();
+                            let title = title.clone();
+                            move |_| {
+                                let token = format!("@{title} ");
+                                input.set(replace_trailing_at(&input(), &token));
+                                let mut next = mentions();
+                                if !next.iter().any(|m| m.note_id == id) {
+                                    next.push(MentionedNote {
+                                        note_id: id.clone(),
+                                        title: title.clone(),
+                                    });
+                                }
+                                mentions.set(next);
+                                app.show_mention_menu.set(false);
+                            }
+                        },
+                        span { class: LEAD_ICON, IconNotebook { size: 22 } }
+                        span { class: "flex-1 min-w-0 truncate {ROW_TITLE}", "{title}" }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/chat/mod.rs
+++ b/src/ui/chat/mod.rs
@@ -1,9 +1,11 @@
 mod actions;
 mod bot_bubble;
 mod empty_state;
+mod mention_menu;
 mod menu;
 mod models;
 mod sources_accordion;
+mod tools_menu;
 mod typing_indicator;
 mod user_bubble;
 mod view;

--- a/src/ui/chat/mod.rs
+++ b/src/ui/chat/mod.rs
@@ -15,4 +15,5 @@ pub(crate) mod chat_input;
 
 pub use actions::md_to_html;
 pub use sources_accordion::NoteWebSources;
+pub(crate) use tools_menu::ConnectorsSection;
 pub use view::ChatView;

--- a/src/ui/chat/tools_menu.rs
+++ b/src/ui/chat/tools_menu.rs
@@ -8,6 +8,8 @@ use dioxus::prelude::*;
 use std::sync::Arc;
 
 pub(crate) const ROW: &str = "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg text-left hover:bg-stone-100 active:bg-stone-100 transition-colors duration-150";
+// Kept for the parked rows (deep search, Notion): restore with them.
+#[allow(dead_code)]
 const ROW_DISABLED: &str = "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg text-left opacity-50";
 pub(crate) const LEAD_ICON: &str = "w-[22px] h-[22px] shrink-0 flex items-center justify-center text-stone-500";
 const LEAD_TILE: &str = "w-7 h-7 shrink-0 flex items-center justify-center rounded-lg bg-stone-100 overflow-hidden";
@@ -16,6 +18,8 @@ const ROW_SUB: &str = "text-xs text-stone-400";
 pub(crate) const SECTION: &str =
     "px-3 py-2 text-xs font-medium text-stone-400 uppercase tracking-wide";
 pub(crate) const SEP: &str = "h-px bg-stone-200 mx-3 my-2";
+// Kept for the parked connector rows (Gmail, Calendar "Connect" pill).
+#[allow(dead_code)]
 const PILL: &str = "shrink-0 h-7 px-3 flex items-center justify-center rounded-lg bg-stone-100 text-stone-900 text-xs font-medium";
 
 #[component]
@@ -66,12 +70,6 @@ fn ToolsMenuBody() -> Element {
         .map(|k| !k.trim().is_empty())
         .unwrap_or(false);
 
-    let mut open_connections = move || {
-        app.show_tools_menu.set(false);
-        app.view
-            .set(View::SettingsSection(SettingsSection::Connections));
-    };
-
     rsx! {
         div { class: SECTION, {t(&lang, "chat-tools-section-tools")} }
 
@@ -92,6 +90,8 @@ fn ToolsMenuBody() -> Element {
             Switch { on: web_on }
         }
 
+        // Parked until implemented (icon + i18n kept): deep search.
+        /*
         div {
             class: ROW_DISABLED,
             span { class: LEAD_ICON, IconMagnifyingGlass { size: 22 } }
@@ -101,13 +101,41 @@ fn ToolsMenuBody() -> Element {
             }
             Switch { on: false }
         }
+        */
 
         div { class: SEP }
+        ConnectorsSection {}
+
+        div { class: "flex items-center gap-1.5 px-3 pt-3 text-xs text-stone-400",
+            span { class: "px-1.5 py-0.5 rounded bg-stone-200 border border-stone-300 text-stone-600 font-mono text-[11px]",
+                "@"
+            }
+            span { {t(&lang, "chat-tools-mention-hint")} }
+        }
+    }
+}
+
+// Shared connectors list (chat + note menus). A connector tap routes to
+// Settings > Connections, the real connect/manage surface; the labels here are a
+// static showcase of the hub.
+#[component]
+pub(crate) fn ConnectorsSection() -> Element {
+    let mut app: AppState = use_context();
+    let lang = (app.current_lang)();
+
+    let open_connections = move |_| {
+        app.show_tools_menu.set(false);
+        app.show_note_tools_menu.set(false);
+        app.view
+            .set(View::SettingsSection(SettingsSection::Connections));
+    };
+
+    rsx! {
         div { class: SECTION, {t(&lang, "chat-tools-section-connectors")} }
 
         button {
             class: ROW,
-            onclick: move |_| open_connections(),
+            onclick: open_connections,
             span { class: LEAD_TILE, IconGoogleSheets { size: 18 } }
             span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
                 span { class: ROW_TITLE, "Google Sheets" }
@@ -118,9 +146,13 @@ fn ToolsMenuBody() -> Element {
             }
         }
 
+        // Parked until wired (icons + i18n kept): Calendar duplicates our own
+        // reminder/calendar system, Gmail and Notion are not connected yet.
+        // Restore these rows when the connectors go live.
+        /*
         button {
             class: ROW,
-            onclick: move |_| open_connections(),
+            onclick: open_connections,
             span { class: LEAD_TILE, IconGmail { size: 18 } }
             span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
                 span { class: ROW_TITLE, "Gmail" }
@@ -131,7 +163,7 @@ fn ToolsMenuBody() -> Element {
 
         button {
             class: ROW,
-            onclick: move |_| open_connections(),
+            onclick: open_connections,
             span { class: LEAD_TILE, IconGoogleCalendar { size: 20 } }
             span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
                 span { class: ROW_TITLE, {t(&lang, "chat-conn-calendar")} }
@@ -148,13 +180,7 @@ fn ToolsMenuBody() -> Element {
                 span { class: ROW_SUB, {t(&lang, "chat-tools-soon")} }
             }
         }
-
-        div { class: "flex items-center gap-1.5 px-3 pt-3 text-xs text-stone-400",
-            span { class: "px-1.5 py-0.5 rounded bg-stone-200 border border-stone-300 text-stone-600 font-mono text-[11px]",
-                "@"
-            }
-            span { {t(&lang, "chat-tools-mention-hint")} }
-        }
+        */
     }
 }
 

--- a/src/ui/chat/tools_menu.rs
+++ b/src/ui/chat/tools_menu.rs
@@ -1,0 +1,178 @@
+use crate::application::i18n::t;
+use crate::infrastructure::persistence::Database;
+use crate::ui::hooks::swipe::use_sheet_dismiss;
+use crate::ui::icons::*;
+use crate::ui::state::{SettingsSection, View};
+use crate::ui::AppState;
+use dioxus::prelude::*;
+use std::sync::Arc;
+
+pub(crate) const ROW: &str = "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg text-left hover:bg-stone-100 active:bg-stone-100 transition-colors duration-150";
+const ROW_DISABLED: &str = "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg text-left opacity-50";
+pub(crate) const LEAD_ICON: &str = "w-[22px] h-[22px] shrink-0 flex items-center justify-center text-stone-500";
+const LEAD_TILE: &str = "w-7 h-7 shrink-0 flex items-center justify-center rounded-lg bg-stone-100 overflow-hidden";
+pub(crate) const ROW_TITLE: &str = "text-sm font-medium text-stone-800";
+const ROW_SUB: &str = "text-xs text-stone-400";
+pub(crate) const SECTION: &str =
+    "px-3 py-2 text-xs font-medium text-stone-400 uppercase tracking-wide";
+pub(crate) const SEP: &str = "h-px bg-stone-200 mx-3 my-2";
+const PILL: &str = "shrink-0 h-7 px-3 flex items-center justify-center rounded-lg bg-stone-100 text-stone-900 text-xs font-medium";
+
+#[component]
+pub fn ToolsMenu() -> Element {
+    let mut app: AppState = use_context();
+
+    // Drag the grabber strip down to dismiss the sheet (finger-follow, then a
+    // slide-out before Rust unmounts it). No-op on desktop: there is no #tools-sheet.
+    use_sheet_dismiss("tools-sheet", "tools-backdrop", 48.0, 0.3, move || {
+        app.show_tools_menu.set(false)
+    });
+
+    let close = move |_| app.show_tools_menu.set(false);
+
+    if cfg!(target_os = "ios") {
+        rsx! {
+            div {
+                id: "tools-backdrop",
+                class: "fixed inset-0 z-30 bg-black/10 backdrop-fade",
+                onclick: close,
+            }
+            div {
+                id: "tools-sheet",
+                class: "fixed bottom-0 left-0 right-0 z-40 bg-warm-white rounded-t-2xl px-2 pt-2 sheet-pop",
+                style: "padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));",
+                div { class: "w-9 h-1 rounded-full bg-stone-300 mx-auto mt-1 mb-3" }
+                ToolsMenuBody {}
+            }
+        }
+    } else {
+        rsx! {
+            div { class: "fixed inset-0 z-30", onclick: close }
+            div { class: "absolute bottom-full left-0 mb-2 w-80 z-40 bg-warm-white border border-stone-200 rounded-xl shadow-lg p-2 popover-pop",
+                ToolsMenuBody {}
+            }
+        }
+    }
+}
+
+#[component]
+fn ToolsMenuBody() -> Element {
+    let mut app: AppState = use_context();
+    let db: Signal<Arc<Database>> = use_context();
+    let lang = (app.current_lang)();
+    let web_on = (app.chat_web)();
+    let has_exa = db()
+        .get_setting("exa_api_key")
+        .map(|k| !k.trim().is_empty())
+        .unwrap_or(false);
+
+    let mut open_connections = move || {
+        app.show_tools_menu.set(false);
+        app.view
+            .set(View::SettingsSection(SettingsSection::Connections));
+    };
+
+    rsx! {
+        div { class: SECTION, {t(&lang, "chat-tools-section-tools")} }
+
+        button {
+            class: ROW,
+            onclick: move |_| app.chat_web.set(!(app.chat_web)()),
+            span { class: LEAD_ICON, IconGlobeSimple { size: 22 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, {t(&lang, "chat-tools-web")} }
+                span { class: ROW_SUB,
+                    if has_exa {
+                        {t(&lang, "chat-tools-web-desc")}
+                    } else {
+                        {t(&lang, "chat-tools-web-needs-key")}
+                    }
+                }
+            }
+            Switch { on: web_on }
+        }
+
+        div {
+            class: ROW_DISABLED,
+            span { class: LEAD_ICON, IconMagnifyingGlass { size: 22 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, {t(&lang, "chat-tools-deep")} }
+                span { class: ROW_SUB, {t(&lang, "chat-tools-deep-desc")} }
+            }
+            Switch { on: false }
+        }
+
+        div { class: SEP }
+        div { class: SECTION, {t(&lang, "chat-tools-section-connectors")} }
+
+        button {
+            class: ROW,
+            onclick: move |_| open_connections(),
+            span { class: LEAD_TILE, IconGoogleSheets { size: 18 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, "Google Sheets" }
+                span { class: ROW_SUB, {t(&lang, "chat-tools-connected")} }
+            }
+            span { class: "shrink-0 flex items-center gap-1 text-ios-orange text-xs font-medium",
+                IconCheck { size: 16 }
+            }
+        }
+
+        button {
+            class: ROW,
+            onclick: move |_| open_connections(),
+            span { class: LEAD_TILE, IconGmail { size: 18 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, "Gmail" }
+                span { class: ROW_SUB, {t(&lang, "chat-tools-gmail-desc")} }
+            }
+            span { class: PILL, {t(&lang, "chat-tools-connect")} }
+        }
+
+        button {
+            class: ROW,
+            onclick: move |_| open_connections(),
+            span { class: LEAD_TILE, IconGoogleCalendar { size: 20 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, {t(&lang, "chat-conn-calendar")} }
+                span { class: ROW_SUB, {t(&lang, "chat-tools-calendar-desc")} }
+            }
+            span { class: PILL, {t(&lang, "chat-tools-connect")} }
+        }
+
+        div {
+            class: ROW_DISABLED,
+            span { class: LEAD_TILE, IconNotion { size: 18 } }
+            span { class: "flex-1 flex flex-col gap-0.5 min-w-0",
+                span { class: ROW_TITLE, "Notion" }
+                span { class: ROW_SUB, {t(&lang, "chat-tools-soon")} }
+            }
+        }
+
+        div { class: "flex items-center gap-1.5 px-3 pt-3 text-xs text-stone-400",
+            span { class: "px-1.5 py-0.5 rounded bg-stone-200 border border-stone-300 text-stone-600 font-mono text-[11px]",
+                "@"
+            }
+            span { {t(&lang, "chat-tools-mention-hint")} }
+        }
+    }
+}
+
+#[component]
+fn Switch(on: bool) -> Element {
+    let track = if on {
+        "relative w-11 h-6 shrink-0 rounded-full bg-ios-orange transition-colors duration-200"
+    } else {
+        "relative w-11 h-6 shrink-0 rounded-full bg-stone-300 transition-colors duration-200"
+    };
+    let knob = if on {
+        "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-5"
+    } else {
+        "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-0"
+    };
+    rsx! {
+        span { class: track,
+            span { class: knob }
+        }
+    }
+}

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -5,6 +5,7 @@ use crate::ui::chat::actions::{load_messages_from_db, send_question};
 use crate::ui::chat::bot_bubble::BotBubble;
 use crate::ui::chat::chat_input::ChatInputBar;
 use crate::ui::chat::empty_state::ChatEmptyState;
+use crate::ui::chat::mention_menu::MentionedNote;
 use crate::ui::chat::menu::ChatMenu;
 use crate::ui::chat::models::ChatMsg;
 use crate::ui::chat::typing_indicator::TypingIndicator;
@@ -34,6 +35,11 @@ pub fn ChatView() -> Element {
                 .chat_scope(cid)
                 .filter(|s| scope_alive(&db.peek(), s));
             app.chat_scope.set(restored);
+            app.chat_web.set(db.peek().chat_web(cid));
+        } else {
+            // Fresh mount with no conversation (new chat from a non-chat view):
+            // start OFF so a prior chat's web toggle never leaks in.
+            app.chat_web.set(false);
         }
         true
     });
@@ -47,6 +53,7 @@ pub fn ChatView() -> Element {
 
     let mut messages: Signal<Vec<ChatMsg>> = use_signal(|| initial_msgs);
     let mut input = use_signal(String::new);
+    let mut mentions: Signal<Vec<MentionedNote>> = use_signal(Vec::new);
     let mut loading = use_signal(|| false);
     let mut tool_status: Signal<Option<String>> = use_signal(|| None);
     let renaming = use_signal(|| false);
@@ -127,17 +134,30 @@ pub fn ChatView() -> Element {
                 pending.filter(|s| scope_alive(&db.peek(), s))
             }
         };
+        let web = match &view_cid {
+            Some(cid) => db.peek().chat_web(cid),
+            None => false,
+        };
         conversation_id.set(view_cid);
         messages.set(msgs);
         input.set(String::new());
         tool_status.set(None);
+        mentions.set(Vec::new());
         app.chat_scope.set(restored);
+        app.chat_web.set(web);
     });
 
     use_effect(move || {
         let scope = (app.chat_scope)();
         if let Some(cid) = conversation_id.peek().clone() {
             let _ = db.peek().set_chat_scope(&cid, scope.as_ref());
+        }
+    });
+
+    use_effect(move || {
+        let web = (app.chat_web)();
+        if let Some(cid) = conversation_id.peek().clone() {
+            let _ = db.peek().set_chat_web(&cid, web);
         }
     });
 
@@ -188,6 +208,7 @@ pub fn ChatView() -> Element {
         }
         ChatInputBar {
             input: input,
+            mentions: mentions,
             disabled: loading(),
             on_send: move |q: String| {
                 if conversation_id().is_none() {
@@ -198,6 +219,7 @@ pub fn ChatView() -> Element {
                             &cid,
                             (app.chat_scope)().as_ref(),
                         );
+                        let _ = db().set_chat_web(&cid, (app.chat_web)());
                         conversation_id.set(Some(cid.clone()));
                         app.view.set(View::Chat {
                             conversation_id: Some(cid),
@@ -209,8 +231,12 @@ pub fn ChatView() -> Element {
                     }
                 }
                 let scope = (app.chat_scope)();
+                let web = (app.chat_web)();
+                let mention_ids: Vec<String> =
+                    mentions().iter().map(|m| m.note_id.clone()).collect();
                 let lang = (app.current_lang)();
-                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, scope, lang);
+                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, scope, web, mention_ids, lang);
+                mentions.set(Vec::new());
             },
         }
     }

--- a/src/ui/hooks/globals.d.ts
+++ b/src/ui/hooks/globals.d.ts
@@ -7,3 +7,5 @@ declare const __EDGE_PX__: number;
 declare const __OPEN_AT__: number;
 declare const __CLOSE_AT__: number;
 declare const __THRESHOLD__: number;
+declare const __GRAB_PX__: number;
+declare const __DISMISS_AT__: number;

--- a/src/ui/hooks/swipe.rs
+++ b/src/ui/hooks/swipe.rs
@@ -66,6 +66,51 @@ pub fn use_swipe_drawer(cfg: DrawerSwipe) {
     });
 }
 
+const SWIPE_SHEET_JS: &str = include_str!("swipe_sheet.js");
+
+pub fn build_sheet_script(
+    sheet_id: &str,
+    backdrop_id: &str,
+    grab_px: f64,
+    dismiss_at: f64,
+) -> String {
+    SWIPE_SHEET_JS
+        .replace("__SHEET__", sheet_id)
+        .replace("__BACKDROP__", backdrop_id)
+        .replace("__GRAB_PX__", &grab_px.to_string())
+        .replace("__DISMISS_AT__", &dismiss_at.to_string())
+}
+
+// Bottom-sheet drag-to-dismiss: a downward drag from the grabber strip follows
+// the finger and, past the threshold (or on a flick), animates out and runs
+// `on_close` so the caller unmounts the sheet. The sheet remounts each open, so
+// the controller tears down its prior listeners on re-eval.
+pub fn use_sheet_dismiss(
+    sheet_id: &'static str,
+    backdrop_id: &'static str,
+    grab_px: f64,
+    dismiss_at: f64,
+    on_close: impl FnMut() + 'static,
+) {
+    let mut on_close = Some(on_close);
+    use_future(move || {
+        let taken = on_close.take();
+        async move {
+            let Some(mut on_close) = taken else {
+                return;
+            };
+            let script =
+                build_sheet_script(sheet_id, backdrop_id, grab_px, dismiss_at);
+            let mut eval = dioxus::document::eval(&script);
+            while let Ok(msg) = eval.recv::<String>().await {
+                if msg == "closed" {
+                    on_close();
+                }
+            }
+        }
+    });
+}
+
 const SWIPE_RIGHT_NAV_JS: &str = include_str!("swipe_right_nav.js");
 
 pub fn build_right_nav_script(edge_px: f64, threshold: f64) -> String {

--- a/src/ui/hooks/swipe_sheet.js
+++ b/src/ui/hooks/swipe_sheet.js
@@ -1,0 +1,140 @@
+// src/ui/hooks/swipe_sheet.ts
+(function() {
+  const CFG = {
+    sheetId: "__SHEET__",
+    backdropId: "__BACKDROP__",
+    grabPx: __GRAB_PX__,
+    dismissAt: __DISMISS_AT__
+  };
+  const FLICK = 0.5;
+  const w0 = window;
+  const KEY = "__sheet_" + CFG.sheetId;
+  const prev = w0[KEY];
+  if (prev)
+    prev();
+  let sheet = null;
+  let backdrop = null;
+  let h = 0;
+  let active = false;
+  let startY = 0;
+  let lastY = 0;
+  let lastT = 0;
+  let vel = 0;
+  let cur = 0;
+  let raf = 0;
+  function apply() {
+    raf = 0;
+    if (!sheet)
+      return;
+    sheet.style.transition = "none";
+    sheet.style.translate = "0 " + cur + "px";
+    if (backdrop) {
+      const p = Math.max(0, Math.min(1, 1 - cur / h));
+      backdrop.style.transition = "none";
+      backdrop.style.opacity = p.toFixed(3);
+    }
+  }
+  function schedule() {
+    if (!raf)
+      raf = requestAnimationFrame(apply);
+  }
+  function dismiss() {
+    if (!sheet)
+      return;
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    sheet.style.transition = "translate .22s cubic-bezier(.32,.72,0,1)";
+    sheet.style.translate = "0 " + h + "px";
+    if (backdrop) {
+      backdrop.style.transition = "opacity .22s ease";
+      backdrop.style.opacity = "0";
+    }
+    setTimeout(() => dioxus.send("closed"), 210);
+  }
+  function snapBack() {
+    if (!sheet)
+      return;
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    sheet.style.transition = "translate .22s cubic-bezier(.32,.72,0,1)";
+    sheet.style.translate = "0 0px";
+    if (backdrop) {
+      backdrop.style.transition = "opacity .22s ease";
+      backdrop.style.opacity = "1";
+    }
+    setTimeout(() => {
+      if (!sheet)
+        return;
+      sheet.style.transition = "";
+      sheet.style.translate = "";
+      if (backdrop) {
+        backdrop.style.transition = "";
+        backdrop.style.opacity = "";
+      }
+    }, 240);
+  }
+  function onDown(e) {
+    if (e.pointerType === "mouse" || active)
+      return;
+    sheet = document.getElementById(CFG.sheetId);
+    backdrop = document.getElementById(CFG.backdropId);
+    if (!sheet)
+      return;
+    const rect = sheet.getBoundingClientRect();
+    h = rect.height || 300;
+    if (e.clientY > rect.top + CFG.grabPx)
+      return;
+    active = true;
+    startY = lastY = e.clientY;
+    lastT = e.timeStamp;
+    vel = 0;
+    cur = 0;
+  }
+  function onMove(e) {
+    if (!active || !sheet)
+      return;
+    const dy = e.clientY - startY;
+    if (dy <= 0) {
+      cur = 0;
+      schedule();
+      return;
+    }
+    const dt = e.timeStamp - lastT;
+    if (dt > 0)
+      vel = (e.clientY - lastY) / dt;
+    lastY = e.clientY;
+    lastT = e.timeStamp;
+    cur = Math.min(h, dy);
+    if (e.cancelable)
+      e.preventDefault();
+    schedule();
+  }
+  function onUp() {
+    if (!active)
+      return;
+    active = false;
+    const progress = h > 0 ? cur / h : 0;
+    if (vel > FLICK || progress > CFG.dismissAt) {
+      dismiss();
+    } else {
+      snapBack();
+    }
+  }
+  document.addEventListener("pointerdown", onDown, true);
+  document.addEventListener("pointermove", onMove, {
+    passive: false,
+    capture: true
+  });
+  document.addEventListener("pointerup", onUp, true);
+  document.addEventListener("pointercancel", onUp, true);
+  w0[KEY] = () => {
+    document.removeEventListener("pointerdown", onDown, true);
+    document.removeEventListener("pointermove", onMove, true);
+    document.removeEventListener("pointerup", onUp, true);
+    document.removeEventListener("pointercancel", onUp, true);
+  };
+})();

--- a/src/ui/hooks/swipe_sheet.ts
+++ b/src/ui/hooks/swipe_sheet.ts
@@ -1,0 +1,151 @@
+// Bottom-sheet drag-to-dismiss controller (webview only; no DOM => no dioxus-native).
+//
+// Same finger-follow mechanics as the edge drawer (native pointer listeners +
+// rAF + driving CSS `translate` directly, never a per-frame Dioxus round-trip),
+// but vertical and transient: the sheet is unmounted by Rust on dismiss, so
+// there is no persistent open state / data-open handoff. The drag engages only
+// when it starts on the grabber strip (top __GRAB_PX__ px of the sheet), so the
+// menu rows below stay tappable/scrollable. On release past the threshold (or a
+// downward flick) the sheet animates out and Rust unmounts it; otherwise it
+// snaps back.
+//
+// The CALLER renders a sheet (#<sheetId>) pinned to the bottom and a backdrop
+// (#<backdropId>). Config placeholders are filled by the Rust hook
+// (use_sheet_dismiss) before eval. Source of truth: this .ts; `make js` -> .js.
+
+(function () {
+  const CFG = {
+    sheetId: "__SHEET__",
+    backdropId: "__BACKDROP__",
+    grabPx: __GRAB_PX__,
+    dismissAt: __DISMISS_AT__,
+  };
+  const FLICK = 0.5; // px/ms downward velocity that commits a dismiss
+
+  // The sheet remounts on every menu open, so a one-shot window guard would
+  // block re-attach. Instead tear down the previous controller's listeners
+  // before installing fresh ones (no accumulation across opens).
+  const w0 = window as unknown as Record<string, (() => void) | undefined>;
+  const KEY = "__sheet_" + CFG.sheetId;
+  const prev = w0[KEY];
+  if (prev) prev();
+
+  let sheet: HTMLElement | null = null;
+  let backdrop: HTMLElement | null = null;
+  let h = 0;
+  let active = false;
+  let startY = 0;
+  let lastY = 0;
+  let lastT = 0;
+  let vel = 0;
+  let cur = 0;
+  let raf = 0;
+
+  function apply(): void {
+    raf = 0;
+    if (!sheet) return;
+    sheet.style.transition = "none";
+    sheet.style.translate = "0 " + cur + "px";
+    if (backdrop) {
+      const p = Math.max(0, Math.min(1, 1 - cur / h));
+      backdrop.style.transition = "none";
+      backdrop.style.opacity = p.toFixed(3);
+    }
+  }
+  function schedule(): void {
+    if (!raf) raf = requestAnimationFrame(apply);
+  }
+  function dismiss(): void {
+    if (!sheet) return;
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    sheet.style.transition = "translate .22s cubic-bezier(.32,.72,0,1)";
+    sheet.style.translate = "0 " + h + "px";
+    if (backdrop) {
+      backdrop.style.transition = "opacity .22s ease";
+      backdrop.style.opacity = "0";
+    }
+    // Let the slide-out play, then ask Rust to unmount (no flash: the element is
+    // already off-screen when it disappears).
+    setTimeout(() => dioxus.send("closed"), 210);
+  }
+  function snapBack(): void {
+    if (!sheet) return;
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    sheet.style.transition = "translate .22s cubic-bezier(.32,.72,0,1)";
+    sheet.style.translate = "0 0px";
+    if (backdrop) {
+      backdrop.style.transition = "opacity .22s ease";
+      backdrop.style.opacity = "1";
+    }
+    setTimeout(() => {
+      if (!sheet) return;
+      sheet.style.transition = "";
+      sheet.style.translate = "";
+      if (backdrop) {
+        backdrop.style.transition = "";
+        backdrop.style.opacity = "";
+      }
+    }, 240);
+  }
+  function onDown(e: PointerEvent): void {
+    if (e.pointerType === "mouse" || active) return;
+    sheet = document.getElementById(CFG.sheetId);
+    backdrop = document.getElementById(CFG.backdropId);
+    if (!sheet) return;
+    const rect = sheet.getBoundingClientRect();
+    h = rect.height || 300;
+    // Engage only on the grabber strip; below it the menu rows handle their taps.
+    if (e.clientY > rect.top + CFG.grabPx) return;
+    active = true;
+    startY = lastY = e.clientY;
+    lastT = e.timeStamp;
+    vel = 0;
+    cur = 0;
+  }
+  function onMove(e: PointerEvent): void {
+    if (!active || !sheet) return;
+    const dy = e.clientY - startY;
+    if (dy <= 0) {
+      cur = 0;
+      schedule();
+      return;
+    }
+    const dt = e.timeStamp - lastT;
+    if (dt > 0) vel = (e.clientY - lastY) / dt;
+    lastY = e.clientY;
+    lastT = e.timeStamp;
+    cur = Math.min(h, dy);
+    if (e.cancelable) e.preventDefault();
+    schedule();
+  }
+  function onUp(): void {
+    if (!active) return;
+    active = false;
+    const progress = h > 0 ? cur / h : 0;
+    if (vel > FLICK || progress > CFG.dismissAt) {
+      dismiss();
+    } else {
+      snapBack();
+    }
+  }
+
+  document.addEventListener("pointerdown", onDown, true);
+  document.addEventListener("pointermove", onMove, {
+    passive: false,
+    capture: true,
+  });
+  document.addEventListener("pointerup", onUp, true);
+  document.addEventListener("pointercancel", onUp, true);
+  w0[KEY] = () => {
+    document.removeEventListener("pointerdown", onDown, true);
+    document.removeEventListener("pointermove", onMove, true);
+    document.removeEventListener("pointerup", onUp, true);
+    document.removeEventListener("pointercancel", onUp, true);
+  };
+})();

--- a/src/ui/notes/mod.rs
+++ b/src/ui/notes/mod.rs
@@ -5,6 +5,7 @@ mod dates;
 mod detail;
 mod menu;
 mod note_actions;
+pub(crate) mod note_tools_menu;
 mod reminders;
 mod tags;
 

--- a/src/ui/notes/note_tools_menu.rs
+++ b/src/ui/notes/note_tools_menu.rs
@@ -1,0 +1,46 @@
+use crate::ui::chat::ConnectorsSection;
+use crate::ui::hooks::swipe::use_sheet_dismiss;
+use crate::ui::AppState;
+use dioxus::prelude::*;
+
+// The note "+" hub: same shell and connectors as the chat composer, scoped to a
+// note. Bottom-sheet (drag-to-dismiss) on mobile, popover above the "+" on
+// desktop. Connector taps route to Settings > Connections.
+#[component]
+pub fn NoteToolsMenu() -> Element {
+    let mut app: AppState = use_context();
+
+    use_sheet_dismiss(
+        "note-tools-sheet",
+        "note-tools-backdrop",
+        48.0,
+        0.3,
+        move || app.show_note_tools_menu.set(false),
+    );
+
+    let close = move |_| app.show_note_tools_menu.set(false);
+
+    if cfg!(target_os = "ios") {
+        rsx! {
+            div {
+                id: "note-tools-backdrop",
+                class: "fixed inset-0 z-30 bg-black/10 backdrop-fade",
+                onclick: close,
+            }
+            div {
+                id: "note-tools-sheet",
+                class: "fixed bottom-0 left-0 right-0 z-40 bg-warm-white rounded-t-2xl px-2 pt-2 sheet-pop",
+                style: "padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));",
+                div { class: "w-9 h-1 rounded-full bg-stone-300 mx-auto mt-1 mb-3" }
+                ConnectorsSection {}
+            }
+        }
+    } else {
+        rsx! {
+            div { class: "fixed inset-0 z-30", onclick: close }
+            div { class: "absolute bottom-full left-0 mb-2 w-80 z-40 bg-warm-white border border-stone-200 rounded-xl shadow-lg p-2 popover-pop",
+                ConnectorsSection {}
+            }
+        }
+    }
+}

--- a/src/ui/recording/bar.rs
+++ b/src/ui/recording/bar.rs
@@ -23,6 +23,19 @@ pub fn RecordingBar(pending_audio: Signal<Option<(String, f64)>>) -> Element {
             div { class: "lg:max-w-3xl lg:mx-auto",
             if is_idle {
                 div { class: "flex items-center gap-2",
+                    div { class: "relative shrink-0",
+                        button {
+                            class: "w-12 h-12 flex items-center justify-center rounded-full bg-warm-white border border-stone-200 text-stone-600 active:bg-stone-100 transition-colors duration-150",
+                            "aria-label": t(&lang, "chat-tools-tooltip"),
+                            onclick: move |_| {
+                                app.show_note_tools_menu.set(!(app.show_note_tools_menu)())
+                            },
+                            IconPlus { size: 20 }
+                        }
+                        if (app.show_note_tools_menu)() {
+                            crate::ui::notes::note_tools_menu::NoteToolsMenu {}
+                        }
+                    }
                     button {
                         class: "flex-1 flex items-center justify-center gap-2.5 h-12 rounded-full bg-warm-white border border-ios-orange/25 text-ios-orange-dark text-sm font-medium",
                         onclick: move |_| start_recording(recorder, app),

--- a/src/ui/settings/intelligence.rs
+++ b/src/ui/settings/intelligence.rs
@@ -12,9 +12,6 @@ pub fn IntelligenceSettings() -> Element {
         use_signal(|| db().get_setting("openai_api_key").unwrap_or_default());
     let mut exa_key =
         use_signal(|| db().get_setting("exa_api_key").unwrap_or_default());
-    let mut web_search = use_signal(|| {
-        db().get_setting("web_search_enabled").as_deref() == Some("true")
-    });
     let mut max_sources = use_signal(|| {
         db().get_setting("rag_max_sources")
             .and_then(|v| v.parse::<i64>().ok())
@@ -54,37 +51,8 @@ pub fn IntelligenceSettings() -> Element {
                     },
                 }
             }
-            div {
-                div { class: "flex items-center justify-between",
-                    label { class: "text-sm font-medium text-stone-700",
-                        {t(&lang, "settings-web-search-label")}
-                    }
-                    button {
-                        class: if web_search() {
-                            "relative w-11 h-6 rounded-full bg-ios-green transition-colors duration-200"
-                        } else {
-                            "relative w-11 h-6 rounded-full bg-stone-300 transition-colors duration-200"
-                        },
-                        onclick: move |_| {
-                            let next = !web_search();
-                            web_search.set(next);
-                            let _ = db().set_setting(
-                                "web_search_enabled",
-                                if next { "true" } else { "false" },
-                            );
-                        },
-                        span {
-                            class: if web_search() {
-                                "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-5"
-                            } else {
-                                "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-0"
-                            },
-                        }
-                    }
-                }
-                p { class: "text-xs text-stone-400 mt-1",
-                    {t(&lang, "settings-web-search-hint")}
-                }
+            p { class: "text-xs text-stone-400",
+                {t(&lang, "settings-web-search-moved")}
             }
             div {
                 div { class: "flex justify-between items-center mb-1",

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -71,6 +71,7 @@ pub struct AppState {
     pub show_thread_menu: Signal<bool>,
     pub show_tools_menu: Signal<bool>,
     pub show_mention_menu: Signal<bool>,
+    pub show_note_tools_menu: Signal<bool>,
     // Per-chat web-search toggle (mirrors chat_scope: restored on open, persisted
     // per conversation). Default OFF; the composer "+" menu flips it.
     pub chat_web: Signal<bool>,
@@ -116,6 +117,7 @@ impl AppState {
             show_thread_menu: Signal::new(false),
             show_tools_menu: Signal::new(false),
             show_mention_menu: Signal::new(false),
+            show_note_tools_menu: Signal::new(false),
             chat_web: Signal::new(false),
             sidebar_tab: Signal::new(SidebarTab::Notes),
             show_folder_picker: Signal::new(false),

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -69,6 +69,11 @@ pub struct AppState {
     pub attachment_modal: Signal<Option<Attachment>>,
     pub show_chat_menu: Signal<bool>,
     pub show_thread_menu: Signal<bool>,
+    pub show_tools_menu: Signal<bool>,
+    pub show_mention_menu: Signal<bool>,
+    // Per-chat web-search toggle (mirrors chat_scope: restored on open, persisted
+    // per conversation). Default OFF; the composer "+" menu flips it.
+    pub chat_web: Signal<bool>,
     pub sidebar_tab: Signal<SidebarTab>,
     pub show_folder_picker: Signal<bool>,
     pub chat_scope: Signal<Option<ChatScope>>,
@@ -109,6 +114,9 @@ impl AppState {
             attachment_modal: Signal::new(None),
             show_chat_menu: Signal::new(false),
             show_thread_menu: Signal::new(false),
+            show_tools_menu: Signal::new(false),
+            show_mention_menu: Signal::new(false),
+            chat_web: Signal::new(false),
             sidebar_tab: Signal::new(SidebarTab::Notes),
             show_folder_picker: Signal::new(false),
             chat_scope: Signal::new(None),

--- a/tailwind.css
+++ b/tailwind.css
@@ -58,6 +58,22 @@
     transform-origin: top right;
 }
 
+/* Composer "+" menu: bottom-sheet springs up on mobile, popover pops above the
+   button on desktop, backdrop and tooltip fade. */
+.sheet-pop {
+    animation: slideInUp 0.24s cubic-bezier(0.2, 0.9, 0.25, 1.12);
+}
+.popover-pop {
+    animation: popUp 0.16s ease-out;
+    transform-origin: bottom left;
+}
+.backdrop-fade {
+    animation: fadeIn 0.2s ease-out;
+}
+.tooltip-fade {
+    animation: fadeIn 0.15s ease-out;
+}
+
 .fab-btn {
     position: relative;
     width: 96px;
@@ -244,6 +260,24 @@
         to {
             opacity: 1;
             transform: scale(1) translateY(0);
+        }
+    }
+    @keyframes popUp {
+        from {
+            opacity: 0;
+            transform: scale(0.96) translateY(8px);
+        }
+        to {
+            opacity: 1;
+            transform: scale(1) translateY(0);
+        }
+    }
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
         }
     }
     @keyframes fadeInUp {

--- a/tests/chat_web_test.rs
+++ b/tests/chat_web_test.rs
@@ -1,0 +1,40 @@
+use flowflow::infrastructure::persistence::Database;
+use tempfile::tempdir;
+
+#[test]
+fn chat_web_defaults_off_and_round_trips() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("flowflow_test.db"))
+        .expect("open_at");
+
+    let conv = db.create_conversation("web test").unwrap();
+    assert!(
+        !db.chat_web(&conv.id),
+        "a new chat is off the web by default"
+    );
+
+    db.set_chat_web(&conv.id, true).unwrap();
+    assert!(db.chat_web(&conv.id), "toggle on must persist");
+
+    db.set_chat_web(&conv.id, false).unwrap();
+    assert!(!db.chat_web(&conv.id), "toggle off must persist");
+}
+
+#[test]
+fn chat_web_key_is_removed_with_conversation() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("flowflow_test.db"))
+        .expect("open_at");
+
+    let conv = db.create_conversation("web cleanup").unwrap();
+    db.set_chat_web(&conv.id, true).unwrap();
+
+    db.delete_conversation(&conv.id).unwrap();
+
+    assert!(!db.chat_web(&conv.id));
+    assert_eq!(
+        db.get_setting(&format!("chat_web:{}", conv.id)),
+        None,
+        "web flag key must be removed with the conversation"
+    );
+}

--- a/tests/rag_resolve_test.rs
+++ b/tests/rag_resolve_test.rs
@@ -1,0 +1,38 @@
+use flowflow::application::rag::{resolve_allowed_ids, resolve_web_on};
+
+#[test]
+fn web_fires_only_when_chat_asked_and_key_present() {
+    assert!(
+        !resolve_web_on(false, "exa-key"),
+        "off chat never hits the web"
+    );
+    assert!(!resolve_web_on(true, ""), "no key -> no web");
+    assert!(!resolve_web_on(true, "   "), "blank key -> no web");
+    assert!(resolve_web_on(true, "exa-key"), "on + key -> web");
+}
+
+#[test]
+fn mentions_override_scope_else_scope_stands() {
+    let scope = Some(vec!["a".to_string(), "b".to_string()]);
+
+    assert_eq!(
+        resolve_allowed_ids(None, vec![]),
+        None,
+        "global chat = all notes"
+    );
+    assert_eq!(
+        resolve_allowed_ids(scope.clone(), vec![]),
+        scope,
+        "no mention -> scope note set stands"
+    );
+    assert_eq!(
+        resolve_allowed_ids(None, vec!["c".to_string()]),
+        Some(vec!["c".to_string()]),
+        "mention in a global chat narrows to the note"
+    );
+    assert_eq!(
+        resolve_allowed_ids(scope, vec!["c".to_string()]),
+        Some(vec!["c".to_string()]),
+        "mention overrides the chat scope"
+    );
+}

--- a/tests/swipe_test.rs
+++ b/tests/swipe_test.rs
@@ -1,4 +1,4 @@
-use flowflow::ui::hooks::swipe::build_script;
+use flowflow::ui::hooks::swipe::{build_script, build_sheet_script};
 
 const PLACEHOLDERS: [&str; 6] = [
     "__PANEL__",
@@ -45,4 +45,25 @@ fn build_script_supports_right_edge() {
     for ph in PLACEHOLDERS {
         assert!(!s.contains(ph));
     }
+}
+
+const SHEET_PLACEHOLDERS: [&str; 4] =
+    ["__SHEET__", "__BACKDROP__", "__GRAB_PX__", "__DISMISS_AT__"];
+
+#[test]
+fn build_sheet_script_fills_every_placeholder() {
+    let s = build_sheet_script("tools-sheet", "tools-backdrop", 48.0, 0.3);
+    for ph in SHEET_PLACEHOLDERS {
+        assert!(!s.contains(ph), "leftover placeholder {ph}");
+    }
+    assert!(s.contains("\"tools-sheet\""));
+    assert!(s.contains("\"tools-backdrop\""));
+}
+
+#[test]
+fn build_sheet_script_numeric_config_is_not_nan() {
+    let s = build_sheet_script("s", "b", 48.0, 0.3);
+    assert!(!s.contains("NaN"), "numeric placeholder folded to NaN");
+    assert!(s.contains("grabPx: 48"));
+    assert!(s.contains("dismissAt: 0.3"));
 }


### PR DESCRIPTION
## Summary

Everything on `development` since the last merge to `main` (14 commits): the composer tools menu (per-chat web search + connectors hub + `@` mentions), the same hub on notes, a finger-following gesture layer, the sync `peers.rs` SRP split, and a docs refresh.

## Composer tools menu (+ and @)

- Web search moves from a single global Settings toggle to a per-chat control inside a composer **+** menu. The switch is brand-orange, off by default, persisted per conversation (settings-KV `chat_web:{cid}`, mirroring the existing chat scope - no migration).
- Bottom-sheet on iPhone (drag the grabber down to dismiss), popover + hover tooltip on Mac, Esc / backdrop-tap to close.
- **@** opens a mention menu that scopes a message's RAG to a chosen note.
- RAG `query()` now takes the per-chat web flag + mention note ids; a scoped chat answers from its notes unless web is explicitly on; the empty-scope guard no longer dead-ends when web is on.
- Global "Web search" switch removed from Settings (Exa key field kept); with no Exa key the row shows an inline hint instead of a silently-inert toggle.

## Note "+" hub

- The same tools/connectors hub on notes (RecordingBar), reusing a shared `ConnectorsSection` + the sheet/popover shell + drag-to-dismiss.
- Menus trimmed to live items: Google Sheets + web search. Gmail, Google Calendar (we already have a calendar/reminder path), Notion, and Deep search are parked as commented blocks - icons and i18n kept for when they go live.

## Gesture UX

- A small native pointer controller (rAF + CSS translate, committed back to Dioxus on release): edge-swipe sidebar drawer + right-edge swipe to open a folder-scoped chat, extracted into a reusable `use_swipe_drawer` hook; a dedicated `use_sheet_dismiss` for the bottom-sheet.
- 60fps waveform (GPU `scaleY`), desktop FAB, burger tap reliably opens the sidebar.

## Sync SRP split

- `src/infrastructure/sync/peers.rs` decomposed into `peers/` modules (lan, codec, account_join, identity, peer_store, host, join). Behavior-preserving file split - the single deletion in the diff is this move.

## Docs

- README: per-chat web via the + menu, the +/@ composer tools, gesture polish, agent-marketplace groundwork; Stack table updated.
- HISTORY: local Whisper, platform/agents groundwork (RFC 0012/0014), the SRP module-split sprint, gesture UX, composer tools menu.
- INDEX: refreshed specs list + test count.

## Verification

- `make format`, `cargo clippy --features mobile` (0 errors; 4 pre-existing warnings in untouched transcription files).
- Tests green incl. new ones: `chat_web` persistence, web/mention resolution, sheet-script generation.
- Device-validated on iPhone (`make all`): per-chat web on/off + persistence, `@note` scoping, sheet drag-to-dismiss, note + hub, Settings without the global switch.
- 4-lens adversarial review pass; 2 majors + 4 minors fixed.

## Notes

- `AGENTS.md` and `src/infrastructure/sync/protocol/mod.rs` carry unrelated pre-existing local edits and were intentionally left out of these commits.

https://claude.ai/code/session_01FbSG5cgfAgTFoGSFCMXp2B
