### PR TITLE
perf(rag): one prep call, parallel temporal, cheap judge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4645 symbols, 11546 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4653 symbols, 11569 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4645 symbols, 11546 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4653 symbols, 11569 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/src/application/constants.rs
+++ b/src/application/constants.rs
@@ -157,19 +157,20 @@ List the relevant numbers, most relevant first, separated by commas. If NONE are
 No explanation, output only the numbers or the word none.\n\
 Example: 3, 1";
 
-pub const QUERY_REWRITE_PROMPT: &str = "\
-You rewrite the user's LAST question into a single standalone search query, using the \
-conversation for context.\n\
-The question may rely on the conversation (pronouns like \"lui\", \"elle\", \"it\", or requests \
-like \"développe\", \"tell me more\"). Resolve every such reference into explicit words: name the \
-person, topic, or thing the question actually refers to.\n\
-If the question is already self-contained, return it unchanged.\n\
-Keep the SAME language as the question. Return ONLY the rewritten query - no quotes, no \
-explanation, one line.\n\
+pub const QUERY_PREP_PROMPT: &str = "\
+You prepare the user's LAST question for retrieval, using the conversation for context. \
+Do TWO things in ONE pass:\n\
+1. Rewrite the question into a single standalone search query. The question may rely on the \
+conversation (pronouns like \"lui\", \"elle\", \"it\", or requests like \"développe\", \"tell me \
+more\"): resolve every such reference into explicit words. If already self-contained, keep it \
+unchanged. Same language as the question.\n\
+2. Extract temporal intent. Today's date is provided; use it to resolve relative dates.\n\
+Return ONLY a JSON object, nothing else:\n\
+{\"query\": \"...\", \"from\": \"YYYY-MM-DD\" or null, \"to\": \"YYYY-MM-DD\" or null}\n\
 Examples:\n\
-- Conversation about a note on Jean, question \"et lui ?\" → \"Qui est Jean, que disent mes notes sur Jean ?\"\n\
-- Conversation about React performance, question \"développe\" → \"Détails sur la performance React (mémoïsation, rendu)\"\n\
-- Question \"quelles notes parlent de budget ?\" → \"quelles notes parlent de budget ?\"";
+- Conversation about a note on Jean, question \"et lui ?\" → {\"query\":\"Qui est Jean, que disent mes notes sur Jean ?\",\"from\":null,\"to\":null}\n\
+- Question \"mes notes budget de la semaine dernière\" with today=2026-05-17 → {\"query\":\"notes budget\",\"from\":\"2026-05-05\",\"to\":\"2026-05-11\"}\n\
+- Question \"quelles notes parlent de budget ?\" → {\"query\":\"quelles notes parlent de budget ?\",\"from\":null,\"to\":null}";
 
 pub const TEMPORAL_DETECT_PROMPT: &str = "\
 Analyze the user's question and extract any temporal intent.\n\

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -53,10 +53,10 @@ use trace::StepTimer;
 pub use trace::{estimate_tokens, RagTrace, StepOutcome, TraceStep};
 
 mod rewrite;
-use rewrite::rewrite_query;
+use rewrite::prep_query;
 pub use rewrite::{
-    build_rewrite_input, format_history, recent_turns, sanitize_rewrite,
-    ChatTurn,
+    build_rewrite_input, format_history, parse_prep, recent_turns,
+    sanitize_rewrite, ChatTurn,
 };
 
 /// Keep only the candidates the LLM judged genuinely relevant to the question. The model reads
@@ -83,7 +83,7 @@ async fn select_relevant(
             .iter()
             .map(|c| estimate_tokens(&c.chunk_text))
             .sum::<u32>();
-    let timer = StepTimer::start("judge", Some(ai.chat_model_name()));
+    let timer = StepTimer::start("judge", Some(CHEAP_MODEL));
     let judged: HashSet<usize> =
         llm_relevance_filter(ai, question, &candidates, RAG_FINAL_K)
             .await
@@ -177,68 +177,99 @@ pub async fn query(
         });
     }
 
