### PR TITLE
feat: chat conversational memory + scoped @ mentions, recursive folder scope, drawer upgrades

### DIFF
--- a/src/application/constants.rs
+++ b/src/application/constants.rs
@@ -75,6 +75,9 @@ pub const RAG_DISTANCE_THRESHOLD: f32 = 0.6;
 // 0.25 conservatively drops clearly-unrelated chunks while minimizing false abstains. Tune on
 // device by logging max relevance per query. Set to 0.0 to neutralize the floor (no-op).
 pub const RAG_RELEVANCE_FLOOR: f32 = 0.25;
+// Conversation turns fed to query rewriting and the final agent prompt. Enough to resolve
+// a pronoun or "développe" without dragging the whole conversation into every call.
+pub const CHAT_HISTORY_TURNS: usize = 6;
 pub const RRF_K: f32 = 60.0;
 pub const RRF_LOCAL_WEIGHT: f32 = 1.2;
 pub const RRF_WEB_WEIGHT: f32 = 1.0;
@@ -127,6 +130,20 @@ A passage that merely shares common words but is about a different subject is NO
 List the relevant numbers, most relevant first, separated by commas. If NONE are relevant, return exactly: none\n\
 No explanation, output only the numbers or the word none.\n\
 Example: 3, 1";
+
+pub const QUERY_REWRITE_PROMPT: &str = "\
+You rewrite the user's LAST question into a single standalone search query, using the \
+conversation for context.\n\
+The question may rely on the conversation (pronouns like \"lui\", \"elle\", \"it\", or requests \
+like \"développe\", \"tell me more\"). Resolve every such reference into explicit words: name the \
+person, topic, or thing the question actually refers to.\n\
+If the question is already self-contained, return it unchanged.\n\
+Keep the SAME language as the question. Return ONLY the rewritten query - no quotes, no \
+explanation, one line.\n\
+Examples:\n\
+- Conversation about a note on Jean, question \"et lui ?\" → \"Qui est Jean, que disent mes notes sur Jean ?\"\n\
+- Conversation about React performance, question \"développe\" → \"Détails sur la performance React (mémoïsation, rendu)\"\n\
+- Question \"quelles notes parlent de budget ?\" → \"quelles notes parlent de budget ?\"";
 
 pub const TEMPORAL_DETECT_PROMPT: &str = "\
 Analyze the user's question and extract any temporal intent.\n\
@@ -181,7 +198,7 @@ pub const REMINDER_EXTRACTION_PROMPT: &str = "\
 You extract timed reminder intents from a personal note. The note may be in French or English.\n\
 \n\
 Return ONLY a JSON object of this exact shape, nothing else:\n\
