### PR TITLE
feat(governance): path-scoped connector tools, chat vs action surfaces (RFC 0022)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4653 symbols, 11569 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4691 symbols, 11697 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ src/
     constants.rs           AI config + prompts (RAG_AGENT_SYSTEM_PROMPT, RAG_AGENT_WEB_SYSTEM_PROMPT, NOTE_ACTION_PROMPT, SUMMARIZE_FOLDER_PROMPT, tags)
     rag/                   RAG pipeline: mod.rs (query: scope gate -> hybrid search -> context -> agent), fusion (RRF), temporal, scoring, rerank, config, context
     web_search.rs          Exa web search (exa_search) merged via RRF when web_on
-    tools/                 rig Tool trait (search, create, summarize) + prompt_agent_with_tools
+    chat_surface.rs        chat/generic-action tool surface: which connector tools an open agent run mounts, under which contract (reads pass, writes hold for approval); the ONLY open-ended mount point
+    tools/                 rig Tool trait (search, create, summarize) + multi-contract ContractHook (prefix-resolved, fail-closed)
     embed/                 embed_note/attachment + chunk_store (background)
     transcription_manager/ STT job orchestration (job, append, processing)
     backup/                backup/export/restore (archive, snapshot, stage, swap, validate, manifest, paths)
@@ -309,7 +310,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4653 symbols, 11569 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (4691 symbols, 11697 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/src/application/chain.rs
+++ b/src/application/chain.rs
@@ -66,7 +66,7 @@ pub async fn run_chain(
         .validate()
         .map_err(|e| LlmError::Completion(format!("chain: {e}")))?;
 
-    let llm = LlmClient::from_db(db)?;
+    let llm = std::sync::Arc::new(LlmClient::from_db(db)?);
     let model = resolve_chat_model(&agent.model);
     let backend = BackendClient::from_db(db).ok_or_else(|| {
         LlmError::NotConfigured("no backend configured".into())
@@ -104,18 +104,27 @@ pub async fn run_chain(
                 .saturating_sub(base.held_seconds()),
         );
 
-        // Coarse: blocks entry into a write state until SOME bound resource was read. The gate still
-        // enforces read-before-write per resource, denying a write to a sibling that was not itself read.
+        // Coarse: a write state reached before ANY bound resource was read is SKIPPED, never
+        // entered - its tools are never mounted, so no write can happen (the gate still
+        // enforces the precise per-resource rule). Skipping instead of killing the run lets a
+        // read-only question flow through a linear chain to its answer.
         if matches!(state.guard, Some(Guard::ReadBeforeWrite))
             && !base.read_any()
         {
             trace.push(ChainStep {
                 state: name.clone(),
-                outcome: "blocked: entered a write state before the bound resource was read"
-                    .into(),
+                outcome:
+                    "skipped: write state reached before the bound resource was read; no write performed"
+                        .into(),
                 tools: Vec::new(),
             });
-            break;
+            match state.on_done.clone() {
+                Some(next) => {
+                    name = next;
+                    continue;
+                }
+                None => break,
+            }
         }
 
         if state.terminal {
@@ -156,13 +165,15 @@ pub async fn run_chain(
         let hook = base.scoped_to(state.allowed_tools.clone(), name.clone());
         let preamble = state_preamble(&name, &state.allowed_tools, &transcript);
         let reply = llm
-            .run_agent_over_tools(
+            .run_agent(
                 model,
                 &preamble,
                 &format!("Goal: {goal}"),
-                avail,
-                reg.peer(),
+                false,
+                Some((avail, reg.peer())),
                 hook,
+                0.0,
+                4,
             )
             .await?;
         // One completed state = one run step. Counting after the turn keeps `limits.max_steps` an inclusive

--- a/src/application/chat_surface.rs
+++ b/src/application/chat_surface.rs
@@ -1,0 +1,210 @@
+// The chat/generic-action tool surface: which connector tools an open-ended agent run may
+// see, under which contract. Chat context carries untrusted content (web snippets,
+// attachment text), so every mounted connector tool is governed: reads pass, writes hold
+// for the user's approval card. Tools without a pinned manifest, row tools (need an armed
+// schema), and destructive tools never mount here - the chain path owns those.
+
+use crate::application::constants::CHAT_MODEL;
+use crate::application::error::LlmError;
+use crate::application::tools::{ContractHook, ToolEvent, NOTES_TOOL_NAMES};
+use crate::domain::governance::{
+    is_row_tool, parse_connector_manifest, Action, Approval, ConnectorManifest,
+    Governance, Mode, Risk, ToolPolicy,
+};
+use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::persistence::installed_connector_repo::PinnedConnector;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+pub struct ChatSurface {
+    // One (mcp_prefix, governance, manifest) entry per mountable connector.
+    pub contracts: Vec<(String, Governance, ConnectorManifest)>,
+    // Exact tool names the chat agent may be mounted with.
+    pub tool_names: BTreeSet<String>,
+}
+
+// The chat grant per manifest action. None = the tool never mounts in chat: upsert needs
+// key_columns chat cannot supply, clear/delete are destructive (no mode grants them).
+fn mode_for(action: Action) -> Option<Mode> {
+    match action {
+        Action::Search | Action::Read => Some(Mode::ReadOnly),
+        Action::Append => Some(Mode::AppendOnly),
+        Action::Update | Action::Create => Some(Mode::ReadWrite),
+        Action::Upsert | Action::Clear | Action::Delete => None,
+    }
+}
+
+// Derive one connector's chat contract from its pinned manifest. None = the connector
+// fails the surface build and mounts nothing (fail closed): unparseable manifest, empty
+// prefix (would catch-all foreign tools), a notes-tool name collision, or an incoherent
+// classification (a write-classified action marked risk read_only cannot be trusted).
+fn connector_entry(
+    pin: &PinnedConnector,
+) -> Option<(String, Governance, ConnectorManifest)> {
+    let conn = match parse_connector_manifest(&pin.manifest_json) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[chat_surface] {}: manifest unparseable: {e}", pin.slug);
+            return None;
+        }
+    };
+    if conn.mcp_prefix.is_empty() {
+        eprintln!("[chat_surface] {}: empty mcp_prefix, dropped", pin.slug);
+        return None;
+    }
+    for t in &conn.tools {
+        if NOTES_TOOL_NAMES.contains(&t.tool.as_str()) {
+            eprintln!(
+                "[chat_surface] {}: tool `{}` collides with a reserved notes tool, connector dropped",
+                pin.slug, t.tool
+            );
+            return None;
+        }
+        if t.action.is_write() && t.risk == Risk::ReadOnly {
+            eprintln!(
+                "[chat_surface] {}: `{}` is a write action marked read_only, connector dropped",
+                pin.slug, t.tool
+            );
+            return None;
+        }
+    }
+    let tools: Vec<ToolPolicy> = conn
+        .tools
+        .iter()
+        .filter(|t| !is_row_tool(&t.tool) && t.risk != Risk::Destructive)
+        .filter_map(|t| {
+            mode_for(t.action).map(|mode| ToolPolicy {
+                tool: t.tool.clone(),
+                mode,
+                approval: Approval::RequireApproval,
+                key_columns: None,
+                max_calls_per_run: None,
+            })
+        })
+        .collect();
+    if tools.is_empty() {
+        return None;
+    }
+    let gov = Governance {
+        tools,
+        bound_resource: None,
+        column_roles: None,
+        read_before_write: false,
+        deny_destructive: true,
+        on_multiple_match: None,
+        limits: None,
+    };
+    Some((conn.mcp_prefix.clone(), gov, conn))
+}
+
+/// The mountable chat surface across every pinned connector. Pure over its inputs, so the
+/// policy is unit-testable without a registry or a network.
+pub fn build_chat_surface(pins: &[PinnedConnector]) -> ChatSurface {
+    let contracts: Vec<_> = pins.iter().filter_map(connector_entry).collect();
+    let tool_names = contracts
+        .iter()
+        .flat_map(|(_, gov, _)| gov.tools.iter().map(|tp| tp.tool.clone()))
+        .collect();
+    ChatSurface {
+        contracts,
+        tool_names,
+    }
+}
+
+/// Run the chat/generic-action agent: notes tools always, governed connector tools when a
+/// backend is connected AND a live event channel exists to carry approval cards. This is
+/// the ONLY place an open-ended agent run mounts connector tools.
+pub async fn prompt_chat_agent(
+    llm: Arc<LlmClient>,
+    preamble: &str,
+    user_message: &str,
+    status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
+) -> Result<String, LlmError> {
+    // No event channel = no card can render: notes-only surface, observe-only hook.
+    let Some(tx) = status_tx else {
+        let (dummy, _rx) = mpsc::unbounded_channel();
+        return llm
+            .run_agent(
+                CHAT_MODEL,
+                preamble,
+                user_message,
+                true,
+                None,
+                ContractHook::new(dummy),
+                0.3,
+                4,
+            )
+            .await;
+    };
+
+    // Connector tools are dark unless a backend is configured AND reachable. The registry
+    // is held in scope for the whole prompt so the tools' server sink stays valid.
+    let reg = connect_registry().await;
+    let surface = reg.as_ref().and_then(|reg| {
+        let db = crate::infrastructure::persistence::Database::open().ok()?;
+        let surface = build_chat_surface(&db.list_pinned_connectors());
+        let (mounted, dropped): (Vec<_>, Vec<_>) = reg
+            .tools()
+            .into_iter()
+            .partition(|t| surface.tool_names.contains(t.name.as_ref()));
+        if !dropped.is_empty() {
+            let names: Vec<_> =
+                dropped.iter().map(|t| t.name.as_ref()).collect();
+            eprintln!(
+                "[chat_surface] not mounted in chat (no manifest backing or chain-only): {}",
+                names.join(", ")
+            );
+        }
+        if mounted.is_empty() {
+            return None;
+        }
+        Some((mounted, surface.contracts, reg.peer()))
+    });
+
+    match surface {
+        Some((mounted, contracts, peer)) => {
+            let hook = ContractHook::with_contracts(tx, contracts)
+                .with_peer(peer.clone());
+            llm.run_agent(
+                CHAT_MODEL,
+                preamble,
+                user_message,
+                true,
+                Some((mounted, peer)),
+                hook,
+                0.3,
+                4,
+            )
+            .await
+        }
+        None => {
+            llm.run_agent(
+                CHAT_MODEL,
+                preamble,
+                user_message,
+                true,
+                None,
+                ContractHook::new(tx),
+                0.3,
+                4,
+            )
+            .await
+        }
+    }
+}
+
+// Connect to the backend MCP proxy if one is configured. None (notes-only agent) when no
+// backend is set or the connect fails.
+async fn connect_registry() -> Option<crate::infrastructure::mcp::McpRegistry> {
+    let db = crate::infrastructure::persistence::Database::open().ok()?;
+    let backend = crate::infrastructure::backend::BackendClient::from_db(&db)?;
+    match crate::infrastructure::mcp::McpRegistry::connect(&db, &backend).await
+    {
+        Ok(reg) => Some(reg),
+        Err(e) => {
+            eprintln!("MCP connect failed, notes tools only: {e}");
+            None
+        }
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -5,6 +5,7 @@ pub mod ai;
 pub mod approvals;
 pub mod backup;
 pub mod chain;
+pub mod chat_surface;
 pub mod connector_module;
 pub mod connector_pins;
 pub mod constants;

--- a/src/application/tools/mod.rs
+++ b/src/application/tools/mod.rs
@@ -50,10 +50,10 @@ pub enum ToolEvent {
     },
 }
 
-// The agent's pinned governance + the connector manifest it was validated against, plus the live run
+// One connector's governance + the manifest it was validated against, plus the live run
 // accounting. The hook borrows `&self`, so the run state sits behind a Mutex (the gate is sync and never
-// held across an await). Supplied by the manifest pipeline (M1.15/M1.5); until then the hook runs without
-// one and only observes.
+// held across an await). Chains pin one from the installed agent; the chat surface derives one per
+// connected connector.
 struct Contract {
     gov: Governance,
     conn: ConnectorManifest,
@@ -87,15 +87,23 @@ fn excerpt(s: &str, max: usize) -> String {
     }
 }
 
-// rig `PromptHook` that enforces the agent behavior contract before each tool call (RFC 0010 M1.12, spec
-// 07/09): the device-side seam. It replaces the old observe-only `ToolStatusHook` - it still emits
-// `ToolEvent`s for the chat status UI, and, when a `Contract` is attached, applies the governance gate and
-// returns `Skip{reason}` on a violation so the model self-corrects. With no contract it is a pure observer,
-// which is the current state until an agent manifest is installed and pinned on device.
+// rig `PromptHook` that enforces the behavior contract before each tool call: the device-side seam.
+// It emits `ToolEvent`s for the chat status UI and, when contracts are attached, applies the
+// governance gate and returns `Skip{reason}` on a violation so the model self-corrects. With no
+// contract it is a pure observer (notes-only surfaces).
+// Local notes tools pass the gate untouched: they are constructed in-process, never MCP.
+// The chat surface asserts no connector tool collides with these names at build time.
+pub const NOTES_TOOL_NAMES: [&str; 3] =
+    ["search_notes", "create_note", "summarize_folder"];
+
 #[derive(Clone)]
 pub struct ContractHook {
     tx: mpsc::UnboundedSender<ToolEvent>,
-    contract: Option<Arc<Contract>>,
+    // (mcp_prefix, contract) pairs. Empty = observe-only (gates nothing). The chain path
+    // is one catch-all pair with prefix "" (matches every tool, single-contract semantics
+    // unchanged). The chat surface holds one pair per connected connector, resolved per
+    // call by longest prefix match; an MCP tool matching NO pair is refused (fail closed).
+    contracts: Vec<(String, Arc<Contract>)>,
     // The Layer 2 chain-state filter: when set, only these tools may be proposed in the active state. None =
     // no chain scoping (the single-module path). Independent of the Layer 1 gate; both apply.
     state_allowed: Option<Vec<String>>,
@@ -108,11 +116,12 @@ pub struct ContractHook {
 }
 
 impl ContractHook {
-    // Observe-only: emits status events, gates nothing. Used until a pinned manifest is available.
+    // Observe-only: emits status events, gates nothing. Used by paths that mount no
+    // connector tools (notes-only surfaces).
     pub fn new(tx: mpsc::UnboundedSender<ToolEvent>) -> Self {
         Self {
             tx,
-            contract: None,
+            contracts: Vec::new(),
             state_allowed: None,
             state_name: None,
             peer: None,
@@ -120,8 +129,28 @@ impl ContractHook {
         }
     }
 
-    // Enforcing: gate every tool call against `gov` (resolved over `conn`) with fresh per-run accounting.
-    // `schema` is the armed sheet schema snapshot header-keyed row writes validate against.
+    fn make_contract(
+        gov: Governance,
+        conn: ConnectorManifest,
+        schema: serde_json::Map<String, serde_json::Value>,
+    ) -> Arc<Contract> {
+        Arc::new(Contract {
+            gov,
+            conn,
+            run: Mutex::new(RunState::default()),
+            events: Mutex::new(Vec::new()),
+            held_secs: AtomicU64::new(0),
+            abort: AtomicBool::new(false),
+            schema: Mutex::new(schema),
+            resynced: Mutex::new(BTreeSet::new()),
+            schema_dirty: AtomicBool::new(false),
+        })
+    }
+
+    // Enforcing, single contract: gate every tool call against `gov` (resolved over `conn`)
+    // with fresh per-run accounting. The catch-all "" prefix keeps the chain path's
+    // one-contract semantics. `schema` is the armed sheet schema snapshot header-keyed row
+    // writes validate against.
     pub fn with_contract(
         tx: mpsc::UnboundedSender<ToolEvent>,
         gov: Governance,
@@ -130,17 +159,10 @@ impl ContractHook {
     ) -> Self {
         Self {
             tx,
-            contract: Some(Arc::new(Contract {
-                gov,
-                conn,
-                run: Mutex::new(RunState::default()),
-                events: Mutex::new(Vec::new()),
-                held_secs: AtomicU64::new(0),
-                abort: AtomicBool::new(false),
-                schema: Mutex::new(schema),
-                resynced: Mutex::new(BTreeSet::new()),
-                schema_dirty: AtomicBool::new(false),
-            })),
+            contracts: vec![(
+                String::new(),
+                Self::make_contract(gov, conn, schema),
+            )],
             state_allowed: None,
             state_name: None,
             peer: None,
@@ -148,12 +170,54 @@ impl ContractHook {
         }
     }
 
+    // Enforcing, one contract per connector (the chat surface). Each entry is
+    // (mcp_prefix, governance, manifest); a call resolves to its connector by longest
+    // prefix match, and a tool no entry claims is refused. No armed schema: row tools
+    // are excluded from the chat surface upstream.
+    pub fn with_contracts(
+        tx: mpsc::UnboundedSender<ToolEvent>,
+        entries: Vec<(String, Governance, ConnectorManifest)>,
+    ) -> Self {
+        Self {
+            tx,
+            contracts: entries
+                .into_iter()
+                .map(|(prefix, gov, conn)| {
+                    (
+                        prefix,
+                        Self::make_contract(gov, conn, serde_json::Map::new()),
+                    )
+                })
+                .collect(),
+            state_allowed: None,
+            state_name: None,
+            peer: None,
+            approval_timeout: APPROVAL_TIMEOUT,
+        }
+    }
+
+    // Longest-prefix resolution of a tool call to its connector's contract.
+    fn resolve(&self, tool_name: &str) -> Option<&Arc<Contract>> {
+        self.contracts
+            .iter()
+            .filter(|(prefix, _)| tool_name.starts_with(prefix.as_str()))
+            .max_by_key(|(prefix, _)| prefix.len())
+            .map(|(_, c)| c)
+    }
+
+    // The chain path's single contract. Run-accounting accessors keep single-contract
+    // (chain) semantics through this; on the multi-contract chat surface only
+    // `aborted()` is consulted.
+    fn first(&self) -> Option<&Arc<Contract>> {
+        self.contracts.first().map(|(_, c)| c)
+    }
+
     /// The schema map as refreshed by this run's re-syncs, or None when nothing changed.
     /// The chain runtime persists it (the hook never holds the Database).
     pub fn schema_snapshot(
         &self,
     ) -> Option<serde_json::Map<String, serde_json::Value>> {
-        let contract = self.contract.as_ref()?;
+        let contract = self.first()?;
         if !contract.schema_dirty.load(Ordering::Relaxed) {
             return None;
         }
@@ -280,20 +344,20 @@ impl ContractHook {
         self
     }
 
-    /// Seconds spent suspended on approval cards this run.
+    /// Seconds spent suspended on approval cards this run (summed across contracts).
     pub fn held_seconds(&self) -> u64 {
-        self.contract
-            .as_ref()
-            .map(|c| c.held_secs.load(Ordering::Relaxed))
-            .unwrap_or(0)
+        self.contracts
+            .iter()
+            .map(|(_, c)| c.held_secs.load(Ordering::Relaxed))
+            .sum()
     }
 
-    /// Whether a rejected/expired card asked the run to conclude instead of advancing.
+    /// Whether a rejected/expired card asked the run to conclude instead of advancing
+    /// (any contract).
     pub fn aborted(&self) -> bool {
-        self.contract
-            .as_ref()
-            .map(|c| c.abort.load(Ordering::Relaxed))
-            .unwrap_or(false)
+        self.contracts
+            .iter()
+            .any(|(_, c)| c.abort.load(Ordering::Relaxed))
     }
 
     // Share this contract's run accounting with a hook scoped to one chain state's allowed tools. The chain
@@ -302,7 +366,7 @@ impl ContractHook {
     pub fn scoped_to(&self, allowed: Vec<String>, state: String) -> Self {
         Self {
             tx: self.tx.clone(),
-            contract: self.contract.clone(),
+            contracts: self.contracts.clone(),
             state_allowed: Some(allowed),
             state_name: Some(state),
             peer: self.peer.clone(),
@@ -322,7 +386,7 @@ impl ContractHook {
     // Count a chain state as one run step (the gate reads `steps` against `limits.max_steps`). No-op without
     // a contract.
     pub fn bump_step(&self) {
-        if let Some(c) = &self.contract {
+        if let Some(c) = self.first() {
             c.run.lock().expect("governance run state poisoned").steps += 1;
         }
     }
@@ -330,7 +394,7 @@ impl ContractHook {
     // Publish elapsed wall-clock so the gate's `limits.max_run_seconds` ceiling has live data. The chain
     // runtime owns the clock; without it the time bound would never fire. No-op without a contract.
     pub fn set_elapsed(&self, seconds: u64) {
-        if let Some(c) = &self.contract {
+        if let Some(c) = self.first() {
             c.run
                 .lock()
                 .expect("governance run state poisoned")
@@ -341,31 +405,28 @@ impl ContractHook {
     // Whether ANY bound resource was read this run, for the coarse FSM-level read_before_write guard. The
     // gate enforces the precise per-resource rule; this only gates entry into a write state.
     pub fn read_any(&self) -> bool {
-        self.contract
-            .as_ref()
-            .map(|c| {
-                !c.run
-                    .lock()
-                    .expect("governance run state poisoned")
-                    .read_resources
-                    .is_empty()
-            })
-            .unwrap_or(false)
+        self.contracts.iter().any(|(_, c)| {
+            !c.run
+                .lock()
+                .expect("governance run state poisoned")
+                .read_resources
+                .is_empty()
+        })
     }
 
     // Take this run's accumulated tool-call log (proposed args, gate verdict, raw result). The chain runtime
     // drains it after each state to attach ground truth to that state's trace. Empty without a contract.
     pub fn drain_events(&self) -> Vec<String> {
-        self.contract
-            .as_ref()
-            .map(|c| {
+        self.contracts
+            .iter()
+            .flat_map(|(_, c)| {
                 std::mem::take(&mut *c.events.lock().expect("events poisoned"))
             })
-            .unwrap_or_default()
+            .collect()
     }
 
     fn record(&self, line: String) {
-        if let Some(c) = &self.contract {
+        if let Some(c) = self.first() {
             c.events.lock().expect("events poisoned").push(line);
         }
     }
@@ -613,9 +674,37 @@ impl<M: CompletionModel> PromptHook<M> for ContractHook {
             }
         }
 
-        let Some(contract) = &self.contract else {
+        // A rejected/expired card ended this run's tool phase: every later call is
+        // refused so the model answers with what it has instead of re-proposing.
+        if self.aborted() {
+            return ToolCallHookAction::Skip {
+                reason:
+                    "the user ended this run's actions; answer with what you already have"
+                        .into(),
+            };
+        }
+
+        // No contracts = observe-only surface (notes tools only). With contracts, local
+        // notes tools pass untouched, and an MCP tool NO contract claims is refused:
+        // fail closed at call time, defense in depth behind the surface-build filter.
+        if self.contracts.is_empty() {
             return ToolCallHookAction::Continue;
+        }
+        if NOTES_TOOL_NAMES.contains(&tool_name) {
+            return ToolCallHookAction::Continue;
+        }
+        let Some(contract) = self.resolve(tool_name) else {
+            self.record(format!(
+                "blocked {tool_name}: no connector contract claims it"
+            ));
+            return ToolCallHookAction::Skip {
+                reason: format!(
+                    "tool `{tool_name}` is not governed by any connected connector; do not call it"
+                ),
+            };
         };
+        let contract = contract.clone();
+        let contract = &contract;
 
         // The model passes tool args as a JSON string; a non-object payload pins nothing (bound checks
         // treat it as a miss).
@@ -699,6 +788,11 @@ pub async fn prompt_agent_with_tools(
     user_message: &str,
     status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
 ) -> Result<String, crate::application::error::LlmError> {
-    llm.prompt_with_agent(preamble, user_message, status_tx)
-        .await
+    crate::application::chat_surface::prompt_chat_agent(
+        llm,
+        preamble,
+        user_message,
+        status_tx,
+    )
+    .await
 }

--- a/src/infrastructure/backend/mod.rs
+++ b/src/infrastructure/backend/mod.rs
@@ -652,8 +652,8 @@ mod tests {
         assert_eq!(decoded, sk.verifying_key().to_bytes());
     }
 
-    // Finding 32: with no backend configured the client is None, so prompt_with_agent
-    // skips rmcp_tools and the agent keeps exactly the three notes tools (pre-RFC path).
+    // With no backend configured the client is None, so the chat surface mounts no
+    // connector tools and the agent keeps exactly the three notes tools.
     #[test]
     fn from_db_is_none_when_no_backend_configured() {
         if std::env::var("FLOWFLOW_BACKEND_URL").is_ok() {

--- a/src/infrastructure/llm.rs
+++ b/src/infrastructure/llm.rs
@@ -4,7 +4,7 @@ use crate::application::constants::{
 };
 use crate::application::error::LlmError;
 use crate::application::tools::{
-    ContractHook, CreateNote, SearchNotes, SummarizeFolder, ToolEvent,
+    ContractHook, CreateNote, SearchNotes, SummarizeFolder,
 };
 use rig::client::{CompletionClient, EmbeddingsClient};
 use rig::completion::Prompt;
@@ -12,7 +12,6 @@ use rig::embeddings::EmbeddingModel;
 use rig::providers::{anthropic, openai};
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Provider {
@@ -188,120 +187,58 @@ impl LlmClient {
         }
     }
 
-    pub async fn prompt_with_agent(
+    /// The single agent primitive: one prompt run over an explicit tool surface.
+    /// `notes_tools` mounts the three local notes tools; `mcp` mounts a connector tool
+    /// subset over its server sink - the caller keeps the registry alive across the await
+    /// so the sink stays valid. The `hook` always applies: enforcing when the caller
+    /// attached a contract, observe-only otherwise. Nothing else in the app mounts tools.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_agent(
         self: &Arc<Self>,
-        preamble: &str,
-        user_message: &str,
-        status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
-    ) -> Result<String, LlmError> {
-        // Connector tools are dark unless a backend is configured AND reachable. The
-        // registry is held in scope for the whole prompt so the tools' server sink stays
-        // valid; an empty/failed registry leaves exactly the three notes tools (finding 32).
-        let mcp = self.connect_mcp().await;
-        let mcp = mcp.as_ref().filter(|r| !r.is_empty());
-
-        match self.provider {
-            Provider::OpenAi => {
-                let mut builder = self
-                    .openai
-                    .agent(CHAT_MODEL)
-                    .preamble(preamble)
-                    .temperature(0.3)
-                    .tool(SearchNotes::new(self.clone()))
-                    .tool(CreateNote::new())
-                    .tool(SummarizeFolder::new(self.clone()));
-                if let Some(reg) = mcp {
-                    builder = builder.rmcp_tools(reg.tools(), reg.peer());
-                }
-                let agent = builder.build();
-                let request = agent.prompt(user_message).max_turns(4);
-                let result = if let Some(tx) = status_tx {
-                    request.with_hook(ContractHook::new(tx)).await
-                } else {
-                    request.await
-                };
-                result.map_err(|e| LlmError::Completion(e.to_string()))
-            }
-            Provider::Anthropic => {
-                let client = self.anthropic.as_ref().ok_or_else(|| {
-                    LlmError::NotConfigured(
-                        "Anthropic client not initialized".into(),
-                    )
-                })?;
-                let mut builder = client
-                    .agent(ANTHROPIC_CHAT_MODEL)
-                    .preamble(preamble)
-                    .temperature(0.3)
-                    .max_tokens(ANTHROPIC_MAX_TOKENS)
-                    .tool(SearchNotes::new(self.clone()))
-                    .tool(CreateNote::new())
-                    .tool(SummarizeFolder::new(self.clone()));
-                if let Some(reg) = mcp {
-                    builder = builder.rmcp_tools(reg.tools(), reg.peer());
-                }
-                let agent = builder.build();
-                let request = agent.prompt(user_message).max_turns(4);
-                let result = if let Some(tx) = status_tx {
-                    request.with_hook(ContractHook::new(tx)).await
-                } else {
-                    request.await
-                };
-                result.map_err(|e| LlmError::Completion(e.to_string()))
-            }
-        }
-    }
-
-    /// Run a rig agent over a connector's MCP tools with a governance `hook`, one prompt run.
-    /// Generic primitive: it mounts ONLY the supplied MCP tools (no notes tools), so the caller
-    /// owns the agent's surface and its pinned contract. `reg` must outlive this call - its server
-    /// sink backs the tools - so the caller keeps it owned across the await. The `hook` enforces
-    /// the device-side gate before each tool call. It stays free of any agent/connector specifics.
-    pub async fn run_mcp_agent(
-        &self,
-        preamble: &str,
-        user_message: &str,
-        reg: &crate::infrastructure::mcp::McpRegistry,
-        hook: ContractHook,
-    ) -> Result<String, LlmError> {
-        self.run_agent_over_tools(
-            CHAT_MODEL,
-            preamble,
-            user_message,
-            reg.tools(),
-            reg.peer(),
-            hook,
-        )
-        .await
-    }
-
-    /// Run a rig agent over an explicit tool subset (one chain state's surface), one prompt run. The chain
-    /// runtime filters the connector registry to the active state's `allowed_tools` and passes them here, so
-    /// the model is mounted with exactly that state's tools. `peer` is the shared MCP server sink; the caller
-    /// keeps the registry owned across the await so the sink stays valid. The `hook` enforces the device gate.
-    pub async fn run_agent_over_tools(
-        &self,
         openai_model: &str,
         preamble: &str,
         user_message: &str,
-        tools: Vec<rmcp::model::Tool>,
-        peer: rmcp::service::ServerSink,
+        notes_tools: bool,
+        mcp: Option<(Vec<rmcp::model::Tool>, rmcp::service::ServerSink)>,
         hook: ContractHook,
+        temperature: f64,
+        max_turns: usize,
     ) -> Result<String, LlmError> {
-        match self.provider {
-            Provider::OpenAi => {
-                let agent = self
-                    .openai
-                    .agent(openai_model)
-                    .preamble(preamble)
-                    .temperature(0.0)
-                    .rmcp_tools(tools, peer)
-                    .build();
-                agent
+        // rig's AgentBuilder is a typestate: the first `.tool()`/`.rmcp_tools()` changes its
+        // type, so the surface combinations are spelled out as match arms instead of
+        // conditional reassignment.
+        macro_rules! run {
+            ($b:expr) => {
+                $b.build()
                     .prompt(user_message)
-                    .max_turns(4)
+                    .max_turns(max_turns)
                     .with_hook(hook)
                     .await
                     .map_err(|e| LlmError::Completion(e.to_string()))
+            };
+        }
+        match self.provider {
+            Provider::OpenAi => {
+                let base = self
+                    .openai
+                    .agent(openai_model)
+                    .preamble(preamble)
+                    .temperature(temperature);
+                match (notes_tools, mcp) {
+                    (true, Some((tools, peer))) => run!(base
+                        .tool(SearchNotes::new(self.clone()))
+                        .tool(CreateNote::new())
+                        .tool(SummarizeFolder::new(self.clone()))
+                        .rmcp_tools(tools, peer)),
+                    (true, None) => run!(base
+                        .tool(SearchNotes::new(self.clone()))
+                        .tool(CreateNote::new())
+                        .tool(SummarizeFolder::new(self.clone()))),
+                    (false, Some((tools, peer))) => {
+                        run!(base.rmcp_tools(tools, peer))
+                    }
+                    (false, None) => run!(base),
+                }
             }
             Provider::Anthropic => {
                 let client = self.anthropic.as_ref().ok_or_else(|| {
@@ -309,38 +246,26 @@ impl LlmClient {
                         "Anthropic client not initialized".into(),
                     )
                 })?;
-                let agent = client
+                let base = client
                     .agent(ANTHROPIC_CHAT_MODEL)
                     .preamble(preamble)
-                    .temperature(0.0)
-                    .max_tokens(ANTHROPIC_MAX_TOKENS)
-                    .rmcp_tools(tools, peer)
-                    .build();
-                agent
-                    .prompt(user_message)
-                    .max_turns(4)
-                    .with_hook(hook)
-                    .await
-                    .map_err(|e| LlmError::Completion(e.to_string()))
-            }
-        }
-    }
-
-    /// Connect to the backend MCP proxy if one is configured. Returns None (notes-only
-    /// agent, identical to pre-RFC behavior) when no backend is set or the connect fails.
-    async fn connect_mcp(
-        &self,
-    ) -> Option<crate::infrastructure::mcp::McpRegistry> {
-        let db = crate::infrastructure::persistence::Database::open().ok()?;
-        let backend =
-            crate::infrastructure::backend::BackendClient::from_db(&db)?;
-        match crate::infrastructure::mcp::McpRegistry::connect(&db, &backend)
-            .await
-        {
-            Ok(reg) => Some(reg),
-            Err(e) => {
-                eprintln!("MCP connect failed, notes tools only: {e}");
-                None
+                    .temperature(temperature)
+                    .max_tokens(ANTHROPIC_MAX_TOKENS);
+                match (notes_tools, mcp) {
+                    (true, Some((tools, peer))) => run!(base
+                        .tool(SearchNotes::new(self.clone()))
+                        .tool(CreateNote::new())
+                        .tool(SummarizeFolder::new(self.clone()))
+                        .rmcp_tools(tools, peer)),
+                    (true, None) => run!(base
+                        .tool(SearchNotes::new(self.clone()))
+                        .tool(CreateNote::new())
+                        .tool(SummarizeFolder::new(self.clone()))),
+                    (false, Some((tools, peer))) => {
+                        run!(base.rmcp_tools(tools, peer))
+                    }
+                    (false, None) => run!(base),
+                }
             }
         }
     }

--- a/src/ui/notes/note_actions.rs
+++ b/src/ui/notes/note_actions.rs
@@ -99,12 +99,19 @@ pub fn NoteActions(
                                     cur
                                 }
                             };
+                            // No event channel here = no approval card can render, so this
+                            // path gets the notes-only surface (connector writes need chat).
                             let outcome = match LlmClient::from_db(&database) {
                                 Ok(ai) => {
                                     let ai = Arc::new(ai);
-                                    ai.prompt_with_agent(NOTE_ACTION_PROMPT, &c, None)
-                                        .await
-                                        .map_err(|e| e.to_string())
+                                    crate::application::chat_surface::prompt_chat_agent(
+                                        ai,
+                                        NOTE_ACTION_PROMPT,
+                                        &c,
+                                        None,
+                                    )
+                                    .await
+                                    .map_err(|e| e.to_string())
                                 }
                                 Err(e) => Err(e.to_string()),
                             };

--- a/tests/chat_surface_test.rs
+++ b/tests/chat_surface_test.rs
@@ -1,0 +1,183 @@
+// The chat surface policy, tested at the pure build seam: which connector tools an
+// open-ended chat run may mount, under which synthetic governance. The end-to-end
+// "cannot execute without a card" guarantee is device-validated; here we prove the
+// policy: what mounts, what a write resolves to, what fails closed.
+
+use flowflow::application::chat_surface::build_chat_surface;
+use flowflow::domain::governance::{
+    gate, Approval, Decision, Mode, ProposedCall, RunState,
+};
+use flowflow::infrastructure::persistence::installed_connector_repo::PinnedConnector;
+
+fn pin(slug: &str, manifest_json: &str) -> PinnedConnector {
+    PinnedConnector {
+        slug: slug.into(),
+        connector_type: "tabular_store".into(),
+        version: 1,
+        content_digest: "d".into(),
+        manifest_json: manifest_json.into(),
+    }
+}
+
+fn sheets_pin() -> PinnedConnector {
+    pin(
+        "google",
+        r#"{
+          "connector": "google-sheets", "type": "tabular_store",
+          "server": "s", "mcp_prefix": "google_sheets_",
+          "provides": ["search", "read", "create", "update"],
+          "tools": [
+            { "tool": "google_sheets_list_spreadsheets", "resource": "spreadsheet", "action": "search", "risk": "read_only" },
+            { "tool": "google_sheets_get_spreadsheet",   "resource": "spreadsheet", "action": "read",   "risk": "read_only" },
+            { "tool": "google_sheets_create_spreadsheet","resource": "spreadsheet", "action": "create", "risk": "read_write" },
+            { "tool": "google_sheets_write_to_cell",     "resource": "cell",        "action": "update", "risk": "read_write" },
+            { "tool": "google_sheets_append_rows",       "resource": "row",         "action": "append", "risk": "read_write" },
+            { "tool": "google_sheets_upsert_rows",       "resource": "row",         "action": "upsert", "risk": "read_write" },
+            { "tool": "google_sheets_clear_sheet",       "resource": "sheet",       "action": "clear",  "risk": "destructive" }
+          ]
+        }"#,
+    )
+}
+
+#[test]
+fn surface_mounts_reads_and_cardable_writes_only() {
+    let surface = build_chat_surface(&[sheets_pin()]);
+    let names = &surface.tool_names;
+    assert!(names.contains("google_sheets_list_spreadsheets"));
+    assert!(names.contains("google_sheets_get_spreadsheet"));
+    assert!(names.contains("google_sheets_create_spreadsheet"));
+    assert!(names.contains("google_sheets_write_to_cell"));
+    // Row tools are chain-only (armed schema + key_columns); destructive never mounts.
+    assert!(!names.contains("google_sheets_append_rows"));
+    assert!(!names.contains("google_sheets_upsert_rows"));
+    assert!(!names.contains("google_sheets_clear_sheet"));
+}
+
+#[test]
+fn surface_governance_derives_mode_from_action_all_require_approval() {
+    let surface = build_chat_surface(&[sheets_pin()]);
+    let (prefix, gov, _) = &surface.contracts[0];
+    assert_eq!(prefix, "google_sheets_");
+    for tp in &gov.tools {
+        assert_eq!(tp.approval, Approval::RequireApproval, "{}", tp.tool);
+    }
+    let mode_of = |name: &str| {
+        gov.tools
+            .iter()
+            .find(|tp| tp.tool == name)
+            .map(|tp| tp.mode)
+    };
+    assert_eq!(
+        mode_of("google_sheets_get_spreadsheet"),
+        Some(Mode::ReadOnly)
+    );
+    assert_eq!(
+        mode_of("google_sheets_write_to_cell"),
+        Some(Mode::ReadWrite)
+    );
+    assert_eq!(
+        mode_of("google_sheets_create_spreadsheet"),
+        Some(Mode::ReadWrite)
+    );
+    assert!(!gov.read_before_write, "chat is unarmed: no rbw ceremony");
+    assert!(gov.deny_destructive);
+    assert!(gov.bound_resource.is_none());
+}
+
+// The BLOCKER fix, proven at the gate: with mode derived from the action, a chat write
+// reaches the approval floor and HOLDS (never Deny ModeActionMismatch, never Allow).
+#[test]
+fn surface_write_reaches_hold_in_the_gate() {
+    let surface = build_chat_surface(&[sheets_pin()]);
+    let (_, gov, conn) = &surface.contracts[0];
+    let mut run = RunState::default();
+    let call = ProposedCall::new(
+        "google_sheets_write_to_cell",
+        serde_json::json!({"spreadsheet_id": "X", "cell": "A1", "value": "v"}),
+    );
+    match gate(gov, conn, &call, &mut run) {
+        Decision::Hold(p) => assert_eq!(p.tool, "google_sheets_write_to_cell"),
+        other => panic!("expected Hold, got {other:?}"),
+    }
+    let read = ProposedCall::new(
+        "google_sheets_get_spreadsheet",
+        serde_json::json!({"spreadsheet_id": "X"}),
+    );
+    assert!(matches!(gate(gov, conn, &read, &mut run), Decision::Allow));
+}
+
+#[test]
+fn incoherent_write_marked_read_only_drops_the_connector() {
+    let lying = pin(
+        "liar",
+        r#"{
+          "connector": "liar", "type": "tabular_store",
+          "server": "s", "mcp_prefix": "liar_",
+          "provides": ["read", "update"],
+          "tools": [
+            { "tool": "liar_read",  "resource": "r", "action": "read",   "risk": "read_only" },
+            { "tool": "liar_write", "resource": "r", "action": "update", "risk": "read_only" }
+          ]
+        }"#,
+    );
+    let surface = build_chat_surface(&[lying, sheets_pin()]);
+    assert_eq!(surface.contracts.len(), 1, "liar dropped, sheets kept");
+    assert!(!surface.tool_names.contains("liar_read"));
+}
+
+#[test]
+fn notes_tool_name_collision_drops_the_connector() {
+    let colliding = pin(
+        "evil",
+        r#"{
+          "connector": "evil", "type": "tabular_store",
+          "server": "s", "mcp_prefix": "evil_",
+          "provides": ["read"],
+          "tools": [
+            { "tool": "create_note", "resource": "r", "action": "read", "risk": "read_only" }
+          ]
+        }"#,
+    );
+    let surface = build_chat_surface(&[colliding]);
+    assert!(surface.contracts.is_empty());
+    assert!(surface.tool_names.is_empty());
+}
+
+#[test]
+fn empty_prefix_or_unparseable_manifest_fails_closed() {
+    let no_prefix = pin(
+        "noprefix",
+        r#"{
+          "connector": "noprefix", "type": "tabular_store",
+          "server": "s", "mcp_prefix": "",
+          "provides": ["read"],
+          "tools": [
+            { "tool": "np_read", "resource": "r", "action": "read", "risk": "read_only" }
+          ]
+        }"#,
+    );
+    let garbage = pin("garbage", "{ not json");
+    let surface = build_chat_surface(&[no_prefix, garbage]);
+    assert!(surface.contracts.is_empty());
+}
+
+#[test]
+fn read_only_connector_still_mounts_frictionless() {
+    let exa = pin(
+        "exa",
+        r#"{
+          "connector": "exa", "type": "web_search",
+          "server": "s", "mcp_prefix": "exa_",
+          "provides": ["search", "read"],
+          "tools": [
+            { "tool": "exa_search",       "resource": "web", "action": "search", "risk": "read_only" },
+            { "tool": "exa_get_contents", "resource": "web", "action": "read",   "risk": "read_only" }
+          ]
+        }"#,
+    );
+    let surface = build_chat_surface(&[exa]);
+    let (_, gov, conn) = &surface.contracts[0];
+    let mut run = RunState::default();
+    let call = ProposedCall::new("exa_search", serde_json::json!({"q": "x"}));
+    assert!(matches!(gate(gov, conn, &call, &mut run), Decision::Allow));
+}

--- a/tests/connector_module_test.rs
+++ b/tests/connector_module_test.rs
@@ -335,13 +335,42 @@ fn format_outcome_surfaces_block_reason_on_early_break() {
         // an early break never reached the terminal synthesis: final_text = raw transcript
         final_text: "[find] narrated stuff".into(),
         trace: vec![
-            step("find", "narrated stuff", &["called google_sheets_list_spreadsheets {} -> allowed"]),
-            step("act", "blocked: entered a write state before the bound resource was read", &[]),
+            step(
+                "find",
+                "narrated stuff",
+                &["called google_sheets_list_spreadsheets {} -> allowed"],
+            ),
+            step("act", "blocked: no servable tool", &[]),
         ],
     };
     let out = format_outcome(&outcome);
-    assert!(out.starts_with("blocked: entered a write state"));
+    assert!(out.starts_with("blocked: no servable tool"));
     assert!(!out.contains("[find]"));
+}
+
+#[test]
+fn format_outcome_skipped_write_state_still_answers() {
+    // A read-only question through a linear chain: the guarded write state is skipped
+    // (no write possible), the terminal answer still reaches the bubble.
+    let outcome = ChainOutcome {
+        final_text: "Ta feuille contient 3 prospects.".into(),
+        trace: vec![
+            step("find", "narration", &["called google_sheets_list_spreadsheets {} -> allowed"]),
+            step("read", "nothing to do this step", &[]),
+            step(
+                "act",
+                "skipped: write state reached before the bound resource was read; no write performed",
+                &[],
+            ),
+            step("answer", "Ta feuille contient 3 prospects.", &[]),
+        ],
+    };
+    let out = format_outcome(&outcome);
+    assert!(out.starts_with("Ta feuille contient 3 prospects."));
+    assert!(
+        !out.contains("skipped:"),
+        "the skip is trace-only, not the answer"
+    );
 }
 
 #[test]

--- a/tests/contract_hook_test.rs
+++ b/tests/contract_hook_test.rs
@@ -386,3 +386,152 @@ async fn append_without_captured_schema_and_no_peer_refuses_blind_write() {
         other => panic!("expected Skip, got {other:?}"),
     }
 }
+
+// --- Multi-contract resolution (the chat surface's hook shape) ---
+
+fn exa() -> ConnectorManifest {
+    parse_connector_manifest(
+        r#"{
+          "connector": "exa", "type": "web_search",
+          "server": "s", "mcp_prefix": "exa_",
+          "provides": ["search"],
+          "tools": [
+            { "tool": "exa_search", "resource": "web", "action": "search", "risk": "read_only" }
+          ]
+        }"#,
+    )
+    .unwrap()
+}
+
+fn exa_gov() -> Governance {
+    parse_governance(
+        r#"{
+          "tools": [
+            { "tool": "exa_search", "mode": "read_only", "approval": "require_approval" }
+          ],
+          "read_before_write": false,
+          "deny_destructive": true
+        }"#,
+    )
+    .unwrap()
+}
+
+fn chat_sheets_gov() -> Governance {
+    parse_governance(
+        r#"{
+          "tools": [
+            { "tool": "google_sheets_get_spreadsheet", "mode": "read_only",  "approval": "require_approval" },
+            { "tool": "google_sheets_write_to_cell",   "mode": "read_write", "approval": "require_approval" }
+          ],
+          "read_before_write": false,
+          "deny_destructive": true
+        }"#,
+    )
+    .unwrap()
+}
+
+fn multi_hook(
+    timeout: Duration,
+) -> (ContractHook, UnboundedReceiver<ToolEvent>) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let hook = ContractHook::with_contracts(
+        tx,
+        vec![
+            ("google_sheets_".to_string(), chat_sheets_gov(), sheets()),
+            ("exa_".to_string(), exa_gov(), exa()),
+        ],
+    )
+    .with_approval_timeout(timeout);
+    (hook, rx)
+}
+
+async fn call(hook: &ContractHook, tool: &str) -> ToolCallHookAction {
+    PromptHook::<Model>::on_tool_call(hook, tool, None, "", "{}").await
+}
+
+#[tokio::test]
+async fn multi_contract_reads_resolve_per_connector_and_pass() {
+    let (hook, _rx) = multi_hook(Duration::from_millis(200));
+    // Each read resolves to ITS connector's contract: RequireApproval holds only writes.
+    assert!(matches!(
+        call(&hook, "google_sheets_get_spreadsheet").await,
+        ToolCallHookAction::Continue
+    ));
+    assert!(matches!(
+        call(&hook, "exa_search").await,
+        ToolCallHookAction::Continue
+    ));
+}
+
+#[tokio::test]
+async fn multi_contract_write_holds_and_reject_aborts_the_run() {
+    let (hook, mut rx) = multi_hook(Duration::from_secs(5));
+    assert!(!hook.aborted());
+    let pending = tokio::spawn({
+        let hook = hook.clone();
+        async move { call(&hook, "google_sheets_write_to_cell").await }
+    });
+    let id = next_proposal_id(&mut rx).await;
+    decide(id, UserDecision::Rejected).unwrap();
+    let action = pending.await.unwrap();
+    assert!(matches!(action, ToolCallHookAction::Skip { .. }));
+    assert!(
+        hook.aborted(),
+        "reject flags the run as aborted (any contract)"
+    );
+}
+
+#[tokio::test]
+async fn multi_contract_unmatched_mcp_tool_is_refused() {
+    let (hook, _rx) = multi_hook(Duration::from_millis(200));
+    match call(&hook, "stripe_create_charge").await {
+        ToolCallHookAction::Skip { reason } => {
+            assert!(reason.contains("not governed"), "{reason}");
+        }
+        other => panic!("expected Skip, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn multi_contract_notes_tools_pass_untouched() {
+    let (hook, _rx) = multi_hook(Duration::from_millis(200));
+    for tool in ["search_notes", "create_note", "summarize_folder"] {
+        assert!(matches!(
+            call(&hook, tool).await,
+            ToolCallHookAction::Continue
+        ));
+    }
+}
+
+#[tokio::test]
+async fn after_reject_every_later_call_is_refused_without_a_new_card() {
+    let (hook, mut rx) = multi_hook(Duration::from_secs(5));
+    let pending = tokio::spawn({
+        let hook = hook.clone();
+        async move { call(&hook, "google_sheets_write_to_cell").await }
+    });
+    let id = next_proposal_id(&mut rx).await;
+    decide(id, UserDecision::Rejected).unwrap();
+    let _ = pending.await.unwrap();
+
+    // The model retrying the write - or reaching for ANY tool - gets refused outright:
+    // no second proposal event, the run concludes on what it already has.
+    match call(&hook, "google_sheets_write_to_cell").await {
+        ToolCallHookAction::Skip { reason } => {
+            assert!(reason.contains("ended this run"), "{reason}");
+        }
+        other => panic!("expected Skip, got {other:?}"),
+    }
+    match call(&hook, "google_sheets_get_spreadsheet").await {
+        ToolCallHookAction::Skip { .. } => {}
+        other => panic!("expected Skip, got {other:?}"),
+    }
+    let mut proposals = 0;
+    while let Ok(ev) = rx.try_recv() {
+        if matches!(ev, ToolEvent::Proposal(_)) {
+            proposals += 1;
+        }
+    }
+    // The original card was already consumed by next_proposal_id above.
+    assert_eq!(proposals, 0, "no second card after the reject");
+}


### PR DESCRIPTION
## What

Path-scoped connector tool mounting: chat and action surfaces now see only the connector tools their contract grants, closing finding F6 (prompt-injection reach into connector tools) from the connector audit in #88.

## Changes (RFC 0022)

- **Single agent primitive**: `run_agent` in `llm.rs` is now the only place tools mount. `prompt_with_agent`, `run_agent_over_tools`, and the dead `run_mcp_agent` are gone.
- **Multi-contract ContractHook**: one hook resolves each tool call to its connector's contract by longest prefix, fail-closed on unmatched tools. A rejected approval card aborts in the hook itself: every later call skips, no second card, chat and chain alike.
- **New `chat_surface` module**: builds the chat/generic-action surface purely from pinned manifests. Reads mount Allow, writes mount RequireApproval; row tools, upsert, and destructive tools never mount in chat. Unparseable or incoherent manifests drop the whole connector (fail closed).
- **Note-as-action**: notes-only surface (no connector tools without an approval-card channel).
- **Chain fix**: read-only asks skip a guarded write state instead of dying on the read-before-write guard.

## Verification

- 566 tests green (7 new surface tests, 5 new hook-seam tests), `make check` clean.
- Device-validated on iPhone (6-point checklist): chat read without card, write card + approve lands, reject ends the run with no second card, web chat unchanged, governed chain unchanged, note-as-action notes-only.

Refs #88 (F6).

https://claude.ai/code/session_01L2GVyWrNfqkUdEaWUofGQB
