### PR TITLE
feat(reminders): one grouped calendar event per slot, not N (closes #85)

### DIFF
--- a/src/application/constants.rs
+++ b/src/application/constants.rs
@@ -181,24 +181,24 @@ pub const REMINDER_EXTRACTION_PROMPT: &str = "\
 You extract timed reminder intents from a personal note. The note may be in French or English.\n\
 \n\
 Return ONLY a JSON object of this exact shape, nothing else:\n\
-{\"intents\": [ {\"action\": \"...\", \"date\": \"YYYY-MM-DD|null\", \"time\": \"HH:mm|null\", \"time_end\": \"HH:mm|null\", \"recurrence\": \"RRULE|null\", \"location\": \"string|null\"} ]}\n\
+{\"intents\": [ {\"action\": \"...\", \"items\": [\"...\"], \"date\": \"YYYY-MM-DD|null\", \"time\": \"HH:mm|null\", \"time_end\": \"HH:mm|null\", \"recurrence\": \"RRULE|null\", \"location\": \"string|null\"} ]}\n\
 \n\
 ## Rules\n\
 1. The current date and time are given below. Resolve every relative date (\"demain\", \"tomorrow\", \"samedi\", \"Saturday\", \"dans 2 jours\", \"in 2 days\", \"le 1er\", \"next Monday\") to an ABSOLUTE date in YYYY-MM-DD.\n\
 2. Emit an intent ONLY when a concrete calendar date can be resolved. Vague phrases with no concrete date (\"bientôt\", \"soon\", \"un de ces jours\", \"someday\", \"plus tard\") must NOT produce an intent.\n\
-3. `action` = a short imperative of what to do, in the note's language, without the date words (\"appeler Paul\", \"call Paul\", \"faire les courses\").\n\
-4. `time` = 24h \"HH:mm\" when an explicit hour is present, else null (the app applies a default hour).\n\
-4b. `time_end` = the END of an explicit time RANGE (\"entre 14h et 16h\", \"de 9h à 10h30\", \"from 2 to 4pm\") as 24h \"HH:mm\", with `time` = the START of that range. Set it ONLY for a true range with two clock times. For a single deadline (\"avant 14h\", \"before 2pm\", \"à 15h\", \"vers midi\") keep `time` = that hour and `time_end` = null.\n\
-5. `recurrence` = an RRULE-like string only for clearly repeated intents, else null. Allowed values: \"DAILY\", \"WEEKLY;BYDAY=MO\" (a single weekday), \"WEEKLY;BYDAY=MO,TU,WE,TH,FR\" (weekdays / jours ouvrés), \"MONTHLY;BYMONTHDAY=1\". For a recurring intent, set `date` to the NEXT occurrence.\n\
-6. `location` = a place only when explicitly mentioned, else null.\n\
-7. If the note has no timed intent at all, return {\"intents\": []}.\n\
-8. A note may hold several intents — return them all.\n\
+3. `action` = a short headline for the appointment, in the note's language, without the date words (\"appeler Paul\", \"réunion budget\", \"rendez-vous notaire\").\n\
+4. `items` = sub-tasks of ONE appointment when the note gives a heading then a list (\"rendez-vous: acheter X, appeler Y\") - `action` = the heading, `items` = [\"acheter X\", \"appeler Y\"]. Otherwise `items: []`; do not invent sub-tasks. (Tasks emitted separately that share one date and time are merged by the app, so you never need to force-group them.)\n\
+5. `time` = 24h \"HH:mm\" when an explicit hour is present, else null (the app applies a default hour).\n\
+5b. `time_end` = the END of an explicit time RANGE (\"entre 14h et 16h\", \"de 9h à 10h30\", \"from 2 to 4pm\") as 24h \"HH:mm\", with `time` = the START of that range. Set it ONLY for a true range with two clock times. For a single deadline (\"avant 14h\", \"before 2pm\", \"à 15h\", \"vers midi\") keep `time` = that hour and `time_end` = null.\n\
+6. `recurrence` = an RRULE-like string only for clearly repeated intents, else null. Allowed values: \"DAILY\", \"WEEKLY;BYDAY=MO\" (a single weekday), \"WEEKLY;BYDAY=MO,TU,WE,TH,FR\" (weekdays / jours ouvrés), \"MONTHLY;BYMONTHDAY=1\". For a recurring intent, set `date` to the NEXT occurrence.\n\
+7. `location` = a place only when explicitly mentioned, else null.\n\
+8. If the note has no timed intent at all, return {\"intents\": []}.\n\
 \n\
 ## Examples (assume current date = 2026-06-01, Monday)\n\
-- \"rappelle-moi d'appeler Paul demain 15h\" -> {\"intents\":[{\"action\":\"appeler Paul\",\"date\":\"2026-06-02\",\"time\":\"15:00\",\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
-- \"faire les courses samedi\" -> {\"intents\":[{\"action\":\"faire les courses\",\"date\":\"2026-06-06\",\"time\":null,\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
-- \"réunion budget demain entre 14h et 16h\" -> {\"intents\":[{\"action\":\"réunion budget\",\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":\"16:00\",\"recurrence\":null,\"location\":null}]}\n\
-- \"call the dentist tomorrow and pay rent on the 1st\" -> {\"intents\":[{\"action\":\"call the dentist\",\"date\":\"2026-06-02\",\"time\":null,\"time_end\":null,\"recurrence\":null,\"location\":null},{\"action\":\"pay rent\",\"date\":\"2026-07-01\",\"time\":null,\"time_end\":null,\"recurrence\":\"MONTHLY;BYMONTHDAY=1\",\"location\":null}]}\n\
-- \"tous les lundis à 9h: standup\" -> {\"intents\":[{\"action\":\"standup\",\"date\":\"2026-06-08\",\"time\":\"09:00\",\"time_end\":null,\"recurrence\":\"WEEKLY;BYDAY=MO\",\"location\":null}]}\n\
+- \"rappelle-moi d'appeler Paul demain 15h\" -> {\"intents\":[{\"action\":\"appeler Paul\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"15:00\",\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
+- \"mardi 14h rendez-vous: acheter du pain, appeler le client, préparer le dossier\" -> {\"intents\":[{\"action\":\"rendez-vous\",\"items\":[\"acheter du pain\",\"appeler le client\",\"préparer le dossier\"],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
+- \"réunion budget demain entre 14h et 16h\" -> {\"intents\":[{\"action\":\"réunion budget\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":\"16:00\",\"recurrence\":null,\"location\":null}]}\n\
+- \"call the dentist tomorrow and pay rent on the 1st\" -> {\"intents\":[{\"action\":\"call the dentist\",\"items\":[],\"date\":\"2026-06-02\",\"time\":null,\"time_end\":null,\"recurrence\":null,\"location\":null},{\"action\":\"pay rent\",\"items\":[],\"date\":\"2026-07-01\",\"time\":null,\"time_end\":null,\"recurrence\":\"MONTHLY;BYMONTHDAY=1\",\"location\":null}]}\n\
+- \"tous les lundis à 9h: standup\" -> {\"intents\":[{\"action\":\"standup\",\"items\":[],\"date\":\"2026-06-08\",\"time\":\"09:00\",\"time_end\":null,\"recurrence\":\"WEEKLY;BYDAY=MO\",\"location\":null}]}\n\
 - \"je verrai ça bientôt\" -> {\"intents\":[]}\n\
 - \"meeting notes about the budget\" -> {\"intents\":[]}";

--- a/src/application/reminders.rs
+++ b/src/application/reminders.rs
@@ -58,6 +58,7 @@ pub async fn schedule(
         };
         let outcome = create_event(EventRequest {
             title: intent.action.clone(),
+            notes: intent.notes_body().unwrap_or_default(),
             year: date.year(),
             month: date.month() as i32,
             day: date.day() as i32,

--- a/src/application/reminders_extract.rs
+++ b/src/application/reminders_extract.rs
@@ -1,4 +1,5 @@
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, Timelike};
+use std::collections::HashMap;
 
 use crate::application::constants::REMINDER_EXTRACTION_PROMPT;
 use crate::application::error::LlmError;
@@ -21,7 +22,54 @@ pub async fn extract_reminders(
     );
     let response = client.chat(&system, &preview).await?;
     let intents = parse_reminder_intents(&response)?;
-    Ok(intents.into_iter().filter(|i| i.has_date()).collect())
+    let dated: Vec<ReminderIntent> =
+        intents.into_iter().filter(|i| i.has_date()).collect();
+    Ok(group_same_slot(dated))
+}
+
+/// A reminder's calendar slot: same date, same start time, same recurrence = same appointment.
+fn slot_key(intent: &ReminderIntent) -> String {
+    let date = intent
+        .resolved_date()
+        .map(|d| d.to_string())
+        .unwrap_or_default();
+    let t = intent.resolved_time();
+    let rec = intent
+        .recurrence
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .to_uppercase();
+    format!("{date}|{:02}:{:02}|{rec}", t.hour(), t.minute())
+}
+
+/// Collapse intents that fall on the SAME slot into one, so a dictation the model still split
+/// task-by-task yields ONE calendar event with the rest in its notes body. The grouping decision
+/// is deterministic here - the extraction prompt only suggests a nicer title, it never has to be
+/// trusted for correctness. The slot's first intent keeps the title; later ones fold into `items`.
+pub fn group_same_slot(intents: Vec<ReminderIntent>) -> Vec<ReminderIntent> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: HashMap<String, ReminderIntent> = HashMap::new();
+    for intent in intents {
+        let key = slot_key(&intent);
+        match groups.get_mut(&key) {
+            Some(base) => {
+                if intent.items.is_empty() {
+                    base.items.push(intent.action);
+                } else {
+                    base.items.extend(intent.items);
+                }
+            }
+            None => {
+                order.push(key.clone());
+                groups.insert(key, intent);
+            }
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|k| groups.remove(&k))
+        .collect()
 }
 
 pub fn parse_reminder_intents(

--- a/src/domain/reminder.rs
+++ b/src/domain/reminder.rs
@@ -6,6 +6,10 @@ pub const DEFAULT_REMINDER_HOUR: u32 = 9;
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct ReminderIntent {
     pub action: String,
+    /// Sub-tasks of ONE appointment that share this intent's date and time. They land in the
+    /// calendar event's notes body; an empty list means a plain single-action reminder.
+    #[serde(default)]
+    pub items: Vec<String>,
     #[serde(default)]
     pub date: Option<String>,
     #[serde(default)]
@@ -54,6 +58,19 @@ impl ReminderIntent {
 
     pub fn has_date(&self) -> bool {
         self.resolved_date().is_some()
+    }
+
+    /// Render the grouped sub-tasks as the calendar event's notes body (one "- item" per line),
+    /// or None when the reminder is a plain single action with no enumeration.
+    pub fn notes_body(&self) -> Option<String> {
+        let lines: Vec<String> = self
+            .items
+            .iter()
+            .map(|i| i.trim())
+            .filter(|i| !i.is_empty())
+            .map(|i| format!("- {i}"))
+            .collect();
+        (!lines.is_empty()).then(|| lines.join("\n"))
     }
 
     pub fn intent_hash(&self) -> String {

--- a/src/infrastructure/platform/ios/reminders.rs
+++ b/src/infrastructure/platform/ios/reminders.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct EventRequest {
     pub title: String,
+    pub notes: String,
     pub year: i32,
     pub month: i32,
     pub day: i32,
@@ -99,6 +100,9 @@ pub async fn create_event(req: EventRequest) -> ReminderOutcome {
 
         let event = EKEvent::eventWithEventStore(&store);
         event.setTitle(Some(&NSString::from_str(&req.title)));
+        if !req.notes.trim().is_empty() {
+            event.setNotes(Some(&NSString::from_str(&req.notes)));
+        }
         event.setCalendar(Some(&calendar));
 
         let alarm_date = if req.all_day {

--- a/src/ui/notes/reminders.rs
+++ b/src/ui/notes/reminders.rs
@@ -247,6 +247,7 @@ pub fn ReminderSuggestions(
                         {
                             let intent = detected[idx].clone();
                             let action = intent.action.clone();
+                            let items = intent.items.clone();
                             let date_val = intent.date.clone().unwrap_or_default();
                             let time_val = intent.time.clone().unwrap_or_default();
                             let end_val = intent.time_end.clone().unwrap_or_default();
@@ -267,6 +268,16 @@ pub fn ReminderSuggestions(
                             rsx! {
                                 div { class: "bg-white/40 rounded-lg p-2.5",
                                     p { class: "text-sm text-stone-800 mb-1.5", "{action}" }
+                                    if !items.is_empty() {
+                                        ul { class: "mb-1.5 ml-1 space-y-0.5",
+                                            for it in items.iter() {
+                                                li { class: "text-xs text-stone-600 flex gap-1.5",
+                                                    span { class: "text-stone-400", "·" }
+                                                    span { "{it}" }
+                                                }
+                                            }
+                                        }
+                                    }
                                     div { class: "flex items-center gap-2 flex-wrap",
                                         input {
                                             r#type: "date",

--- a/tests/reminders_extract.rs
+++ b/tests/reminders_extract.rs
@@ -1,5 +1,7 @@
 use chrono::{NaiveDate, NaiveTime};
-use flowflow::application::reminders_extract::parse_reminder_intents;
+use flowflow::application::reminders_extract::{
+    group_same_slot, parse_reminder_intents,
+};
 use flowflow::domain::DEFAULT_REMINDER_HOUR;
 
 #[test]
@@ -64,4 +66,73 @@ fn no_date_flagged_by_has_date() {
 #[test]
 fn invalid_json_errors() {
     assert!(parse_reminder_intents("not json at all").is_err());
+}
+
+#[test]
+fn groups_sub_items_into_one_intent_with_notes_body() {
+    let raw = r#"{"intents":[{"action":"rendez-vous","items":["acheter X","appeler Y","préparer Z"],"date":"2026-06-02","time":"14:00"}]}"#;
+    let v = parse_reminder_intents(raw).unwrap();
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].items, vec!["acheter X", "appeler Y", "préparer Z"]);
+    assert_eq!(
+        v[0].notes_body().as_deref(),
+        Some("- acheter X\n- appeler Y\n- préparer Z")
+    );
+}
+
+#[test]
+fn single_action_has_no_items_and_no_notes() {
+    let raw = r#"{"intents":[{"action":"appeler Paul","date":"2026-06-02","time":"15:00"}]}"#;
+    let v = parse_reminder_intents(raw).unwrap();
+    assert!(v[0].items.is_empty());
+    assert!(v[0].notes_body().is_none());
+}
+
+#[test]
+fn notes_body_drops_blank_items() {
+    let raw = r#"{"intents":[{"action":"x","items":["a","  ",""],"date":"2026-06-02"}]}"#;
+    let v = parse_reminder_intents(raw).unwrap();
+    assert_eq!(v[0].notes_body().as_deref(), Some("- a"));
+}
+
+#[test]
+fn merges_same_slot_fanout_into_one_event() {
+    let raw = r#"{"intents":[
+        {"action":"acheter X","date":"2026-06-02","time":"14:00"},
+        {"action":"appeler Y","date":"2026-06-02","time":"14:00"},
+        {"action":"préparer Z","date":"2026-06-02","time":"14:00"}
+    ]}"#;
+    let grouped = group_same_slot(parse_reminder_intents(raw).unwrap());
+    assert_eq!(grouped.len(), 1);
+    assert_eq!(grouped[0].action, "acheter X");
+    assert_eq!(grouped[0].items, vec!["appeler Y", "préparer Z"]);
+    assert_eq!(
+        grouped[0].notes_body().as_deref(),
+        Some("- appeler Y\n- préparer Z")
+    );
+}
+
+#[test]
+fn keeps_distinct_slots_separate() {
+    let raw = r#"{"intents":[
+        {"action":"call dentist","date":"2026-06-02","time":null},
+        {"action":"pay rent","date":"2026-07-01","time":null}
+    ]}"#;
+    let grouped = group_same_slot(parse_reminder_intents(raw).unwrap());
+    assert_eq!(grouped.len(), 2);
+}
+
+#[test]
+fn folds_a_model_grouped_intent_and_a_stray_at_the_same_slot() {
+    let raw = r#"{"intents":[
+        {"action":"rendez-vous","items":["acheter X","appeler Y"],"date":"2026-06-02","time":"14:00"},
+        {"action":"préparer Z","date":"2026-06-02","time":"14:00"}
+    ]}"#;
+    let grouped = group_same_slot(parse_reminder_intents(raw).unwrap());
+    assert_eq!(grouped.len(), 1);
+    assert_eq!(grouped[0].action, "rendez-vous");
+    assert_eq!(
+        grouped[0].items,
+        vec!["acheter X", "appeler Y", "préparer Z"]
+    );
 }


### PR DESCRIPTION
Dictating one appointment with several sub-tasks under a single date used to create N
separate calendar events (one per verb). This fixes it by separating extraction from
grouping.

## What changed

- The extractor returns atomic timed intents (its strength: parse dates / times /
  actions). It no longer has to decide grouping via fragile few-shot examples.
- A deterministic same-slot merge (`group_same_slot`, keyed on date + start time +
  recurrence) collapses sub-tasks dictated under one appointment into a single event.
  Correctness is code, not prompt. Distinct slots stay separate.
- New `items[]` field on `ReminderIntent` carries the sub-tasks into the calendar
  event's notes body via `EKEvent.setNotes` (only `setTitle` was wired before).
- The suggestion card shows the grouped sub-items so the grouping is visible before
  confirming.

## Verification

- 13/13 host tests (extraction, same-slot merge, distinct slots kept separate, notes
  body rendering), iOS cross-compile clean (`setNotes` binding), clippy clean.
- Device-validated by Mirko: "mardi 14h rendez-vous: acheter X, appeler Y, préparer Z"
  -> ONE event whose Notes list X / Y / Z. Two distinct date/time appointments in one
  note stay two events, each grouped correctly.

Closes #85.