-{\"intents\": [ {\"action\": \"...\", \"items\": [\"...\"], \"date\": \"YYYY-MM-DD|null\", \"time\": \"HH:mm|null\", \"time_end\": \"HH:mm|null\", \"recurrence\": \"RRULE|null\", \"location\": \"string|null\"} ]}\n\
+{\"intents\": [ {\"action\": \"...\", \"items\": [\"...\"], \"date\": \"YYYY-MM-DD|null\", \"time\": \"HH:mm|null\", \"time_end\": \"HH:mm|null\", \"recurrence\": \"RRULE|null\", \"until\": \"YYYY-MM-DD|null\", \"location\": \"string|null\"} ]}\n\
 \n\
 ## Rules\n\
 1. The current date and time are given below. Resolve every relative date (\"demain\", \"tomorrow\", \"samedi\", \"Saturday\", \"dans 2 jours\", \"in 2 days\", \"le 1er\", \"next Monday\") to an ABSOLUTE date in YYYY-MM-DD.\n\
@@ -191,14 +208,16 @@ Return ONLY a JSON object of this exact shape, nothing else:\n\
 5. `time` = 24h \"HH:mm\" when an explicit hour is present, else null (the app applies a default hour).\n\
 5b. `time_end` = the END of an explicit time RANGE (\"entre 14h et 16h\", \"de 9h à 10h30\", \"from 2 to 4pm\") as 24h \"HH:mm\", with `time` = the START of that range. Set it ONLY for a true range with two clock times. For a single deadline (\"avant 14h\", \"before 2pm\", \"à 15h\", \"vers midi\") keep `time` = that hour and `time_end` = null.\n\
 6. `recurrence` = an RRULE-like string only for clearly repeated intents, else null. Allowed values: \"DAILY\", \"WEEKLY;BYDAY=MO\" (a single weekday), \"WEEKLY;BYDAY=MO,TU,WE,TH,FR\" (weekdays / jours ouvrés), \"MONTHLY;BYMONTHDAY=1\". For a recurring intent, set `date` to the NEXT occurrence.\n\
+6b. `until` = the explicit END date of a recurring intent (\"jusqu'au 30 juin\", \"jusqu'à mars 2027\", \"until June 30\", \"pendant 3 mois\" / \"for 3 months\" -> resolve to the end date) as YYYY-MM-DD, else null. Only meaningful together with a recurrence.\n\
 7. `location` = a place only when explicitly mentioned, else null.\n\
 8. If the note has no timed intent at all, return {\"intents\": []}.\n\
 \n\
 ## Examples (assume current date = 2026-06-01, Monday)\n\
-- \"rappelle-moi d'appeler Paul demain 15h\" -> {\"intents\":[{\"action\":\"appeler Paul\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"15:00\",\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
-- \"mardi 14h rendez-vous: acheter du pain, appeler le client, préparer le dossier\" -> {\"intents\":[{\"action\":\"rendez-vous\",\"items\":[\"acheter du pain\",\"appeler le client\",\"préparer le dossier\"],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":null,\"recurrence\":null,\"location\":null}]}\n\
-- \"réunion budget demain entre 14h et 16h\" -> {\"intents\":[{\"action\":\"réunion budget\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":\"16:00\",\"recurrence\":null,\"location\":null}]}\n\
-- \"call the dentist tomorrow and pay rent on the 1st\" -> {\"intents\":[{\"action\":\"call the dentist\",\"items\":[],\"date\":\"2026-06-02\",\"time\":null,\"time_end\":null,\"recurrence\":null,\"location\":null},{\"action\":\"pay rent\",\"items\":[],\"date\":\"2026-07-01\",\"time\":null,\"time_end\":null,\"recurrence\":\"MONTHLY;BYMONTHDAY=1\",\"location\":null}]}\n\
-- \"tous les lundis à 9h: standup\" -> {\"intents\":[{\"action\":\"standup\",\"items\":[],\"date\":\"2026-06-08\",\"time\":\"09:00\",\"time_end\":null,\"recurrence\":\"WEEKLY;BYDAY=MO\",\"location\":null}]}\n\
+- \"rappelle-moi d'appeler Paul demain 15h\" -> {\"intents\":[{\"action\":\"appeler Paul\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"15:00\",\"time_end\":null,\"recurrence\":null,\"until\":null,\"location\":null}]}\n\
+- \"mardi 14h rendez-vous: acheter du pain, appeler le client, préparer le dossier\" -> {\"intents\":[{\"action\":\"rendez-vous\",\"items\":[\"acheter du pain\",\"appeler le client\",\"préparer le dossier\"],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":null,\"recurrence\":null,\"until\":null,\"location\":null}]}\n\
+- \"réunion budget demain entre 14h et 16h\" -> {\"intents\":[{\"action\":\"réunion budget\",\"items\":[],\"date\":\"2026-06-02\",\"time\":\"14:00\",\"time_end\":\"16:00\",\"recurrence\":null,\"until\":null,\"location\":null}]}\n\
+- \"call the dentist tomorrow and pay rent on the 1st\" -> {\"intents\":[{\"action\":\"call the dentist\",\"items\":[],\"date\":\"2026-06-02\",\"time\":null,\"time_end\":null,\"recurrence\":null,\"until\":null,\"location\":null},{\"action\":\"pay rent\",\"items\":[],\"date\":\"2026-07-01\",\"time\":null,\"time_end\":null,\"recurrence\":\"MONTHLY;BYMONTHDAY=1\",\"until\":null,\"location\":null}]}\n\
+- \"tous les lundis à 9h: standup\" -> {\"intents\":[{\"action\":\"standup\",\"items\":[],\"date\":\"2026-06-08\",\"time\":\"09:00\",\"time_end\":null,\"recurrence\":\"WEEKLY;BYDAY=MO\",\"until\":null,\"location\":null}]}\n\
+- \"tous les mercredis à 9h jusqu'au 30 juin: point équipe\" -> {\"intents\":[{\"action\":\"point équipe\",\"items\":[],\"date\":\"2026-06-03\",\"time\":\"09:00\",\"time_end\":null,\"recurrence\":\"WEEKLY;BYDAY=WE\",\"until\":\"2026-06-30\",\"location\":null}]}\n\
 - \"je verrai ça bientôt\" -> {\"intents\":[]}\n\
 - \"meeting notes about the budget\" -> {\"intents\":[]}";

--- a/src/application/i18n/locales/en.ftl
+++ b/src/application/i18n/locales/en.ftl
@@ -194,6 +194,8 @@ sidebar-no-folders = No theme
 sidebar-subfolder-placeholder = Subtheme
 folder-menu-rename = Rename
 folder-menu-subtheme = New subtheme
+folder-menu-move = Move to…
+folder-menu-move-root = Root
 folder-menu-delete = Delete
 
 note-list-search-placeholder = Search my notes...
@@ -248,6 +250,9 @@ chat-tools-mention-hint = Type @ to mention a tool or a note
 chat-tools-tooltip = Add tools and connectors
 chat-mention-section-notes = Notes
 chat-mention-no-notes = No matching note
+chat-mention-recent = Recent
+chat-mention-in-folder = In this folder
+chat-mention-others = Other notes
 
 recording-dictate = Dictate
 

--- a/src/application/i18n/locales/fr.ftl
+++ b/src/application/i18n/locales/fr.ftl
@@ -194,6 +194,8 @@ sidebar-no-folders = Aucun thème
 sidebar-subfolder-placeholder = Sous-thème
 folder-menu-rename = Renommer
 folder-menu-subtheme = Nouveau sous-thème
+folder-menu-move = Déplacer vers…
+folder-menu-move-root = Racine
 folder-menu-delete = Supprimer
 
 note-list-search-placeholder = Chercher mes notes...
@@ -248,6 +250,9 @@ chat-tools-mention-hint = Tapez @ pour mentionner un outil ou une note
 chat-tools-tooltip = Ajouter des outils et connecteurs
 chat-mention-section-notes = Notes
 chat-mention-no-notes = Aucune note correspondante
+chat-mention-recent = Récentes
+chat-mention-in-folder = Dans ce dossier
+chat-mention-others = Autres notes
 
 recording-dictate = Dicter
 

--- a/src/application/mention.rs
+++ b/src/application/mention.rs
@@ -1,0 +1,82 @@
+use crate::application::ai::{char_prefix, plain_preview};
+use crate::domain::Note;
+use std::collections::HashSet;
+
+/// One row of the chat "@" menu, ready to render.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MentionHit {
+    pub note_id: String,
+    /// Title when the note has one, else a content excerpt.
+    pub label: String,
+    pub untitled: bool,
+    /// YYYY-MM-DD, same shape the note cards show.
+    pub date: String,
+}
+
+/// Split of the menu into the chat's scoped notes first, the rest after.
+/// `others` holds everything when the chat has no scope.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MentionResults {
+    pub in_scope: Vec<MentionHit>,
+    pub others: Vec<MentionHit>,
+}
+
+fn matches(note: &Note, q: &str) -> bool {
+    if q.is_empty() {
+        return true;
+    }
+    let title_hit = note
+        .title
+        .as_deref()
+        .is_some_and(|t| t.to_lowercase().contains(q));
+    title_hit
+        || note.tags.iter().any(|t| t.to_lowercase().contains(q))
+        || note.content.to_lowercase().contains(q)
+}
+
+fn to_hit(note: &Note) -> MentionHit {
+    let title = note.title.clone().unwrap_or_default();
+    let untitled = title.is_empty();
+    let label = if untitled {
+        char_prefix(plain_preview(&note.content).trim(), 60)
+    } else {
+        title
+    };
+    MentionHit {
+        note_id: note.id.clone(),
+        label,
+        untitled,
+        date: char_prefix(&note.created_at, 10),
+    }
+}
+
+/// Filter + rank the "@" menu. Notes arrive newest-first (list_notes order) and
+/// stay that way; matching covers title, tags AND content so "the note that talks
+/// about X" is reachable even when X never made it into the title. Untitled notes
+/// show a content excerpt instead of being hidden. Only mentionable rows count
+/// toward `cap`, scoped notes get the slots first.
+pub fn search_mentions(
+    notes: &[Note],
+    query: &str,
+    scoped_ids: Option<&HashSet<String>>,
+    cap: usize,
+) -> MentionResults {
+    let q = query.to_lowercase();
+    let mut res = MentionResults::default();
+    for note in notes {
+        if !matches(note, &q) {
+            continue;
+        }
+        let hit = to_hit(note);
+        if hit.label.is_empty() {
+            continue;
+        }
+        match scoped_ids {
+            Some(ids) if ids.contains(&note.id) => res.in_scope.push(hit),
+            _ => res.others.push(hit),
+        }
+    }
+    res.in_scope.truncate(cap);
+    res.others.truncate(cap - res.in_scope.len());
+    res
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -8,6 +8,7 @@ pub mod embed;
 pub mod error;
 pub mod i18n;
 pub mod intent;
+pub mod mention;
 pub mod note_persistence;
 pub mod rag;
 pub mod reminders;

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -48,6 +48,13 @@ pub fn abstain_decision(
 mod rerank;
 use rerank::llm_relevance_filter;
 
+mod rewrite;
+use rewrite::rewrite_query;
+pub use rewrite::{
+    build_rewrite_input, format_history, recent_turns, sanitize_rewrite,
+    ChatTurn,
+};
+
 /// Keep only the candidates the LLM judged genuinely relevant to the question. The model reads
 /// the question and the note contents, so it understands "the note about Jean" means the note that
 /// discusses Jean - not every note that happens to contain the common word "note". Returns the
@@ -105,6 +112,7 @@ pub async fn query(
     scope: Option<ChatScope>,
     web: bool,
     mention_note_ids: Vec<String>,
+    history: Vec<ChatTurn>,
     lang: &str,
 ) -> Result<RagResponse, String> {
     let ai = Arc::new(LlmClient::from_env()?);
@@ -119,7 +127,7 @@ pub async fn query(
                 .collect()
         }),
         Some(ChatScope::Folder(fid)) => Database::open().ok().map(|db| {
-            db.list_notes_in_folder(&fid)
+            db.list_notes_in_folder_tree(&fid)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|n| n.id)
@@ -145,14 +153,22 @@ pub async fn query(
         });
     }
 
-    let date_range = detect_temporal_regex(question);
+    // Follow-ups lean on the conversation ("et lui ?", "développe"): retrieval runs on a
+    // standalone rewrite of the question, while the final agent still sees the user's words.
+    let retrieval_q = rewrite_query(&ai, &history, question).await;
+    if retrieval_q != question {
+        eprintln!("[rag] rewrite: {retrieval_q}");
+    }
+    let retrieval_q = retrieval_q.as_str();
+
+    let date_range = detect_temporal_regex(retrieval_q);
     let date_range = match date_range {
         Some(r) => {
             eprintln!("[rag] temporal regex: {} to {}", r.from, r.to);
             Some(r)
         }
         None => {
-            let r = detect_temporal_llm(&ai, question).await;
+            let r = detect_temporal_llm(&ai, retrieval_q).await;
             if let Some(ref r) = r {
                 eprintln!("[rag] temporal LLM: {} to {}", r.from, r.to);
             }
@@ -161,7 +177,7 @@ pub async fn query(
     };
 
     let _ = store.ensure_fts_index().await;
-    let query_vector = ai.embed(question).await?;
+    let query_vector = ai.embed(retrieval_q).await?;
     let fetch_k = if date_range.is_some() {
         RAG_INITIAL_K * 3
     } else {
@@ -174,12 +190,12 @@ pub async fn query(
         }
         let (local_res, web_res) = tokio::join!(
             store.hybrid_search(
-                question,
+                retrieval_q,
                 query_vector,
                 fetch_k,
                 allowed_note_ids.as_deref(),
             ),
-            crate::application::web_search::exa_search(question, &exa),
+            crate::application::web_search::exa_search(retrieval_q, &exa),
         );
         if let Some(ref tx) = status_tx {
             let _ = tx.send(ToolEvent::Finished("web_search".into()));
@@ -209,14 +225,14 @@ pub async fn query(
             rrf_merge(local, web_res, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT);
         // Cite only the genuinely relevant rows (notes AND web results), judged by the LLM, not
         // the top-N by rank.
-        let selected = select_relevant(&ai, question, merged).await;
+        let selected = select_relevant(&ai, retrieval_q, merged).await;
         let filtered = dedup_merged(selected);
         let count = read_max_sources().min(RAG_FINAL_K).min(filtered.len());
         filtered.into_iter().take(count).collect()
     } else {
         let candidates = store
             .hybrid_search(
-                question,
+                retrieval_q,
                 query_vector,
                 fetch_k,
                 allowed_note_ids.as_deref(),
@@ -235,7 +251,7 @@ pub async fn query(
         let mut selected = if has_mention {
             candidates
         } else {
-            select_relevant(&ai, question, candidates).await
+            select_relevant(&ai, retrieval_q, candidates).await
         };
         apply_temporal_boost(&mut selected);
         let kept = dedup_sources(selected);
@@ -296,7 +312,16 @@ pub async fn query(
         }
         ctx
     };
-    let user_msg = format!("{context}\n--- Question ---\n{question}");
+    // The agent gets the recent turns verbatim so "développe" stays answerable even
+    // when retrieval adds nothing new; the raw question keeps the user's exact words.
+    let user_msg = if history.is_empty() {
+        format!("{context}\n--- Question ---\n{question}")
+    } else {
+        format!(
+            "{context}\n--- Conversation so far ---\n{}\n\n--- Question ---\n{question}",
+            format_history(recent_turns(&history))
+        )
+    };
 
     let system_prompt = if web_on {
         RAG_AGENT_WEB_SYSTEM_PROMPT

--- a/src/application/rag/rewrite.rs
+++ b/src/application/rag/rewrite.rs
@@ -1,0 +1,82 @@
+use crate::application::ai::char_prefix;
+use crate::application::constants::{
+    CHAT_HISTORY_TURNS, CHEAP_MODEL, QUERY_REWRITE_PROMPT,
+};
+use crate::infrastructure::llm::LlmClient;
+
+/// One prior conversation turn, decoupled from the UI's message model.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChatTurn {
+    pub role: String,
+    pub content: String,
+}
+
+/// Last CHAT_HISTORY_TURNS turns; older turns drop first.
+pub fn recent_turns(history: &[ChatTurn]) -> &[ChatTurn] {
+    let start = history.len().saturating_sub(CHAT_HISTORY_TURNS);
+    &history[start..]
+}
+
+/// Render turns as prompt lines. Each turn is whitespace-collapsed and truncated so the
+/// rewrite call stays cheap no matter how verbose the bot has been.
+pub fn format_history(turns: &[ChatTurn]) -> String {
+    turns
+        .iter()
+        .map(|t| {
+            let who = if t.role == "user" {
+                "User"
+            } else {
+                "Assistant"
+            };
+            let flat =
+                t.content.split_whitespace().collect::<Vec<_>>().join(" ");
+            format!("{}: {}", who, char_prefix(&flat, 500))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// User message for the rewrite call; None when there is no history, so the first
+/// message of a conversation never pays a rewrite round-trip.
+pub fn build_rewrite_input(
+    history: &[ChatTurn],
+    question: &str,
+) -> Option<String> {
+    if history.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "--- Conversation ---\n{}\n--- Last question ---\n{}",
+        format_history(recent_turns(history)),
+        question
+    ))
+}
+
+/// Guard against a degenerate rewrite: empty output falls back to the raw question.
+pub fn sanitize_rewrite(raw: &str, fallback: &str) -> String {
+    let cleaned = raw.trim().trim_matches('"').trim();
+    if cleaned.is_empty() {
+        fallback.to_string()
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// Condense (history + question) into a standalone retrieval query via the cheap model.
+/// Any failure falls back to the raw question - the rewriter must never break the chat.
+pub async fn rewrite_query(
+    ai: &LlmClient,
+    history: &[ChatTurn],
+    question: &str,
+) -> String {
+    let Some(input) = build_rewrite_input(history, question) else {
+        return question.to_string();
+    };
+    match ai
+        .chat_with_model(CHEAP_MODEL, QUERY_REWRITE_PROMPT, &input)
+        .await
+    {
+        Ok(raw) => sanitize_rewrite(&raw, question),
+        Err(_) => question.to_string(),
+    }
+}

--- a/src/domain/folder.rs
+++ b/src/domain/folder.rs
@@ -21,3 +21,52 @@ pub struct UpdateFolder {
     pub description: Option<String>,
     pub parent_id: Option<Option<String>>,
 }
+
+/// Flatten a folder forest into display order: roots then children (each level
+/// sorted by name, case-insensitive), tagged with depth for indentation.
+pub fn flatten_tree(folders: &[Folder]) -> Vec<(Folder, u32)> {
+    fn push_level(
+        folders: &[Folder],
+        parent: Option<&str>,
+        depth: u32,
+        out: &mut Vec<(Folder, u32)>,
+    ) {
+        let mut level: Vec<&Folder> = folders
+            .iter()
+            .filter(|f| f.parent_id.as_deref() == parent)
+            .collect();
+        level.sort_by_key(|f| f.name.to_lowercase());
+        for f in level {
+            out.push((f.clone(), depth));
+            push_level(folders, Some(&f.id), depth + 1, out);
+        }
+    }
+    let mut out = Vec::with_capacity(folders.len());
+    push_level(folders, None, 0, &mut out);
+    // Orphans (parent deleted mid-sync) still need to show up somewhere: append at root level.
+    for f in folders {
+        if !out.iter().any(|(o, _)| o.id == f.id) {
+            out.push((f.clone(), 0));
+        }
+    }
+    out
+}
+
+/// Ids of `folder_id` and every folder below it. Used to forbid moving a folder
+/// into itself or one of its descendants (would detach the subtree into a cycle).
+pub fn subtree_ids(folders: &[Folder], folder_id: &str) -> Vec<String> {
+    let mut out = vec![folder_id.to_string()];
+    let mut i = 0;
+    while i < out.len() {
+        let current = out[i].clone();
+        for f in folders {
+            if f.parent_id.as_deref() == Some(current.as_str())
+                && !out.contains(&f.id)
+            {
+                out.push(f.id.clone());
+            }
+        }
+        i += 1;
+    }
+    out
+}

--- a/src/infrastructure/persistence/note_repo.rs
+++ b/src/infrastructure/persistence/note_repo.rs
@@ -177,6 +177,57 @@ impl Database {
         Ok(notes)
     }
 
+    /// Notes of the folder AND its whole subtree. Chat scope must match the
+    /// hierarchy the sidebar shows: scoping "Travail" includes "Travail/Clients".
+    pub fn list_notes_in_folder_tree(
+        &self,
+        folder_id: &str,
+    ) -> Result<Vec<Note>, String> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "WITH RECURSIVE tree(id) AS (
+                     SELECT ?1
+                     UNION ALL
+                     SELECT f.id FROM folders f JOIN tree ON f.parent_id = tree.id
+                 )
+                 SELECT DISTINCT n.* FROM notes n
+                 JOIN notes_folders nf ON nf.note_id = n.id
+                 WHERE nf.folder_id IN (SELECT id FROM tree)
+                 ORDER BY n.created_at DESC",
+            )
+            .map_err(|e| format!("Prepare: {e}"))?;
+        let rows = stmt
+            .query_map([folder_id], row_to_note)
+            .map_err(|e| format!("Query: {e}"))?;
+        let mut notes = Vec::new();
+        for row in rows {
+            notes.push(row.map_err(|e| format!("Row: {e}"))?);
+        }
+        Ok(notes)
+    }
+
+    /// Distinct note count over the folder's subtree, for the sidebar badges.
+    pub fn count_notes_in_folder_tree(
+        &self,
+        folder_id: &str,
+    ) -> Result<usize, String> {
+        let conn = self.conn();
+        conn.query_row(
+            "WITH RECURSIVE tree(id) AS (
+                 SELECT ?1
+                 UNION ALL
+                 SELECT f.id FROM folders f JOIN tree ON f.parent_id = tree.id
+             )
+             SELECT COUNT(DISTINCT nf.note_id) FROM notes_folders nf
+             WHERE nf.folder_id IN (SELECT id FROM tree)",
+            [folder_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n as usize)
+        .map_err(|e| format!("Count folder tree: {e}"))
+    }
+
     pub fn list_root_notes_in_folder(
         &self,
         folder_id: &str,

--- a/src/ui/chat/actions.rs
+++ b/src/ui/chat/actions.rs
@@ -176,6 +176,28 @@ pub fn send_question(
     mention_ids: Vec<String>,
     lang: String,
 ) {
+    // Snapshot the recent turns BEFORE pushing the new question: this is the conversation
+    // context rag::query rewrites follow-ups against ("et lui ?" -> the referent's name).
+    let history: Vec<rag::ChatTurn> = {
+        let msgs = messages.read();
+        let skip = msgs
+            .len()
+            .saturating_sub(crate::application::constants::CHAT_HISTORY_TURNS);
+        msgs.iter()
+            .skip(skip)
+            .map(|m| match m {
+                ChatMsg::User(t) => rag::ChatTurn {
+                    role: "user".into(),
+                    content: t.clone(),
+                },
+                ChatMsg::Bot { text, .. } => rag::ChatTurn {
+                    role: "bot".into(),
+                    content: text.clone(),
+                },
+            })
+            .collect()
+    };
+
     messages.write().push(ChatMsg::User(question.clone()));
     loading.set(true);
     tool_status.set(None);
@@ -221,6 +243,7 @@ pub fn send_question(
                 scope,
                 web,
                 mention_ids,
+                history,
                 &lang_for_query,
             )
             .await

--- a/src/ui/chat/mention_menu.rs
+++ b/src/ui/chat/mention_menu.rs
@@ -1,10 +1,15 @@
 use crate::application::i18n::t;
+use crate::application::mention::{search_mentions, MentionHit};
+use crate::domain::ChatScope;
 use crate::infrastructure::persistence::Database;
 use crate::ui::chat::tools_menu::{LEAD_ICON, ROW, ROW_TITLE, SECTION, SEP};
 use crate::ui::icons::*;
 use crate::ui::AppState;
 use dioxus::prelude::*;
+use std::collections::HashSet;
 use std::sync::Arc;
+
+const MENTION_CAP: usize = 8;
 
 #[derive(Clone, PartialEq)]
 pub struct MentionedNote {
@@ -21,6 +26,29 @@ fn replace_trailing_at(s: &str, replacement: &str) -> String {
     }
 }
 
+fn scoped_note_ids(
+    db: &Database,
+    scope: &Option<ChatScope>,
+) -> Option<HashSet<String>> {
+    match scope {
+        Some(ChatScope::Folder(fid)) => Some(
+            db.list_notes_in_folder_tree(fid)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|n| n.id)
+                .collect(),
+        ),
+        Some(ChatScope::Thread(tid)) => Some(
+            db.list_thread_notes(tid)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|n| n.id)
+                .collect(),
+        ),
+        None => None,
+    }
+}
+
 #[component]
 pub fn MentionMenu(
     input: Signal<String>,
@@ -31,25 +59,43 @@ pub fn MentionMenu(
     let db: Signal<Arc<Database>> = use_context();
     let lang = (app.current_lang)();
 
-    let q = query.to_lowercase();
-    let notes: Vec<(String, String)> = db()
-        .list_notes()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|n| {
-            let title = n.title.unwrap_or_default();
-            if title.is_empty() {
-                None
-            } else {
-                Some((n.id, title))
-            }
-        })
-        .filter(|(_, title)| q.is_empty() || title.to_lowercase().contains(&q))
-        .take(8)
-        .collect();
+    let scope = (app.chat_scope)();
+    let (results, folder_of): (
+        crate::application::mention::MentionResults,
+        std::collections::HashMap<String, String>,
+    ) = {
+        let db = db();
+        let notes = db.list_notes().unwrap_or_default();
+        let scoped = scoped_note_ids(&db, &scope);
+        let results =
+            search_mentions(&notes, &query, scoped.as_ref(), MENTION_CAP);
+        // Folder subtitle only for the handful of rows actually shown.
+        let folder_of = results
+            .in_scope
+            .iter()
+            .chain(results.others.iter())
+            .filter_map(|h| {
+                db.folders_for_note(&h.note_id)
+                    .ok()
+                    .and_then(|fs| fs.into_iter().next())
+                    .map(|f| (h.note_id.clone(), f.name))
+            })
+            .collect();
+        (results, folder_of)
+    };
+
+    let scoped_chat = scope.is_some();
+    let others_label = if scoped_chat {
+        t(&lang, "chat-mention-others")
+    } else if query.is_empty() {
+        t(&lang, "chat-mention-recent")
+    } else {
+        t(&lang, "chat-mention-section-notes")
+    };
+    let empty = results.in_scope.is_empty() && results.others.is_empty();
 
     rsx! {
-        div { class: "absolute bottom-full left-2 right-2 lg:left-0 lg:right-auto lg:w-72 mb-2 z-40 max-h-64 overflow-y-auto bg-warm-white border border-stone-200 rounded-xl shadow-lg p-2 popover-pop",
+        div { class: "absolute bottom-full left-2 right-2 lg:left-0 lg:right-auto lg:w-80 mb-2 z-40 max-h-72 overflow-y-auto bg-warm-white border border-stone-200 rounded-xl shadow-lg p-2 popover-pop",
             div { class: SECTION, {t(&lang, "chat-tools-section-tools")} }
             button {
                 class: ROW,
@@ -61,45 +107,78 @@ pub fn MentionMenu(
                 span { class: LEAD_ICON, IconGlobeSimple { size: 22 } }
                 span { class: ROW_TITLE, {t(&lang, "chat-tools-web")} }
             }
-            // Parked until implemented (icon + i18n kept): deep search.
-            /*
-            div { class: "w-full flex items-center gap-3 px-3 min-h-[48px] rounded-lg opacity-50",
-                span { class: LEAD_ICON, IconMagnifyingGlass { size: 22 } }
-                span { class: ROW_TITLE, {t(&lang, "chat-tools-deep")} }
-            }
-            */
             div { class: SEP }
-            div { class: SECTION, {t(&lang, "chat-mention-section-notes")} }
-            if notes.is_empty() {
+            if empty {
+                div { class: SECTION, {others_label.clone()} }
                 div { class: "px-3 py-2 text-sm text-stone-400",
                     {t(&lang, "chat-mention-no-notes")}
                 }
-            } else {
-                for (id, title) in notes {
-                    button {
-                        key: "{id}",
-                        class: ROW,
-                        onclick: {
-                            let id = id.clone();
-                            let title = title.clone();
-                            move |_| {
-                                let token = format!("@{title} ");
-                                input.set(replace_trailing_at(&input(), &token));
-                                let mut next = mentions();
-                                if !next.iter().any(|m| m.note_id == id) {
-                                    next.push(MentionedNote {
-                                        note_id: id.clone(),
-                                        title: title.clone(),
-                                    });
-                                }
-                                mentions.set(next);
-                                app.show_mention_menu.set(false);
-                            }
-                        },
-                        span { class: LEAD_ICON, IconNotebook { size: 22 } }
-                        span { class: "flex-1 min-w-0 truncate {ROW_TITLE}", "{title}" }
+            }
+            if !results.in_scope.is_empty() {
+                div { class: SECTION, {t(&lang, "chat-mention-in-folder")} }
+                for hit in results.in_scope.clone() {
+                    MentionRow {
+                        hit: hit.clone(),
+                        folder: folder_of.get(&hit.note_id).cloned(),
+                        input: input,
+                        mentions: mentions,
                     }
                 }
+            }
+            if !results.others.is_empty() {
+                div { class: SECTION, {others_label} }
+                for hit in results.others.clone() {
+                    MentionRow {
+                        hit: hit.clone(),
+                        folder: folder_of.get(&hit.note_id).cloned(),
+                        input: input,
+                        mentions: mentions,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn MentionRow(
+    hit: MentionHit,
+    folder: Option<String>,
+    input: Signal<String>,
+    mentions: Signal<Vec<MentionedNote>>,
+) -> Element {
+    let mut app: AppState = use_context();
+    let subtitle = match &folder {
+        Some(name) => format!("{name} · {}", hit.date),
+        None => hit.date.clone(),
+    };
+    let id = hit.note_id.clone();
+    let label = hit.label.clone();
+    rsx! {
+        button {
+            key: "{hit.note_id}",
+            class: ROW,
+            onclick: move |_| {
+                let token = format!("@{label} ");
+                input.set(replace_trailing_at(&input(), &token));
+                let mut next = mentions();
+                if !next.iter().any(|m| m.note_id == id) {
+                    next.push(MentionedNote {
+                        note_id: id.clone(),
+                        title: label.clone(),
+                    });
+                }
+                mentions.set(next);
+                app.show_mention_menu.set(false);
+            },
+            span { class: LEAD_ICON, IconNotebook { size: 22 } }
+            div { class: "flex-1 min-w-0 text-left",
+                div {
+                    class: "truncate {ROW_TITLE}",
+                    class: if hit.untitled { "italic text-stone-500" },
+                    "{hit.label}"
+                }
+                div { class: "truncate text-xs text-stone-400", "{subtitle}" }
             }
         }
     }

--- a/src/ui/notes/folder_picker.rs
+++ b/src/ui/notes/folder_picker.rs
@@ -1,5 +1,5 @@
 use crate::application::i18n::t;
-use crate::domain::{ChatScope, Folder};
+use crate::domain::{flatten_tree, ChatScope, Folder};
 use crate::infrastructure::persistence::Database;
 use crate::ui::AppState;
 use dioxus::prelude::*;
@@ -32,9 +32,11 @@ pub fn FolderPicker(
     let mut picked: Signal<Option<Option<String>>> = use_signal(|| None);
     let mut closing = use_signal(|| false);
 
-    let all_folders: Memo<Vec<Folder>> = use_memo(move || {
+    // Hierarchical order with depth: subfolders render indented under their
+    // parent instead of mixed alphabetically with the roots.
+    let all_folders: Memo<Vec<(Folder, u32)>> = use_memo(move || {
         let _v = (app.folders_version)();
-        db().list_all_folders().unwrap_or_default()
+        flatten_tree(&db().list_all_folders().unwrap_or_default())
     });
     let lang = (app.current_lang)();
 
@@ -101,7 +103,7 @@ pub fn FolderPicker(
             None
         } else {
             match all_folders.peek().get(i - 1) {
-                Some(f) => Some(f.id.clone()),
+                Some((f, _)) => Some(f.id.clone()),
                 None => return,
             }
         };
@@ -135,12 +137,13 @@ pub fn FolderPicker(
                     }
                 }
             }
-            for (idx, folder) in all_folders().into_iter().enumerate() {
+            for (idx, (folder, depth)) in all_folders().into_iter().enumerate() {
                 {
                     let fid = folder.id.clone();
                     let fname = folder.name.clone();
                     let is_current = selected() == Some(fid.clone());
                     let is_picked = picked() == Some(Some(fid.clone()));
+                    let indent = format!("padding-left: {}px", 12 + depth * 16);
                     rsx! {
                         button {
                             class: "w-full text-left px-3 py-2.5 text-sm transition-colors duration-150",
@@ -151,6 +154,7 @@ pub fn FolderPicker(
                             } else {
                                 "text-stone-900 active:bg-stone-50 hover:bg-stone-50"
                             },
+                            style: "{indent}",
                             onclick: move |_| choose(Some(fid.clone())),
                             "{fname}"
                         }

--- a/src/ui/sidebar/folders.rs
+++ b/src/ui/sidebar/folders.rs
@@ -1,5 +1,7 @@
 use crate::application::i18n::t;
-use crate::domain::{Folder, NewFolder, UpdateFolder};
+use crate::domain::{
+    flatten_tree, subtree_ids, Folder, NewFolder, UpdateFolder,
+};
 use crate::infrastructure::persistence::Database;
 use crate::ui::icons::*;
 use crate::ui::kit;
@@ -112,13 +114,13 @@ pub fn FolderSection() -> Element {
 fn FolderItem(folder: Folder, depth: u32) -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
-    let mut expanded = use_signal(|| false);
     let mut creating_sub = use_signal(|| false);
     let mut sub_name = use_signal(String::new);
     let mut editing = use_signal(|| false);
     let mut edit_name = use_signal(|| folder.name.clone());
     let mut confirm_delete = use_signal(|| false);
     let mut show_actions = use_signal(|| false);
+    let mut moving = use_signal(|| false);
     let lang = (app.current_lang)();
 
     let folder_id = folder.id.clone();
@@ -127,12 +129,45 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
     let folder_id_for_sub2 = folder.id.clone();
     let folder_id_for_rename = folder.id.clone();
     let folder_id_for_rename2 = folder.id.clone();
+    let folder_id_for_toggle = folder.id.clone();
+    let folder_id_for_count = folder.id.clone();
+    let folder_id_for_move = folder.id.clone();
+    let folder_id_move_root = folder.id.clone();
+    let folder_id_move_self = folder.id.clone();
 
     let children = use_memo(move || {
         let _v = (app.folders_version)();
         db().list_subfolders(&folder_id).unwrap_or_default()
     });
     let has_children = !children().is_empty();
+
+    // Expansion lives in AppState so the tree survives drawer close/reopen.
+    let is_expanded = (app.expanded_folders)().contains(&folder.id);
+    let mut toggle_expanded = move || {
+        let mut set = (app.expanded_folders)();
+        if !set.remove(&folder_id_for_toggle) {
+            set.insert(folder_id_for_toggle.clone());
+        }
+        app.expanded_folders.set(set);
+    };
+
+    let note_count = use_memo(move || {
+        let _f = (app.folders_version)();
+        let _n = (app.notes_version)();
+        db().count_notes_in_folder_tree(&folder_id_for_count)
+            .unwrap_or(0)
+    });
+
+    // Move targets: every folder except this one and its own subtree (cycle guard).
+    let move_targets = use_memo(move || {
+        let _v = (app.folders_version)();
+        let all = db().list_all_folders().unwrap_or_default();
+        let forbidden = subtree_ids(&all, &folder_id_for_move);
+        flatten_tree(&all)
+            .into_iter()
+            .filter(|(f, _)| !forbidden.contains(&f.id))
+            .collect::<Vec<(Folder, u32)>>()
+    });
 
     let folder_id_nav = folder.id.clone();
     let is_selected =
@@ -200,10 +235,10 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                     if has_children {
                         button {
                             class: "min-w-[32px] min-h-[44px] flex items-center justify-center hover:opacity-70 transition-opacity duration-150",
-                            onclick: move |_| expanded.set(!expanded()),
+                            onclick: move |_| toggle_expanded(),
                             div {
                                 class: "w-1.5 h-1.5 border-r-2 border-b-2 border-stone-400 chevron-pivot",
-                                class: if expanded() { "rotate-45" } else { "-rotate-45" },
+                                class: if is_expanded { "rotate-45" } else { "-rotate-45" },
                             }
                         }
                     } else {
@@ -218,7 +253,10 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                             crate::ui::sidebar::navigate_with_slide(app, View::NotesList);
                         },
                         IconFolder { size: 16 }
-                        "{folder.name}"
+                        span { class: "flex-1 min-w-0 truncate", "{folder.name}" }
+                        if note_count() > 0 {
+                            span { class: "shrink-0 text-xs text-stone-400", "{note_count}" }
+                        }
                     }
                     button {
                         class: "w-11 h-11 flex items-center justify-center text-stone-400 hover:text-stone-600 transition-all duration-150",
@@ -236,10 +274,57 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                             onclick: move |_| {
                                 show_actions.set(false);
                                 confirm_delete.set(false);
+                                moving.set(false);
                             },
                         }
-                        div { class: "absolute right-2 top-full {kit::MENU_PANEL}",
-                            if confirm_delete() {
+                        div { class: "absolute right-2 top-full max-h-64 overflow-y-auto {kit::MENU_PANEL}",
+                            if moving() {
+                                if folder.parent_id.is_some() {
+                                    button {
+                                        class: kit::MENU_ITEM,
+                                        onclick: move |_| {
+                                            let upd = UpdateFolder {
+                                                name: None,
+                                                description: None,
+                                                parent_id: Some(None),
+                                            };
+                                            let _ = db().update_folder(&folder_id_move_root, &upd);
+                                            moving.set(false);
+                                            show_actions.set(false);
+                                            app.folders_version.set((app.folders_version)() + 1);
+                                        },
+                                        IconFolder { size: 16 }
+                                        {t(&lang, "folder-menu-move-root")}
+                                    }
+                                }
+                                for (target, target_depth) in move_targets() {
+                                    {
+                                        let tid = target.id.clone();
+                                        let fid = folder_id_move_self.clone();
+                                        let indent = format!("padding-left: {}px", 12 + target_depth * 14);
+                                        rsx! {
+                                            button {
+                                                key: "{target.id}",
+                                                class: kit::MENU_ITEM,
+                                                style: "{indent}",
+                                                onclick: move |_| {
+                                                    let upd = UpdateFolder {
+                                                        name: None,
+                                                        description: None,
+                                                        parent_id: Some(Some(tid.clone())),
+                                                    };
+                                                    let _ = db().update_folder(&fid, &upd);
+                                                    moving.set(false);
+                                                    show_actions.set(false);
+                                                    app.folders_version.set((app.folders_version)() + 1);
+                                                },
+                                                IconFolder { size: 16 }
+                                                span { class: "truncate", "{target.name}" }
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if confirm_delete() {
                                 div { class: "px-3 py-2.5",
                                     p { class: "text-sm font-semibold text-stone-900 mb-0.5",
                                         {t(&lang, "folder-menu-delete-title")}
@@ -290,6 +375,12 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                                     IconFolderPlus { size: 16 }
                                     {t(&lang, "folder-menu-subtheme")}
                                 }
+                                button {
+                                    class: kit::MENU_ITEM,
+                                    onclick: move |_| moving.set(true),
+                                    IconArrowUpRight { size: 16 }
+                                    {t(&lang, "folder-menu-move")}
+                                }
                                 div { class: kit::MENU_SEP }
                                 button {
                                     class: kit::MENU_ITEM_DANGER,
@@ -326,7 +417,9 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                                 let _ = db().create_folder(&folder);
                                 sub_name.set(String::new());
                                 creating_sub.set(false);
-                                expanded.set(true);
+                                let mut set = (app.expanded_folders)();
+                                set.insert(folder_id_for_sub.clone());
+                                app.expanded_folders.set(set);
                                 app.folders_version.set((app.folders_version)() + 1);
                             }
                         },
@@ -348,7 +441,9 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                                 let _ = db().create_folder(&folder);
                                 sub_name.set(String::new());
                                 creating_sub.set(false);
-                                expanded.set(true);
+                                let mut set = (app.expanded_folders)();
+                                set.insert(folder_id_for_sub2.clone());
+                                app.expanded_folders.set(set);
                                 app.folders_version.set((app.folders_version)() + 1);
                             }
                         },
@@ -356,11 +451,9 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                     }
                 }
             }
-            if expanded() || has_children {
-                if expanded() {
-                    for child in children() {
-                        FolderItem { folder: child, depth: depth + 1 }
-                    }
+            if is_expanded {
+                for child in children() {
+                    FolderItem { folder: child, depth: depth + 1 }
                 }
             }
         }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -3,7 +3,7 @@ use crate::domain::Attachment;
 use crate::domain::ChatScope;
 use crate::infrastructure::audio::RecordingState;
 use dioxus::prelude::*;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SidebarTab {
@@ -58,6 +58,9 @@ pub struct AppState {
     pub selected_folder_id: Signal<Option<String>>,
     pub recording_state: Signal<RecordingState>,
     pub folders_version: Signal<u32>,
+    // Folders left expanded in the sidebar; app-global so the tree does not
+    // collapse every time the drawer is reopened.
+    pub expanded_folders: Signal<HashSet<String>>,
     pub sliding_out: Signal<bool>,
     pub audio_levels: Signal<Vec<f32>>,
     pub notes_version: Signal<u32>,
@@ -104,6 +107,7 @@ impl AppState {
             selected_folder_id: Signal::new(None),
             recording_state: Signal::new(RecordingState::Idle),
             folders_version: Signal::new(0),
+            expanded_folders: Signal::new(HashSet::new()),
             sliding_out: Signal::new(false),
             audio_levels: Signal::new(vec![0.0; 12]),
             notes_version: Signal::new(0),

--- a/tests/folder_tree_test.rs
+++ b/tests/folder_tree_test.rs
@@ -1,0 +1,148 @@
+// Pure tree helpers (flatten for indented pickers, subtree ids for the move-folder
+// cycle guard) + the recursive folder-scope queries against a real SQLite file.
+
+use flowflow::domain::{
+    flatten_tree, subtree_ids, Folder, NewFolder, NewTextNote,
+};
+use flowflow::infrastructure::persistence::Database;
+use tempfile::tempdir;
+
+fn folder(id: &str, name: &str, parent: Option<&str>) -> Folder {
+    Folder {
+        id: id.into(),
+        name: name.into(),
+        description: None,
+        parent_id: parent.map(String::from),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        modified_at: "2026-01-01T00:00:00Z".into(),
+    }
+}
+
+#[test]
+fn flatten_orders_roots_then_children_with_depth() {
+    let folders = vec![
+        folder("b", "Bravo", None),
+        folder("a", "alpha", None),
+        folder("b1", "Sub", Some("b")),
+        folder("b1a", "Deep", Some("b1")),
+    ];
+    let flat = flatten_tree(&folders);
+    let names: Vec<(String, u32)> =
+        flat.into_iter().map(|(f, d)| (f.name, d)).collect();
+    assert_eq!(
+        names,
+        vec![
+            ("alpha".to_string(), 0),
+            ("Bravo".to_string(), 0),
+            ("Sub".to_string(), 1),
+            ("Deep".to_string(), 2),
+        ]
+    );
+}
+
+#[test]
+fn flatten_appends_orphans_at_root() {
+    let folders =
+        vec![folder("a", "A", None), folder("lost", "Lost", Some("gone"))];
+    let flat = flatten_tree(&folders);
+    assert_eq!(flat.len(), 2);
+    assert!(flat.iter().any(|(f, d)| f.id == "lost" && *d == 0));
+}
+
+#[test]
+fn subtree_ids_covers_self_and_descendants_only() {
+    let folders = vec![
+        folder("a", "A", None),
+        folder("b", "B", Some("a")),
+        folder("c", "C", Some("b")),
+        folder("x", "X", None),
+    ];
+    let mut ids = subtree_ids(&folders, "a");
+    ids.sort();
+    assert_eq!(ids, vec!["a", "b", "c"]);
+    assert_eq!(subtree_ids(&folders, "x"), vec!["x"]);
+}
+
+#[test]
+fn folder_tree_queries_include_subfolders() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("test.db")).expect("open");
+
+    let parent = db
+        .create_folder(&NewFolder {
+            name: "Travail".into(),
+            description: None,
+            parent_id: None,
+        })
+        .unwrap();
+    let child = db
+        .create_folder(&NewFolder {
+            name: "Clients".into(),
+            description: None,
+            parent_id: Some(parent.id.clone()),
+        })
+        .unwrap();
+
+    let in_parent = db
+        .create_text_note(&NewTextNote {
+            title: Some("racine".into()),
+            content: "note racine".into(),
+            tags: vec![],
+        })
+        .unwrap();
+    let in_child = db
+        .create_text_note(&NewTextNote {
+            title: Some("feuille".into()),
+            content: "note feuille".into(),
+            tags: vec![],
+        })
+        .unwrap();
+    db.add_note_to_folder(&in_parent.id, &parent.id).unwrap();
+    db.add_note_to_folder(&in_child.id, &child.id).unwrap();
+
+    let direct = db.list_notes_in_folder(&parent.id).unwrap();
+    assert_eq!(direct.len(), 1);
+
+    let tree = db.list_notes_in_folder_tree(&parent.id).unwrap();
+    let mut ids: Vec<String> = tree.into_iter().map(|n| n.id).collect();
+    ids.sort();
+    let mut expected = vec![in_parent.id.clone(), in_child.id.clone()];
+    expected.sort();
+    assert_eq!(ids, expected);
+
+    assert_eq!(db.count_notes_in_folder_tree(&parent.id).unwrap(), 2);
+    assert_eq!(db.count_notes_in_folder_tree(&child.id).unwrap(), 1);
+}
+
+#[test]
+fn folder_tree_count_deduplicates_note_in_two_folders_of_same_tree() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("test.db")).expect("open");
+
+    let parent = db
+        .create_folder(&NewFolder {
+            name: "P".into(),
+            description: None,
+            parent_id: None,
+        })
+        .unwrap();
+    let child = db
+        .create_folder(&NewFolder {
+            name: "C".into(),
+            description: None,
+            parent_id: Some(parent.id.clone()),
+        })
+        .unwrap();
+    let note = db
+        .create_text_note(&NewTextNote {
+            title: Some("double".into()),
+            content: "n".into(),
+            tags: vec![],
+        })
+        .unwrap();
+    db.add_note_to_folder(&note.id, &parent.id).unwrap();
+    db.add_note_to_folder(&note.id, &child.id).unwrap();
+
+    assert_eq!(db.count_notes_in_folder_tree(&parent.id).unwrap(), 1);
+    assert_eq!(db.list_notes_in_folder_tree(&parent.id).unwrap().len(), 1);
+}

--- a/tests/mention_search_test.rs
+++ b/tests/mention_search_test.rs
@@ -1,0 +1,95 @@
+// Pure tests for the chat "@" menu search: matching over title/tags/content,
+// scoped-first partition, untitled excerpt labels, cap.
+
+use flowflow::application::mention::search_mentions;
+use flowflow::domain::{Note, NoteType};
+use std::collections::HashSet;
+
+fn note(id: &str, title: Option<&str>, content: &str, tags: &[&str]) -> Note {
+    Note {
+        id: id.into(),
+        note_type: NoteType::Text,
+        title: title.map(String::from),
+        content: content.into(),
+        tags: tags.iter().map(|t| t.to_string()).collect(),
+        sources_json: None,
+        thread_id: None,
+        created_at: format!("2026-06-0{}T10:00:00Z", id.len().min(9)),
+        modified_at: "2026-06-01T10:00:00Z".into(),
+    }
+}
+
+#[test]
+fn empty_query_returns_notes_in_incoming_order_capped() {
+    let notes: Vec<Note> = (0..12)
+        .map(|i| note(&format!("n{i}"), Some(&format!("Titre {i}")), "x", &[]))
+        .collect();
+    let res = search_mentions(&notes, "", None, 8);
+    assert!(res.in_scope.is_empty());
+    assert_eq!(res.others.len(), 8);
+    assert_eq!(res.others[0].note_id, "n0");
+}
+
+#[test]
+fn matches_title_tags_and_content() {
+    let notes = vec![
+        note("a", Some("Réunion budget"), "rien", &[]),
+        note("b", Some("Divers"), "on a parlé du budget avec Jean", &[]),
+        note("c", Some("Courses"), "lait", &["budget"]),
+        note("d", Some("Vacances"), "plage", &["été"]),
+    ];
+    let res = search_mentions(&notes, "budget", None, 8);
+    let ids: Vec<&str> =
+        res.others.iter().map(|h| h.note_id.as_str()).collect();
+    assert_eq!(ids, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn match_is_case_insensitive_and_substring() {
+    let notes = vec![note("a", Some("Réunion Budget"), "", &[])];
+    let res = search_mentions(&notes, "budg", None, 8);
+    assert_eq!(res.others.len(), 1);
+}
+
+#[test]
+fn scoped_notes_come_first_and_keep_their_slots() {
+    let mut notes: Vec<Note> = (0..10)
+        .map(|i| note(&format!("out{i}"), Some(&format!("Hors {i}")), "x", &[]))
+        .collect();
+    notes.push(note("in1", Some("Dedans"), "x", &[]));
+    let scoped: HashSet<String> = ["in1".to_string()].into_iter().collect();
+    let res = search_mentions(&notes, "", Some(&scoped), 8);
+    assert_eq!(res.in_scope.len(), 1);
+    assert_eq!(res.in_scope[0].note_id, "in1");
+    assert_eq!(res.others.len(), 7);
+}
+
+#[test]
+fn untitled_note_gets_content_excerpt_not_dropped() {
+    let notes = vec![note(
+        "u",
+        None,
+        "| a | b |\nidée de pitch pour la startup",
+        &[],
+    )];
+    let res = search_mentions(&notes, "pitch", None, 8);
+    assert_eq!(res.others.len(), 1);
+    let hit = &res.others[0];
+    assert!(hit.untitled);
+    assert!(hit.label.contains("pitch") || hit.label.contains("idée"));
+    assert!(!hit.label.contains('|'));
+}
+
+#[test]
+fn hit_date_is_day_prefix() {
+    let notes = vec![note("ab", Some("T"), "x", &[])];
+    let res = search_mentions(&notes, "", None, 8);
+    assert_eq!(res.others[0].date, "2026-06-02");
+}
+
+#[test]
+fn truly_empty_note_is_skipped() {
+    let notes = vec![note("e", None, "   ", &[])];
+    let res = search_mentions(&notes, "", None, 8);
+    assert!(res.others.is_empty());
+}

--- a/tests/rag_rewrite_test.rs
+++ b/tests/rag_rewrite_test.rs
@@ -1,0 +1,95 @@
+// Pure-function tests for conversational query rewriting (issue #88 F1). No LLM call, no
+// key: the seams under test (turn capping, history formatting, skip decision, output
+// sanitizing) are pure fns; the live rewrite stays a device concern.
+
+use flowflow::application::constants::CHAT_HISTORY_TURNS;
+use flowflow::application::rag::{
+    build_rewrite_input, format_history, recent_turns, sanitize_rewrite,
+    ChatTurn,
+};
+
+fn turn(role: &str, content: &str) -> ChatTurn {
+    ChatTurn {
+        role: role.into(),
+        content: content.into(),
+    }
+}
+
+#[test]
+fn recent_turns_keeps_everything_under_the_cap() {
+    let history = vec![turn("user", "a"), turn("bot", "b")];
+    assert_eq!(recent_turns(&history), &history[..]);
+}
+
+#[test]
+fn recent_turns_caps_to_most_recent() {
+    let history: Vec<ChatTurn> = (0..CHAT_HISTORY_TURNS + 4)
+        .map(|i| turn("user", &format!("m{i}")))
+        .collect();
+    let kept = recent_turns(&history);
+    assert_eq!(kept.len(), CHAT_HISTORY_TURNS);
+    assert_eq!(kept[0].content, "m4");
+    assert_eq!(
+        kept.last().unwrap().content,
+        format!("m{}", CHAT_HISTORY_TURNS + 3)
+    );
+}
+
+#[test]
+fn format_history_labels_roles_in_order() {
+    let history = vec![
+        turn("user", "qui est Jean ?"),
+        turn("bot", "Jean est ton plombier."),
+    ];
+    let out = format_history(&history);
+    assert_eq!(
+        out,
+        "User: qui est Jean ?\nAssistant: Jean est ton plombier."
+    );
+}
+
+#[test]
+fn format_history_collapses_newlines_and_truncates_long_answers() {
+    let long = "mot ".repeat(400);
+    let history = vec![turn("bot", &format!("ligne1\nligne2  {long}"))];
+    let out = format_history(&history);
+    assert!(out.starts_with("Assistant: ligne1 ligne2 mot"));
+    assert!(!out.contains('\n'));
+    assert!(out.chars().count() <= "Assistant: ".chars().count() + 500);
+}
+
+#[test]
+fn format_history_is_char_safe_on_accents() {
+    let accented = "é".repeat(600);
+    let history = vec![turn("user", &accented)];
+    let out = format_history(&history);
+    assert_eq!(out, format!("User: {}", "é".repeat(500)));
+}
+
+#[test]
+fn empty_history_skips_the_rewrite_entirely() {
+    assert_eq!(build_rewrite_input(&[], "et lui ?"), None);
+}
+
+#[test]
+fn rewrite_input_carries_history_and_question() {
+    let history = vec![turn("user", "parle-moi de Jean")];
+    let input = build_rewrite_input(&history, "et lui ?").unwrap();
+    assert!(input.contains("User: parle-moi de Jean"));
+    assert!(input.contains("--- Last question ---\net lui ?"));
+}
+
+#[test]
+fn sanitize_falls_back_on_empty_or_blank_output() {
+    assert_eq!(sanitize_rewrite("", "et lui ?"), "et lui ?");
+    assert_eq!(sanitize_rewrite("  \n ", "et lui ?"), "et lui ?");
+    assert_eq!(sanitize_rewrite("\"\"", "et lui ?"), "et lui ?");
+}
+
+#[test]
+fn sanitize_trims_quotes_and_whitespace() {
+    assert_eq!(
+        sanitize_rewrite("  \"notes sur Jean\" \n", "et lui ?"),
+        "notes sur Jean"
+    );
+}


### PR DESCRIPTION
## What

Two features, both device-validated on iPhone.

### feat(rag): conversational memory via query rewriting (part of #88, F1)

- The last 6 conversation turns + the new question are condensed into a standalone retrieval query by the cheap model (`gpt-5.4-nano`) before retrieval; the rewritten query feeds temporal detection, embedding, hybrid search, web search and the relevance judge.
- The final agent prompt receives the recent turns verbatim, so "développe" stays answerable even when retrieval adds nothing; the user's exact words are preserved.
- First message of a conversation pays zero extra LLM call; any rewrite failure falls back to the raw question.
- Fixes the classic multi-turn RAG failure: "et lui ?" used to embed only a pronoun and retrieve noise.
- New `src/application/rag/rewrite.rs`; wiring in `rag/mod.rs`; history snapshot in `ui/chat/actions.rs`.

### feat(ui): scoped @ mention search, recursive folder scope, drawer upgrades

- @ mention menu now searches title, tags AND content (was title-only); scoped chats list in-folder notes first ("Dans ce dossier" / "Autres notes"), empty query shows "Récentes"; every row carries a folder + date subtitle; untitled notes show a content excerpt instead of being hidden.
- Folder chat scope resolves the whole subtree via `WITH RECURSIVE` (scoping "Travail" now includes "Travail/Clients"); the scope picker renders the hierarchy indented instead of a flat alphabetical list.
- Sidebar drawer: per-folder note counts (subtree-wide, deduplicated), expansion state survives drawer close/reopen, and a new "Déplacer vers…" action re-parents folders with a cycle guard (a folder cannot move into its own subtree; "Racine" moves it back to top level).
- New pure helpers `flatten_tree` / `subtree_ids` in `domain/folder.rs`; mention search logic in `application/mention.rs`.

## Tests

- 21 new tests (`rag_rewrite_test`, `folder_tree_test`, `mention_search_test`): turn capping, history formatting, skip-on-empty, sanitize fallback, recursive folder queries, count dedup, subtree cycle guard, mention matching/priority/untitled handling.
- Full suite: 438 passed, 12 ignored. `cargo fmt` + `clippy` clean.
- Device-validated: follow-up questions, scoped @ menu, recursive scope citations, drawer counts/expansion/move.

## Issue

Part of #88 (F1 done; F2-F11 remain open).

https://claude.ai/code/session_01TDpMxPmFnTb31QoEwXPQt9