-    // Follow-ups lean on the conversation ("et lui ?", "développe"): retrieval runs on a
-    // standalone rewrite of the question, while the final agent still sees the user's words.
-    let rewrite_timer = StepTimer::start("rewrite", Some(CHEAP_MODEL));
-    let retrieval_q = rewrite_query(&ai, &history, question).await;
-    let rewrite_in = estimate_tokens(question)
-        + history
-            .iter()
-            .map(|t| estimate_tokens(&t.content))
-            .sum::<u32>();
-    rewrite_timer.finish(
-        &mut rag_trace,
-        Some(rewrite_in),
-        Some(estimate_tokens(&retrieval_q)),
-        if history.is_empty() {
-            StepOutcome::Skipped
-        } else {
-            StepOutcome::Ok
-        },
-    );
+    // Follow-ups lean on the conversation ("et lui ?", "développe"): ONE cheap prep call
+    // yields both the standalone retrieval query and the temporal intent, while the final
+    // agent still sees the user's words. First messages skip it entirely.
+    let (retrieval_q, mut date_range) = if history.is_empty() {
+        StepTimer::start("prep", None).finish(
+            &mut rag_trace,
+            None,
+            None,
+            StepOutcome::Skipped,
+        );
+        (question.to_string(), None)
+    } else {
+        let prep_in = estimate_tokens(question)
+            + history
+                .iter()
+                .map(|t| estimate_tokens(&t.content))
+                .sum::<u32>();
+        let timer = StepTimer::start("prep", Some(CHEAP_MODEL));
+        let (q, range) = prep_query(&ai, &history, question).await;
+        timer.finish(
+            &mut rag_trace,
+            Some(prep_in),
+            Some(estimate_tokens(&q)),
+            StepOutcome::Ok,
+        );
+        (q, range)
+    };
     if retrieval_q != question {
         eprintln!("[rag] rewrite: {retrieval_q}");
     }
     let retrieval_q = retrieval_q.as_str();
 
