### PR TITLE
feat(rag): per-question execution trace behind a debug toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4599 symbols, 11428 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4645 symbols, 11546 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4599 symbols, 11428 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4645 symbols, 11546 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/src/application/i18n/locales/en.ftl
+++ b/src/application/i18n/locales/en.ftl
@@ -395,3 +395,10 @@ chat-empty-scope = No notes in this scope to answer from.
 chat-no-relevant = No relevant note found. Turn on web search to look beyond your notes.
 chat-web-empty = Nothing found in your notes or on the web for this.
 thread-open = Open thread
+
+# RAG execution trace - debug only
+settings-debug-title = Diagnostics
+settings-debug-trace = Chat execution trace
+settings-debug-trace-desc = Show each answer’s pipeline steps (model, latency). Debug only.
+chat-trace-summary = { $steps } steps - { $secs }s
+chat-trace-title = Execution trace

--- a/src/application/i18n/locales/fr.ftl
+++ b/src/application/i18n/locales/fr.ftl
@@ -395,3 +395,10 @@ chat-empty-scope = Aucune note dans ce contexte pour répondre.
 chat-no-relevant = Aucune note pertinente trouvée. Active la recherche web pour aller au-delà des notes.
 chat-web-empty = Rien trouvé dans les notes ni sur le web pour cette question.
 thread-open = Ouvrir le fil