-    let date_range = detect_temporal_regex(retrieval_q);
-    let date_range = match date_range {
-        Some(r) => {
+    if date_range.is_none() {
+        date_range = detect_temporal_regex(retrieval_q);
+        if let Some(ref r) = date_range {
             eprintln!("[rag] temporal regex: {} to {}", r.from, r.to);
-            StepTimer::start("temporal", None).finish(
-                &mut rag_trace,
-                None,
-                None,
-                StepOutcome::Skipped,
-            );
-            Some(r)
         }
-        None => {
-            let timer =
-                StepTimer::start("temporal", Some(ai.chat_model_name()));
-            let r = detect_temporal_llm(&ai, retrieval_q).await;
-            timer.finish(
-                &mut rag_trace,
-                Some(estimate_tokens(retrieval_q)),
-                None,
-                StepOutcome::Ok,
-            );
-            if let Some(ref r) = r {
-                eprintln!("[rag] temporal LLM: {} to {}", r.from, r.to);
-            }
-            r
-        }
-    };
+    }
 
     let _ = store.ensure_fts_index().await;
-    let embed_timer = StepTimer::start("embed", Some(EMBEDDING_MODEL));
-    let query_vector = ai.embed(retrieval_q).await?;
-    embed_timer.finish(
-        &mut rag_trace,
-        Some(estimate_tokens(retrieval_q)),
-        None,
-        StepOutcome::Ok,
-    );
+
+    // The LLM date fallback only fires on a first message with no regex hit (a follow-up's
+    // prep call already judged dates). It used to serialize ~2.5s before embed; now the two
+    // run concurrently and the wall clock pays only the slower of them. The date filter
+    // applies after search and fetch_k is decided after this join, so nothing downstream
+    // needs the range earlier.
+    let needs_temporal_llm = date_range.is_none() && history.is_empty();
+    let temporal_fut = async {
+        if !needs_temporal_llm {
+            return (None, 0u64);
+        }
+        let started = std::time::Instant::now();
+        let r = detect_temporal_llm(&ai, retrieval_q).await;
+        (r, started.elapsed().as_millis() as u64)
+    };
+    let embed_fut = async {
+        let started = std::time::Instant::now();
+        let r = ai.embed(retrieval_q).await;
+        (r, started.elapsed().as_millis() as u64)
+    };
+    let ((llm_range, temporal_ms), (embed_res, embed_ms)) =
+        tokio::join!(temporal_fut, embed_fut);
+    rag_trace.push(TraceStep {
+        step: "temporal".to_string(),
+        model: needs_temporal_llm.then(|| CHEAP_MODEL.to_string()),
+        tokens_in: needs_temporal_llm.then(|| estimate_tokens(retrieval_q)),
+        tokens_out: None,
+        approx: true,
+        latency_ms: temporal_ms,
+        retries: 0,
+        outcome: if needs_temporal_llm {
+            StepOutcome::Ok
+        } else {
+            StepOutcome::Skipped
+        },
+    });
+    rag_trace.push(TraceStep {
+        step: "embed".to_string(),
+        model: Some(EMBEDDING_MODEL.to_string()),
+        tokens_in: Some(estimate_tokens(retrieval_q)),
+        tokens_out: None,
+        approx: true,
+        latency_ms: embed_ms,
+        retries: 0,
+        outcome: StepOutcome::Ok,
+    });
+    let query_vector = embed_res?;
+    if date_range.is_none() {
+        date_range = llm_range;
+        if let Some(ref r) = date_range {
+            eprintln!("[rag] temporal LLM: {} to {}", r.from, r.to);
+        }
+    }
     let fetch_k = if date_range.is_some() {
         RAG_INITIAL_K * 3
     } else {

--- a/src/application/rag/rerank.rs
+++ b/src/application/rag/rerank.rs
@@ -1,4 +1,4 @@
-use crate::application::constants::RELEVANCE_FILTER_PROMPT;
+use crate::application::constants::{CHEAP_MODEL, RELEVANCE_FILTER_PROMPT};
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::vectordb::SearchResult;
 use std::collections::HashSet;
@@ -47,7 +47,12 @@ pub(super) async fn llm_relevance_filter(
 
     let user_msg = format!("Question: {question}\n\nPassages:\n{passages}");
 
-    let response = match llm.chat(RELEVANCE_FILTER_PROMPT, &user_msg).await {
+    // The judge reads short previews and returns indices: the cheap tier handles that,
+    // and this call sits on the serial path of every question.
+    let response = match llm
+        .chat_with_model(CHEAP_MODEL, RELEVANCE_FILTER_PROMPT, &user_msg)
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             eprintln!(

--- a/src/application/rag/rewrite.rs
+++ b/src/application/rag/rewrite.rs
@@ -1,6 +1,7 @@
+use super::temporal::{range_from_strs, DateRange};
 use crate::application::ai::char_prefix;
 use crate::application::constants::{
-    CHAT_HISTORY_TURNS, CHEAP_MODEL, QUERY_REWRITE_PROMPT,
+    CHAT_HISTORY_TURNS, CHEAP_MODEL, QUERY_PREP_PROMPT,
 };
 use crate::infrastructure::llm::LlmClient;
 
@@ -62,21 +63,60 @@ pub fn sanitize_rewrite(raw: &str, fallback: &str) -> String {
     }
 }
 
-/// Condense (history + question) into a standalone retrieval query via the cheap model.
-/// Any failure falls back to the raw question - the rewriter must never break the chat.
-pub async fn rewrite_query(
+/// Parse the prep model's JSON into (standalone query, optional from/to date strings).
+/// Tolerates code fences; plain-text output degrades to a bare rewrite; anything
+/// unusable falls back to the raw question.
+pub fn parse_prep(
+    raw: &str,
+    fallback: &str,
+) -> (String, Option<(String, String)>) {
+    let cleaned = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(cleaned) else {
+        return (sanitize_rewrite(raw, fallback), None);
+    };
+    let query = v
+        .get("query")
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_rewrite(s, fallback))
+        .unwrap_or_else(|| fallback.to_string());
+    let range = match (
+        v.get("from").and_then(|x| x.as_str()),
+        v.get("to").and_then(|x| x.as_str()),
+    ) {
+        (Some(f), Some(t)) => Some((f.to_string(), t.to_string())),
+        _ => None,
+    };
+    (query, range)
+}
+
+/// One cheap-model call turns (history + question) into a standalone retrieval query
+/// AND the temporal intent - the follow-up path pays a single round-trip instead of
+/// two. Any failure falls back to the raw question with no dates: prep must never
+/// break the chat.
+pub(super) async fn prep_query(
     ai: &LlmClient,
     history: &[ChatTurn],
     question: &str,
-) -> String {
+) -> (String, Option<DateRange>) {
     let Some(input) = build_rewrite_input(history, question) else {
-        return question.to_string();
+        return (question.to_string(), None);
     };
+    let today = chrono::Local::now().date_naive();
+    let msg = format!("Today: {today}\n{input}");
     match ai
-        .chat_with_model(CHEAP_MODEL, QUERY_REWRITE_PROMPT, &input)
+        .chat_with_model(CHEAP_MODEL, QUERY_PREP_PROMPT, &msg)
         .await
     {
-        Ok(raw) => sanitize_rewrite(&raw, question),
-        Err(_) => question.to_string(),
+        Ok(raw) => {
+            let (query, dates) = parse_prep(&raw, question);
+            let range = dates.and_then(|(f, t)| range_from_strs(&f, &t));
+            (query, range)
+        }
+        Err(_) => (question.to_string(), None),
     }
 }

--- a/src/application/rag/temporal.rs
+++ b/src/application/rag/temporal.rs
@@ -1,4 +1,4 @@
-use crate::application::constants::TEMPORAL_DETECT_PROMPT;
+use crate::application::constants::{CHEAP_MODEL, TEMPORAL_DETECT_PROMPT};
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::vectordb::SearchResult;
 use chrono::{Datelike, Local, NaiveDate};
@@ -99,13 +99,23 @@ pub(super) fn detect_temporal_regex(question: &str) -> Option<DateRange> {
     None
 }
 
+/// Build a range from "YYYY-MM-DD" strings; shared with the query-prep parser.
+pub(super) fn range_from_strs(from: &str, to: &str) -> Option<DateRange> {
+    let from = NaiveDate::parse_from_str(from, "%Y-%m-%d").ok()?;
+    let to = NaiveDate::parse_from_str(to, "%Y-%m-%d").ok()?;
+    Some(DateRange { from, to })
+}
+
 pub(super) async fn detect_temporal_llm(
     llm: &LlmClient,
     question: &str,
 ) -> Option<DateRange> {
     let today = Local::now().date_naive();
     let user_msg = format!("Today: {today}\nQuestion: {question}");
-    let response = match llm.chat(TEMPORAL_DETECT_PROMPT, &user_msg).await {
+    let response = match llm
+        .chat_with_model(CHEAP_MODEL, TEMPORAL_DETECT_PROMPT, &user_msg)
+        .await
+    {
         Ok(r) => r,
         Err(_) => return None,
     };
@@ -116,9 +126,7 @@ pub(super) async fn detect_temporal_llm(
     let parsed: serde_json::Value = serde_json::from_str(trimmed).ok()?;
     let from_str = parsed.get("from")?.as_str()?;
     let to_str = parsed.get("to")?.as_str()?;
-    let from = NaiveDate::parse_from_str(from_str, "%Y-%m-%d").ok()?;
-    let to = NaiveDate::parse_from_str(to_str, "%Y-%m-%d").ok()?;
-    Some(DateRange { from, to })
+    range_from_strs(from_str, to_str)
 }
 
 pub(super) fn apply_date_filter(

--- a/tests/rag_rewrite_test.rs
+++ b/tests/rag_rewrite_test.rs
@@ -93,3 +93,68 @@ fn sanitize_trims_quotes_and_whitespace() {
         "notes sur Jean"
     );
 }
+
+// --- parse_prep: the merged rewrite+temporal call's JSON parser ---
+
+use flowflow::application::rag::parse_prep;
+
+#[test]
+fn parse_prep_reads_query_and_dates() {
+    let raw =
+        r#"{"query":"notes budget","from":"2026-05-05","to":"2026-05-11"}"#;
+    let (q, dates) = parse_prep(raw, "fallback");
+    assert_eq!(q, "notes budget");
+    assert_eq!(
+        dates,
+        Some(("2026-05-05".to_string(), "2026-05-11".to_string()))
+    );
+}
+
+#[test]
+fn parse_prep_null_dates_mean_no_range() {
+    let raw = r#"{"query":"qui est Jean ?","from":null,"to":null}"#;
+    let (q, dates) = parse_prep(raw, "et lui ?");
+    assert_eq!(q, "qui est Jean ?");
+    assert_eq!(dates, None);
+}
+
+#[test]
+fn parse_prep_tolerates_code_fences() {
+    let raw = "```json\n{\"query\":\"notes sur Jean\",\"from\":null,\"to\":null}\n```";
+    let (q, dates) = parse_prep(raw, "et lui ?");
+    assert_eq!(q, "notes sur Jean");
+    assert_eq!(dates, None);
+}
+
+#[test]
+fn parse_prep_plain_text_degrades_to_bare_rewrite() {
+    let (q, dates) = parse_prep("notes sur Jean", "et lui ?");
+    assert_eq!(q, "notes sur Jean");
+    assert_eq!(dates, None);
+}
+
+#[test]
+fn parse_prep_garbage_falls_back_to_question() {
+    let (q, dates) = parse_prep("", "et lui ?");
+    assert_eq!(q, "et lui ?");
+    assert_eq!(dates, None);
+
+    let (q, dates) = parse_prep(r#"{"nope":1}"#, "et lui ?");
+    assert_eq!(q, "et lui ?");
+    assert_eq!(dates, None);
+}
+
+#[test]
+fn parse_prep_partial_dates_are_ignored() {
+    let raw = r#"{"query":"notes budget","from":"2026-05-05","to":null}"#;
+    let (q, dates) = parse_prep(raw, "fallback");
+    assert_eq!(q, "notes budget");
+    assert_eq!(dates, None, "a half range is no range");
+}
+
+#[test]
+fn parse_prep_empty_query_field_falls_back() {
+    let raw = r#"{"query":"","from":null,"to":null}"#;
+    let (q, _) = parse_prep(raw, "et lui ?");
+    assert_eq!(q, "et lui ?");
+}


### PR DESCRIPTION
## RAG pipeline: one prep call, parallel temporal, cheap judge

Follow-up to #97 (this commit landed on `development` right after that merge).
The optimizations the execution trace was built to justify:

- Follow-ups: a single cheap "query prep" call returns the standalone retrieval
  query AND the temporal intent as one JSON, replacing the separate rewrite +
  temporal calls.
- First messages: the temporal LLM fallback runs concurrently with embed
  instead of before it; `fetch_k` is decided after the join, the date filter
  still applies post-search unchanged.
- Relevance judge + temporal detection move to the cheap model.

Trace step `rewrite` becomes `prep` (skip on first message, ok on follow-ups).
Device-measured on iPhone: follow-up 8.8s vs ~10-11s before, answers unchanged.
Tests: parse_prep suite (7) added; full suite green (65 binaries, 0 failures).

https://claude.ai/code/session_01L2GVyWrNfqkUdEaWUofGQB