+
+# RAG execution trace - debug only
+settings-debug-title = Diagnostics
+settings-debug-trace = Trace d’exécution du chat
+settings-debug-trace-desc = Affiche les étapes de chaque réponse (modèle, latence). Debug uniquement.
+chat-trace-summary = { $steps } étapes - { $secs } s
+chat-trace-title = Trace d’exécution

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -1,7 +1,7 @@
 use crate::application::constants::{
-    RAG_AGENT_SYSTEM_PROMPT, RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K,
-    RAG_INITIAL_K, RAG_RELEVANCE_FLOOR, RRF_K, RRF_LOCAL_WEIGHT,
-    RRF_WEB_WEIGHT,
+    CHEAP_MODEL, EMBEDDING_MODEL, RAG_AGENT_SYSTEM_PROMPT,
+    RAG_AGENT_WEB_SYSTEM_PROMPT, RAG_FINAL_K, RAG_INITIAL_K,
+    RAG_RELEVANCE_FLOOR, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
 use crate::infrastructure::llm::LlmClient;
@@ -48,6 +48,10 @@ pub fn abstain_decision(
 mod rerank;
 use rerank::llm_relevance_filter;
 
+mod trace;
+use trace::StepTimer;
+pub use trace::{estimate_tokens, RagTrace, StepOutcome, TraceStep};
+
 mod rewrite;
 use rewrite::rewrite_query;
 pub use rewrite::{
@@ -63,15 +67,29 @@ async fn select_relevant(
     ai: &LlmClient,
     question: &str,
     candidates: Vec<SearchResult>,
+    rag_trace: &mut RagTrace,
 ) -> Vec<SearchResult> {
     if candidates.is_empty() {
+        StepTimer::start("judge", None).finish(
+            rag_trace,
+            None,
+            None,
+            StepOutcome::Skipped,
+        );
         return candidates;
     }
+    let judge_in = estimate_tokens(question)
+        + candidates
+            .iter()
+            .map(|c| estimate_tokens(&c.chunk_text))
+            .sum::<u32>();
+    let timer = StepTimer::start("judge", Some(ai.chat_model_name()));
     let judged: HashSet<usize> =
         llm_relevance_filter(ai, question, &candidates, RAG_FINAL_K)
             .await
             .into_iter()
             .collect();
+    timer.finish(rag_trace, Some(judge_in), None, StepOutcome::Ok);
     candidates
         .into_iter()
         .enumerate()
@@ -104,6 +122,8 @@ pub struct RagSource {
 pub struct RagResponse {
     pub answer: String,
     pub sources: Vec<RagSource>,
+    /// Per-step execution trace (observation only); None on non-RAG paths.
+    pub trace: Option<RagTrace>,
 }
 
 pub async fn query(
@@ -115,6 +135,8 @@ pub async fn query(
     history: Vec<ChatTurn>,
     lang: &str,
 ) -> Result<RagResponse, String> {
+    let run_started = std::time::Instant::now();
+    let mut rag_trace = RagTrace::default();
     let ai = Arc::new(LlmClient::from_env()?);
     let store = VectorStore::open().await?;
 
@@ -147,15 +169,33 @@ pub async fn query(
     // An empty scope only dead-ends when there is no web to fall back on; with web
     // on, the chat still answers from the web even if the scoped note set is empty.
     if !web_on && matches!(allowed_note_ids, Some(ref ids) if ids.is_empty()) {
+        rag_trace.total_ms = run_started.elapsed().as_millis() as u64;
         return Ok(RagResponse {
             answer: crate::application::i18n::t(lang, "chat-empty-scope"),
             sources: vec![],
+            trace: Some(rag_trace),
         });
     }
 
     // Follow-ups lean on the conversation ("et lui ?", "développe"): retrieval runs on a
     // standalone rewrite of the question, while the final agent still sees the user's words.
+    let rewrite_timer = StepTimer::start("rewrite", Some(CHEAP_MODEL));
     let retrieval_q = rewrite_query(&ai, &history, question).await;
+    let rewrite_in = estimate_tokens(question)
+        + history
+            .iter()
+            .map(|t| estimate_tokens(&t.content))
+            .sum::<u32>();
+    rewrite_timer.finish(
+        &mut rag_trace,
+        Some(rewrite_in),
+        Some(estimate_tokens(&retrieval_q)),
+        if history.is_empty() {
+            StepOutcome::Skipped
+        } else {
+            StepOutcome::Ok
+        },
+    );
     if retrieval_q != question {
         eprintln!("[rag] rewrite: {retrieval_q}");
     }
@@ -165,10 +205,24 @@ pub async fn query(
     let date_range = match date_range {
         Some(r) => {
             eprintln!("[rag] temporal regex: {} to {}", r.from, r.to);
+            StepTimer::start("temporal", None).finish(
+                &mut rag_trace,
+                None,
+                None,
+                StepOutcome::Skipped,
+            );
             Some(r)
         }
         None => {
+            let timer =
+                StepTimer::start("temporal", Some(ai.chat_model_name()));
             let r = detect_temporal_llm(&ai, retrieval_q).await;
+            timer.finish(
+                &mut rag_trace,
+                Some(estimate_tokens(retrieval_q)),
+                None,
+                StepOutcome::Ok,
+            );
             if let Some(ref r) = r {
                 eprintln!("[rag] temporal LLM: {} to {}", r.from, r.to);
             }
@@ -177,7 +231,14 @@ pub async fn query(
     };
 
     let _ = store.ensure_fts_index().await;
+    let embed_timer = StepTimer::start("embed", Some(EMBEDDING_MODEL));
     let query_vector = ai.embed(retrieval_q).await?;
+    embed_timer.finish(
+        &mut rag_trace,
+        Some(estimate_tokens(retrieval_q)),
+        None,
+        StepOutcome::Ok,
+    );
     let fetch_k = if date_range.is_some() {
         RAG_INITIAL_K * 3
     } else {
@@ -188,6 +249,7 @@ pub async fn query(
         if let Some(ref tx) = status_tx {
             let _ = tx.send(ToolEvent::Started("web_search".into()));
         }
+        let search_timer = StepTimer::start("search", None);
         let (local_res, web_res) = tokio::join!(
             store.hybrid_search(
                 retrieval_q,
@@ -197,6 +259,7 @@ pub async fn query(
             ),
             crate::application::web_search::exa_search(retrieval_q, &exa),
         );
+        search_timer.finish(&mut rag_trace, None, None, StepOutcome::Ok);
         if let Some(ref tx) = status_tx {
             let _ = tx.send(ToolEvent::Finished("web_search".into()));
         }
@@ -216,20 +279,24 @@ pub async fn query(
             && !is_actionable
         {
             eprintln!("[rag] abstain: web on, both legs empty");
+            rag_trace.total_ms = run_started.elapsed().as_millis() as u64;
             return Ok(RagResponse {
                 answer: crate::application::i18n::t(lang, "chat-web-empty"),
                 sources: vec![],
+                trace: Some(rag_trace),
             });
         }
         let merged =
             rrf_merge(local, web_res, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT);
         // Cite only the genuinely relevant rows (notes AND web results), judged by the LLM, not
         // the top-N by rank.
-        let selected = select_relevant(&ai, retrieval_q, merged).await;
+        let selected =
+            select_relevant(&ai, retrieval_q, merged, &mut rag_trace).await;
         let filtered = dedup_merged(selected);
         let count = read_max_sources().min(RAG_FINAL_K).min(filtered.len());
         filtered.into_iter().take(count).collect()
     } else {
+        let search_timer = StepTimer::start("search", None);
         let candidates = store
             .hybrid_search(
                 retrieval_q,
@@ -238,6 +305,7 @@ pub async fn query(
                 allowed_note_ids.as_deref(),
             )
             .await?;
+        search_timer.finish(&mut rag_trace, None, None, StepOutcome::Ok);
 
         let candidates = if let Some(ref range) = date_range {
             apply_date_filter(candidates, range)
@@ -249,9 +317,15 @@ pub async fn query(
         // so it judges what a note is ABOUT, not mere word overlap. An `@mention` is an explicit
         // pointer: answer from the named notes without judging.
         let mut selected = if has_mention {
+            StepTimer::start("judge", None).finish(
+                &mut rag_trace,
+                None,
+                None,
+                StepOutcome::Skipped,
+            );
             candidates
         } else {
-            select_relevant(&ai, retrieval_q, candidates).await
+            select_relevant(&ai, retrieval_q, candidates, &mut rag_trace).await
         };
         apply_temporal_boost(&mut selected);
         let kept = dedup_sources(selected);
@@ -262,9 +336,11 @@ pub async fn query(
             == AbstainDecision::Abstain
         {
             eprintln!("[rag] abstain: nothing relevant (web off)");
+            rag_trace.total_ms = run_started.elapsed().as_millis() as u64;
             return Ok(RagResponse {
                 answer: crate::application::i18n::t(lang, "chat-no-relevant"),
                 sources: vec![],
+                trace: Some(rag_trace),
             });
         }
 
@@ -328,9 +404,16 @@ pub async fn query(
     } else {
         RAG_AGENT_SYSTEM_PROMPT
     };
+    let agent_timer = StepTimer::start("agent", Some(ai.chat_model_name()));
     let answer =
         prompt_agent_with_tools(ai, system_prompt, &user_msg, status_tx)
             .await?;
+    agent_timer.finish(
+        &mut rag_trace,
+        Some(estimate_tokens(&user_msg)),
+        Some(estimate_tokens(&answer)),
+        StepOutcome::Ok,
+    );
 
     let sources = results
         .into_iter()
@@ -345,7 +428,12 @@ pub async fn query(
         })
         .collect();
 
-    Ok(RagResponse { answer, sources })
+    rag_trace.total_ms = run_started.elapsed().as_millis() as u64;
+    Ok(RagResponse {
+        answer,
+        sources,
+        trace: Some(rag_trace),
+    })
 }
 
 /// Run an explicit "lance xxx" message straight through the note-action agent path
@@ -368,5 +456,6 @@ pub async fn run_action(
     Ok(RagResponse {
         answer,
         sources: vec![],
+        trace: None,
     })
 }

--- a/src/application/rag/trace.rs
+++ b/src/application/rag/trace.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+
+/// How a pipeline step ended: `Ok` = the call ran, `Fallback` = it failed and a
+/// degraded path answered instead, `Skipped` = a fast-path made the call unnecessary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepOutcome {
+    Ok,
+    Fallback,
+    Skipped,
+}
+
+/// One observed pipeline step. Token counts are char-based estimates (`approx`)
+/// until the provider exposes real usage; `model` is None for non-LLM steps.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceStep {
+    pub step: String,
+    pub model: Option<String>,
+    pub tokens_in: Option<u32>,
+    pub tokens_out: Option<u32>,
+    pub approx: bool,
+    pub latency_ms: u64,
+    pub retries: u32,
+    pub outcome: StepOutcome,
+}
+
+/// Per-question execution trace of the RAG pipeline. Observation only: it never
+/// influences the answer. Persisted with the bot message, device-local.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct RagTrace {
+    pub steps: Vec<TraceStep>,
+    pub total_ms: u64,
+}
+
+impl RagTrace {
+    pub fn push(&mut self, step: TraceStep) {
+        self.steps.push(step);
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".into())
+    }
+
+    pub fn from_json(raw: &str) -> Option<RagTrace> {
+        serde_json::from_str(raw).ok()
+    }
+
+    /// Compact label data for the UI line under the answer: (step count, seconds).
+    pub fn summary(&self) -> (usize, f64) {
+        (self.steps.len(), self.total_ms as f64 / 1000.0)
+    }
+}
+
+/// Rough token estimate from text length; real usage plumbing can replace it later.
+pub fn estimate_tokens(text: &str) -> u32 {
+    (text.len() / 4) as u32
+}
+
+/// Measure one step around a call site: start it, then `finish` with what happened.
+pub struct StepTimer {
+    step: &'static str,
+    model: Option<String>,
+    started: Instant,
+}
+
+impl StepTimer {
+    pub fn start(step: &'static str, model: Option<&str>) -> Self {
+        Self {
+            step,
+            model: model.map(String::from),
+            started: Instant::now(),
+        }
+    }
+
+    pub fn finish(
+        self,
+        trace: &mut RagTrace,
+        tokens_in: Option<u32>,
+        tokens_out: Option<u32>,
+        outcome: StepOutcome,
+    ) {
+        trace.push(TraceStep {
+            step: self.step.to_string(),
+            model: self.model,
+            tokens_in,
+            tokens_out,
+            approx: true,
+            latency_ms: self.started.elapsed().as_millis() as u64,
+            retries: 0,
+            outcome,
+        });
+    }
+}

--- a/src/infrastructure/llm.rs
+++ b/src/infrastructure/llm.rs
@@ -180,6 +180,14 @@ impl LlmClient {
         }
     }
 
+    /// Model id the chat/agent path actually uses under the configured provider.
+    pub fn chat_model_name(&self) -> &'static str {
+        match self.provider {
+            Provider::OpenAi => CHAT_MODEL,
+            Provider::Anthropic => ANTHROPIC_CHAT_MODEL,
+        }
+    }
+
     pub async fn prompt_with_agent(
         self: &Arc<Self>,
         preamble: &str,

--- a/src/infrastructure/persistence/conversation_repo.rs
+++ b/src/infrastructure/persistence/conversation_repo.rs
@@ -184,6 +184,34 @@ impl Database {
         })
     }
 
+    // The execution trace lives in its own column with its own accessors: the
+    // ConversationMessage struct feeds the sync wire, so it must not grow a
+    // device-local field.
+    pub fn set_message_trace(
+        &self,
+        message_id: &str,
+        trace_json: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn();
+        conn.execute(
+            "UPDATE conversation_messages SET trace_json = ?1 WHERE id = ?2",
+            rusqlite::params![trace_json, message_id],
+        )
+        .map_err(|e| format!("Set message trace: {e}"))?;
+        Ok(())
+    }
+
+    pub fn message_trace(&self, message_id: &str) -> Option<String> {
+        let conn = self.conn();
+        conn.query_row(
+            "SELECT trace_json FROM conversation_messages WHERE id = ?1",
+            [message_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten()
+    }
+
     // Rewrite a message's content in place. Used to update a persisted proposal card from its
     // Pending propose-time shape to its final decided status, without a new row or migration.
     pub fn update_message_content(

--- a/src/infrastructure/persistence/schema.rs
+++ b/src/infrastructure/persistence/schema.rs
@@ -17,7 +17,15 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     (16, V16_SCHEMA),
     (17, V17_SCHEMA),
     (18, V18_SCHEMA),
+    (19, V19_SCHEMA),
 ];
+
+// Per-question RAG execution trace, persisted with the bot message. Nullable and
+// device-local: the sync wire never carries it, so a plain additive column suffices
+// (triggers survive ALTER TABLE ADD COLUMN).
+const V19_SCHEMA: &str = "
+ALTER TABLE conversation_messages ADD COLUMN trace_json TEXT;
+";
 
 // Approval cards (RFC 0019) persist as messages with role "proposal", but the original
 // conversation_messages CHECK only admits 'user'/'bot'. SQLite cannot alter a CHECK in place,

--- a/src/ui/chat/actions.rs
+++ b/src/ui/chat/actions.rs
@@ -362,6 +362,7 @@ pub fn send_question(
             .map(|answer| rag::RagResponse {
                 answer,
                 sources: vec![],
+                trace: None,
             })
         } else if crate::application::intent::is_action_trigger(&question) {
             rag::run_action(&question, Some(tx)).await
@@ -395,17 +396,23 @@ pub fn send_question(
                 let sources_json = serialize_sources(&sources);
 
                 if let Some(ref cid) = conv_signal() {
-                    let _ = db().add_message(
+                    if let Ok(msg) = db().add_message(
                         cid,
                         "bot",
                         &r.answer,
                         sources_json.as_deref(),
-                    );
+                    ) {
+                        if let Some(ref trace) = r.trace {
+                            let _ = db()
+                                .set_message_trace(&msg.id, &trace.to_json());
+                        }
+                    }
                 }
 
                 msgs.write().push(ChatMsg::Bot {
                     text: r.answer,
                     sources,
+                    trace: r.trace,
                 });
             }
             Err(e) => {
@@ -416,6 +423,7 @@ pub fn send_question(
                 msgs.write().push(ChatMsg::Bot {
                     text: err_msg,
                     sources: vec![],
+                    trace: None,
                 });
             }
         }
@@ -460,9 +468,14 @@ pub fn load_messages_from_db(
                         .as_deref()
                         .map(parse_sources)
                         .unwrap_or_default();
+                    let trace = db
+                        .message_trace(&m.id)
+                        .as_deref()
+                        .and_then(crate::application::rag::RagTrace::from_json);
                     Some(ChatMsg::Bot {
                         text: m.content,
                         sources,
+                        trace,
                     })
                 }
                 // Only "proposal" remains; a run never survives the app, so a persisted

--- a/src/ui/chat/bot_bubble.rs
+++ b/src/ui/chat/bot_bubble.rs
@@ -4,6 +4,7 @@ use crate::ui::chat::action_card::ActionResultCard;
 use crate::ui::chat::actions::{find_saved_note, md_to_html, save_as_note};
 use crate::ui::chat::models::ChatSource;
 use crate::ui::chat::sources_accordion::SourcesAccordion;
+use crate::ui::chat::trace_accordion::TraceAccordion;
 use crate::ui::clipboard::copy_text;
 use crate::ui::icons::{IconCheck, IconCopy, IconFloppyDisk};
 use crate::ui::state::View;
@@ -16,6 +17,7 @@ pub fn BotBubble(
     text: String,
     sources: Vec<ChatSource>,
     conversation_id: Option<String>,
+    #[props(default)] trace: Option<crate::application::rag::RagTrace>,
 ) -> Element {
     let mut app: AppState = use_context();
     let db: Signal<Arc<Database>> = use_context();
@@ -150,6 +152,11 @@ pub fn BotBubble(
                         sources: sources.clone(),
                         conversation_id: conversation_id,
                     }
+                }
+                if let Some(tr) = trace.filter(|_| {
+                    db().get_setting("debug_trace").as_deref() == Some("1")
+                }) {
+                    TraceAccordion { trace: tr }
                 }
             }
         }

--- a/src/ui/chat/mod.rs
+++ b/src/ui/chat/mod.rs
@@ -6,6 +6,7 @@ mod menu;
 mod models;
 mod sources_accordion;
 mod tools_menu;
+mod trace_accordion;
 mod typing_indicator;
 mod user_bubble;
 mod view;

--- a/src/ui/chat/models.rs
+++ b/src/ui/chat/models.rs
@@ -17,6 +17,8 @@ pub enum ChatMsg {
     Bot {
         text: String,
         sources: Vec<ChatSource>,
+        /// RAG execution trace, shown only under the Settings debug toggle.
+        trace: Option<crate::application::rag::RagTrace>,
     },
     /// A suspended connector write awaiting the user's decision, rendered as the approval card.
     /// `status` drives the card (buttons while `Pending`, a frozen pill after); `edit_error`

--- a/src/ui/chat/trace_accordion.rs
+++ b/src/ui/chat/trace_accordion.rs
@@ -1,0 +1,65 @@
+use crate::application::i18n::t_args;
+use crate::application::rag::{RagTrace, StepOutcome};
+use crate::ui::AppState;
+use dioxus::prelude::*;
+
+/// Debug-only pipeline trace under a bot answer: a compact "N steps - X.Xs" line
+/// that expands into the per-step table. Rendered only when the Settings debug
+/// toggle is on; end users never see it.
+#[component]
+pub fn TraceAccordion(trace: RagTrace) -> Element {
+    let app: AppState = use_context();
+    let lang = (app.current_lang)();
+    let mut open = use_signal(|| false);
+
+    let (steps, secs) = trace.summary();
+    let label = t_args(
+        &lang,
+        "chat-trace-summary",
+        &[
+            ("steps", &steps.to_string()),
+            ("secs", &format!("{secs:.1}")),
+        ],
+    );
+
+    rsx! {
+        div { class: "mt-1.5 border-t border-stone-100 pt-1.5",
+            button {
+                class: "text-xs text-stone-400 active:text-stone-600 hover:text-stone-600 transition-colors duration-150",
+                onclick: move |_| open.set(!open()),
+                "{label}"
+            }
+            if open() {
+                div { class: "mt-1 space-y-0.5",
+                    for step in trace.steps.iter() {
+                        div { class: "flex items-baseline gap-2 text-xs font-mono",
+                            span { class: "w-16 shrink-0 text-stone-600", "{step.step}" }
+                            span {
+                                class: match step.outcome {
+                                    StepOutcome::Ok => "text-ios-green",
+                                    StepOutcome::Fallback => "text-ios-red",
+                                    StepOutcome::Skipped => "text-stone-400",
+                                },
+                                match step.outcome {
+                                    StepOutcome::Ok => "ok",
+                                    StepOutcome::Fallback => "fallback",
+                                    StepOutcome::Skipped => "skip",
+                                }
+                            }
+                            span { class: "text-stone-500", "{step.latency_ms}ms" }
+                            if let Some(ref model) = step.model {
+                                span { class: "text-stone-400 truncate", "{model}" }
+                            }
+                            if let Some(tin) = step.tokens_in {
+                                span { class: "text-stone-400", "~{tin}t in" }
+                            }
+                            if let Some(tout) = step.tokens_out {
+                                span { class: "text-stone-400", "~{tout}t out" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -189,12 +189,13 @@ pub fn ChatView() -> Element {
                                         UserBubble { text: text.clone() }
                                     }
                                 },
-                                ChatMsg::Bot { text, sources } => rsx! {
+                                ChatMsg::Bot { text, sources, trace } => rsx! {
                                     div { key: "{i}",
                                         BotBubble {
                                             text: text.clone(),
                                             sources: sources.clone(),
                                             conversation_id: conversation_id(),
+                                            trace: trace.clone(),
                                         }
                                     }
                                 },

--- a/src/ui/settings/intelligence.rs
+++ b/src/ui/settings/intelligence.rs
@@ -18,6 +18,8 @@ pub fn IntelligenceSettings() -> Element {
             .unwrap_or(8)
     });
     let mut saved = use_signal(|| false);
+    let mut debug_trace =
+        use_signal(|| db().get_setting("debug_trace").as_deref() == Some("1"));
     let lang = (app.current_lang)();
 
     rsx! {
@@ -79,6 +81,34 @@ pub fn IntelligenceSettings() -> Element {
                 div { class: "flex justify-between text-xs text-stone-400",
                     span { "3" }
                     span { "15" }
+                }
+            }
+
+            h2 { class: "text-lg font-semibold text-stone-900 pt-2", {t(&lang, "settings-debug-title")} }
+            button {
+                class: "w-full flex items-center justify-between gap-3 text-left",
+                onclick: move |_| {
+                    let on = !debug_trace();
+                    debug_trace.set(on);
+                    let _ = db().set_setting("debug_trace", if on { "1" } else { "0" });
+                },
+                div {
+                    p { class: "text-sm font-medium text-stone-700", {t(&lang, "settings-debug-trace")} }
+                    p { class: "text-xs text-stone-400", {t(&lang, "settings-debug-trace-desc")} }
+                }
+                span {
+                    class: if debug_trace() {
+                        "relative w-11 h-6 shrink-0 rounded-full bg-ios-orange transition-colors duration-200"
+                    } else {
+                        "relative w-11 h-6 shrink-0 rounded-full bg-stone-300 transition-colors duration-200"
+                    },
+                    span {
+                        class: if debug_trace() {
+                            "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-5"
+                        } else {
+                            "absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 translate-x-0"
+                        },
+                    }
                 }
             }
 

--- a/tests/rag_test.rs
+++ b/tests/rag_test.rs
@@ -60,6 +60,7 @@ fn test_rag_response_empty_sources() {
     let resp = RagResponse {
         answer: "Aucune note trouvée".to_string(),
         sources: vec![],
+        trace: None,
     };
     assert_eq!(resp.answer, "Aucune note trouvée");
     assert!(resp.sources.is_empty());
@@ -73,6 +74,7 @@ fn test_rag_response_with_sources() {
             make_source("n1", "T1", "C1", 0.1),
             make_source("n2", "T2", "C2", 0.2),
         ],
+        trace: None,
     };
     assert_eq!(resp.sources.len(), 2);
     assert_eq!(resp.sources[0].note_id, "n1");
@@ -84,6 +86,7 @@ fn test_rag_response_clone() {
     let resp = RagResponse {
         answer: "Réponse".to_string(),
         sources: vec![make_source("n1", "T1", "C1", 0.5)],
+        trace: None,
     };
     let copy = resp.clone();
     assert_eq!(resp.answer, copy.answer);

--- a/tests/rag_trace_test.rs
+++ b/tests/rag_trace_test.rs
@@ -1,0 +1,100 @@
+use flowflow::application::rag::{
+    estimate_tokens, RagTrace, StepOutcome, TraceStep,
+};
+use flowflow::infrastructure::persistence::Database;
+use tempfile::tempdir;
+
+fn step(name: &str, outcome: StepOutcome) -> TraceStep {
+    TraceStep {
+        step: name.to_string(),
+        model: Some("gpt-5.4-mini".to_string()),
+        tokens_in: Some(120),
+        tokens_out: Some(40),
+        approx: true,
+        latency_ms: 250,
+        retries: 0,
+        outcome,
+    }
+}
+
+#[test]
+fn estimate_tokens_scales_with_length() {
+    assert_eq!(estimate_tokens(""), 0);
+    assert_eq!(estimate_tokens("abcd"), 1);
+    assert_eq!(estimate_tokens(&"x".repeat(400)), 100);
+}
+
+#[test]
+fn trace_json_round_trips() {
+    let mut trace = RagTrace::default();
+    trace.push(step("rewrite", StepOutcome::Skipped));
+    trace.push(step("judge", StepOutcome::Ok));
+    trace.push(step("temporal", StepOutcome::Fallback));
+    trace.total_ms = 4200;
+
+    let json = trace.to_json();
+    let back = RagTrace::from_json(&json).expect("parse back");
+    assert_eq!(back, trace);
+    assert_eq!(back.steps.len(), 3);
+    assert_eq!(back.steps[0].outcome, StepOutcome::Skipped);
+    assert!(
+        json.contains("\"skipped\""),
+        "outcome serializes snake_case"
+    );
+}
+
+#[test]
+fn from_json_rejects_garbage() {
+    assert!(RagTrace::from_json("not json").is_none());
+    assert!(RagTrace::from_json("{\"steps\": 3}").is_none());
+}
+
+#[test]
+fn summary_reports_count_and_seconds() {
+    let mut trace = RagTrace::default();
+    trace.push(step("embed", StepOutcome::Ok));
+    trace.push(step("agent", StepOutcome::Ok));
+    trace.total_ms = 6234;
+    let (n, secs) = trace.summary();
+    assert_eq!(n, 2);
+    assert!((secs - 6.234).abs() < 1e-9);
+}
+
+#[test]
+fn message_trace_round_trips_in_db() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("flowflow_test.db"))
+        .expect("open_at");
+
+    let conv = db.create_conversation("trace test").unwrap();
+    let msg = db.add_message(&conv.id, "bot", "answer", None).unwrap();
+
+    assert_eq!(db.message_trace(&msg.id), None, "unset trace reads None");
+
+    let mut trace = RagTrace::default();
+    trace.push(step("search", StepOutcome::Ok));
+    trace.total_ms = 900;
+    db.set_message_trace(&msg.id, &trace.to_json()).unwrap();
+
+    let raw = db.message_trace(&msg.id).expect("trace stored");
+    let back = RagTrace::from_json(&raw).expect("stored trace parses");
+    assert_eq!(back, trace);
+}
+
+#[test]
+fn message_trace_is_message_scoped() {
+    let dir = tempdir().expect("dir");
+    let db = Database::open_at(dir.path().join("flowflow_test.db"))
+        .expect("open_at");
+
+    let conv = db.create_conversation("trace scope").unwrap();
+    let a = db.add_message(&conv.id, "bot", "a", None).unwrap();
+    let b = db.add_message(&conv.id, "bot", "b", None).unwrap();
+
+    let mut trace = RagTrace::default();
+    trace.push(step("agent", StepOutcome::Ok));
+    db.set_message_trace(&a.id, &trace.to_json()).unwrap();
+
+    assert!(db.message_trace(&a.id).is_some());
+    assert_eq!(db.message_trace(&b.id), None);
+}

--- a/tests/sync_conflict_test.rs
+++ b/tests/sync_conflict_test.rs
@@ -597,7 +597,7 @@ fn restore_conflict_drops_dangling_thread_keeps_folder() {
     let (db_b, _db) = open_db();
     let (id_a, _) = pair(&db_a, &db_b);
 
-    let (folder, thread, note) =
+    let (_folder, thread, note) =
         seed_foldered_threaded_conflict(&db_a, &db_b, &id_a);
     let (db_with, conflict) = losing_side(&db_a, &db_b);
 


### PR DESCRIPTION
## RAG execution trace per question (debug toggle)

Closes #96. Follow-up to the round-trips discussion in #88.

Every `rag::query` now records one entry per pipeline step - rewrite, temporal,
embed, hybrid search, relevance judge, agent - with the model, approximate
tokens in/out, latency in ms, and the outcome (ok / fallback / skipped).
Observation only: answers are byte-identical to before.

### How it works
- `application/rag/trace.rs`: `RagTrace` / `TraceStep` / `StepTimer` +
  `estimate_tokens` (char-based until providers expose real usage).
- Persistence: migration V19 adds a nullable `conversation_messages.trace_json`
  column. Device-local by design - the `ConversationMessage` struct feeds the
  sync wire, so the trace lives behind its own repo accessors and never syncs.
- Settings > Intelligence > Diagnostics: a `debug_trace` toggle, off by default.
- Chat: while the toggle is on, a compact "N steps - X.Xs" line under each new
  answer expands into the per-step list. Off = nothing rendered, ever.
- `LlmClient::chat_model_name()` exposes the effective chat model per provider.

### Device-validated (iPhone)
First real trace: rewrite skip 0ms, temporal ok 2498ms, embed ok 2401ms,
search ok 67ms, judge ok 1361ms (~3010t in), agent ok 2850ms - 6 steps, 9.4s.
The serial cost is now measurable, which is exactly what the future
optimizations in #96 (merge prep calls, cheap-model judge, parallel temporal)
will be judged against.

### Tests
`tests/rag_trace_test.rs` (6: serde round-trip, garbage rejection, summary,
DB round-trip incl. V19, message scoping). Full suite: 65 test binaries,
0 failures. fmt + clippy clean.

https://claude.ai/code/session_01L2GVyWrNfqkUdEaWUofGQB
