### PR TITLE
fix(rag): month names matched as substrings, and the agent's search escaping scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4865 symbols, 12149 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (5010 symbols, 12504 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ xcrun devicectl manage pair --device <DEVICE_ID>
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **flowflow** (4865 symbols, 12149 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **flowflow** (5010 symbols, 12504 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/src/application/chain.rs
+++ b/src/application/chain.rs
@@ -8,7 +8,7 @@ use crate::application::error::LlmError;
 use crate::application::tools::ContractHook;
 use crate::domain::orchestration::{Chain, Guard};
 use crate::infrastructure::backend::BackendClient;
-use crate::infrastructure::llm::{resolve_chat_model, LlmClient};
+use crate::infrastructure::llm::{resolve_chat_model, LlmClient, NotesTools};
 use crate::infrastructure::mcp::McpRegistry;
 use crate::infrastructure::persistence::Database;
 use tokio::sync::mpsc;
@@ -169,7 +169,7 @@ pub async fn run_chain(
                 model,
                 &preamble,
                 &format!("Goal: {goal}"),
-                false,
+                NotesTools::None,
                 Some((avail, reg.peer())),
                 hook,
                 0.0,

--- a/src/application/chat_surface.rs
+++ b/src/application/chat_surface.rs
@@ -11,7 +11,7 @@ use crate::domain::governance::{
     is_row_tool, parse_connector_manifest, Action, Approval, ConnectorManifest,
     Governance, Mode, Risk, ToolPolicy,
 };
-use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::llm::{LlmClient, NotesTools};
 use crate::infrastructure::persistence::installed_connector_repo::PinnedConnector;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
@@ -132,6 +132,7 @@ pub async fn prompt_chat_agent(
     preamble: &str,
     user_message: &str,
     status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
+    notes_tools: NotesTools,
 ) -> Result<String, LlmError> {
     // No event channel = no card can render: notes-only surface, observe-only hook.
     let Some(tx) = status_tx else {
@@ -141,7 +142,7 @@ pub async fn prompt_chat_agent(
                 CHAT_MODEL,
                 preamble,
                 user_message,
-                true,
+                notes_tools.clone(),
                 None,
                 ContractHook::new(dummy),
                 0.3,
@@ -183,7 +184,7 @@ pub async fn prompt_chat_agent(
                 CHAT_MODEL,
                 preamble,
                 user_message,
-                true,
+                notes_tools.clone(),
                 Some((mounted, peer)),
                 hook,
                 0.3,
@@ -196,7 +197,7 @@ pub async fn prompt_chat_agent(
                 CHAT_MODEL,
                 preamble,
                 user_message,
-                true,
+                notes_tools.clone(),
                 None,
                 ContractHook::new(tx),
                 0.3,

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -16,7 +16,33 @@ use fusion::dedup_merged;
 pub use fusion::rrf_merge;
 
 mod temporal;
-use temporal::{apply_date_filter, detect_temporal_llm, detect_temporal_regex};
+use temporal::detect_temporal_llm;
+pub use temporal::{apply_date_filter, detect_temporal_regex, DateRange};
+
+/// Apply a date range, but never let it be the reason nothing is answered.
+///
+/// The filter drops every note outside the period, so a period the user has no
+/// notes in turns a good candidate set into an empty one and the chat abstains -
+/// looking as if it found nothing at all. When that happens the unfiltered set is
+/// kept and the caller is told, so the answer can say the period was empty
+/// instead of passing off-period notes as on-period ones.
+fn filter_by_date(
+    candidates: Vec<crate::infrastructure::vectordb::SearchResult>,
+    range: Option<&DateRange>,
+) -> (Vec<crate::infrastructure::vectordb::SearchResult>, bool) {
+    let Some(range) = range else {
+        return (candidates, false);
+    };
+    if candidates.is_empty() {
+        return (candidates, false);
+    }
+    let filtered = apply_date_filter(candidates.clone(), range);
+    if filtered.is_empty() {
+        eprintln!("[rag] date filter emptied the set, falling back unfiltered");
+        return (candidates, true);
+    }
+    (filtered, false)
+}
 
 mod scoring;
 use scoring::{apply_temporal_boost, compute_source_count, dedup_sources};
@@ -276,6 +302,9 @@ pub async fn query(
         RAG_INITIAL_K
     };
 
+    // Set when a date range matched nothing and was waived, so the answer can say
+    // the period was empty rather than present off-period notes as on-period.
+    let mut period_empty = false;
     let results: Vec<SearchResult> = if web_on {
         if let Some(ref tx) = status_tx {
             let _ = tx.send(ToolEvent::Started("web_search".into()));
@@ -295,11 +324,8 @@ pub async fn query(
             let _ = tx.send(ToolEvent::Finished("web_search".into()));
         }
         let local = local_res?;
-        let local = if let Some(ref range) = date_range {
-            apply_date_filter(local, range)
-        } else {
-            local
-        };
+        let (local, empty_period) = filter_by_date(local, date_range.as_ref());
+        period_empty = empty_period;
         eprintln!("[rag] web on: {} local, {} web", local.len(), web_res.len());
         // Both legs empty (no local chunk clears the floor AND the web returned nothing) ->
         // say so instead of fabricating from "(no relevant excerpts)" under the web prompt.
@@ -338,11 +364,9 @@ pub async fn query(
             .await?;
         search_timer.finish(&mut rag_trace, None, None, StepOutcome::Ok);
 
-        let candidates = if let Some(ref range) = date_range {
-            apply_date_filter(candidates, range)
-        } else {
-            candidates
-        };
+        let (candidates, empty_period) =
+            filter_by_date(candidates, date_range.as_ref());
+        period_empty = empty_period;
 
         // The LLM judge decides WHICH notes genuinely answer the question - it reads the content,
         // so it judges what a note is ABOUT, not mere word overlap. An `@mention` is an explicit
@@ -380,11 +404,20 @@ pub async fn query(
         kept.into_iter().take(source_count).collect()
     };
 
+    // The user asked for a period that holds nothing. Saying so beats both staying
+    // silent and letting off-period notes pass for on-period ones.
+    let period_note = if period_empty {
+        "Note: no note falls in the period the question asks about. The excerpts \
+         below are the closest matches from other dates - say the period is empty \
+         before using them.\n\n"
+    } else {
+        ""
+    };
     let context = if results.is_empty() {
         String::from("--- User notes ---\n\n(no relevant excerpts)\n")
     } else {
         let db_tags = Database::open().ok();
-        let mut ctx = String::from("--- User notes ---\n\n");
+        let mut ctx = format!("--- User notes ---\n\n{period_note}");
         for (i, r) in results.iter().enumerate() {
             match r.source_type {
                 SourceType::Web => {

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -4,7 +4,7 @@ use crate::application::constants::{
     RAG_RELEVANCE_FLOOR, RRF_K, RRF_LOCAL_WEIGHT, RRF_WEB_WEIGHT,
 };
 use crate::application::tools::{prompt_agent_with_tools, ToolEvent};
-use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::llm::{LlmClient, NotesTools};
 use crate::infrastructure::persistence::Database;
 use crate::infrastructure::vectordb::{SearchResult, SourceType, VectorStore};
 use std::collections::HashSet;
@@ -469,9 +469,16 @@ pub async fn query(
         RAG_AGENT_SYSTEM_PROMPT
     };
     let agent_timer = StepTimer::start("agent", Some(ai.chat_model_name()));
-    let answer =
-        prompt_agent_with_tools(ai, system_prompt, &user_msg, status_tx)
-            .await?;
+    // Same perimeter as the initial retrieval: inside a folder or a thread, the
+    // agent's own re-search must not reach past what the user narrowed to.
+    let answer = prompt_agent_with_tools(
+        ai,
+        system_prompt,
+        &user_msg,
+        status_tx,
+        NotesTools::from_allowed(allowed_note_ids.as_deref()),
+    )
+    .await?;
     agent_timer.finish(
         &mut rag_trace,
         Some(estimate_tokens(&user_msg)),
@@ -509,11 +516,14 @@ pub async fn run_action(
     status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
 ) -> Result<RagResponse, String> {
     let ai = Arc::new(LlmClient::from_env()?);
+    // A note action is global by construction: it is triggered from one note and
+    // may create or summarize anywhere.
     let answer = prompt_agent_with_tools(
         ai,
         crate::application::constants::NOTE_ACTION_PROMPT,
         question,
         status_tx,
+        NotesTools::Global,
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/src/application/rag/temporal.rs
+++ b/src/application/rag/temporal.rs
@@ -2,13 +2,57 @@ use crate::application::constants::{CHEAP_MODEL, TEMPORAL_DETECT_PROMPT};
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::vectordb::SearchResult;
 use chrono::{Datelike, Local, NaiveDate};
+use regex::Regex;
+use std::sync::OnceLock;
 
-pub(super) struct DateRange {
-    pub(super) from: NaiveDate,
-    pub(super) to: NaiveDate,
+#[derive(Debug, Clone, PartialEq)]
+pub struct DateRange {
+    pub from: NaiveDate,
+    pub to: NaiveDate,
 }
 
-pub(super) fn detect_temporal_regex(question: &str) -> Option<DateRange> {
+const FR_MONTHS: [(&str, u32); 15] = [
+    ("janvier", 1),
+    ("février", 2),
+    ("fevrier", 2),
+    ("mars", 3),
+    ("avril", 4),
+    ("mai", 5),
+    ("juin", 6),
+    ("juillet", 7),
+    ("août", 8),
+    ("aout", 8),
+    ("septembre", 9),
+    ("octobre", 10),
+    ("novembre", 11),
+    ("décembre", 12),
+    ("decembre", 12),
+];
+
+/// A month name only counts as a date intent when it stands as a whole word.
+///
+/// The test used to be a bare substring check, and "mai" hides inside some of the
+/// most ordinary French words there are - mais, demain, jamais, maintenant, mail,
+/// maison, domaine. Any question holding one of them was read as "the month of
+/// May": every note outside May was dropped and the chat answered "no relevant
+/// note" over the empty set, with nothing on screen saying a date filter had run.
+/// `\b` is Unicode-aware, so "j'aimais" stays one word too.
+fn month_matchers() -> &'static [(Regex, u32)] {
+    static MATCHERS: OnceLock<Vec<(Regex, u32)>> = OnceLock::new();
+    MATCHERS.get_or_init(|| {
+        FR_MONTHS
+            .iter()
+            .map(|(name, month)| {
+                let re =
+                    Regex::new(&format!(r"(?i)\b{}\b", regex::escape(name)))
+                        .expect("valid month regex");
+                (re, *month)
+            })
+            .collect()
+    })
+}
+
+pub fn detect_temporal_regex(question: &str) -> Option<DateRange> {
     let today = Local::now().date_naive();
     let q = question.to_lowercase();
 
@@ -62,26 +106,9 @@ pub(super) fn detect_temporal_regex(question: &str) -> Option<DateRange> {
         });
     }
 
-    let fr_months = [
-        ("janvier", 1),
-        ("février", 2),
-        ("fevrier", 2),
-        ("mars", 3),
-        ("avril", 4),
-        ("mai", 5),
-        ("juin", 6),
-        ("juillet", 7),
-        ("août", 8),
-        ("aout", 8),
-        ("septembre", 9),
-        ("octobre", 10),
-        ("novembre", 11),
-        ("décembre", 12),
-        ("decembre", 12),
-    ];
-    for (name, month) in fr_months {
-        if q.contains(name) {
-            let year = today.year();
+    for (re, month) in month_matchers() {
+        if re.is_match(&q) {
+            let (month, year) = (*month, today.year());
             let first = NaiveDate::from_ymd_opt(year, month, 1)?;
             let next_month = if month == 12 {
                 NaiveDate::from_ymd_opt(year + 1, 1, 1)?
@@ -129,7 +156,7 @@ pub(super) async fn detect_temporal_llm(
     range_from_strs(from_str, to_str)
 }
 
-pub(super) fn apply_date_filter(
+pub fn apply_date_filter(
     results: Vec<SearchResult>,
     range: &DateRange,
 ) -> Vec<SearchResult> {

--- a/src/application/tools/mod.rs
+++ b/src/application/tools/mod.rs
@@ -17,7 +17,7 @@ use crate::domain::governance::{
     ConnectorManifest, Decision, DenyReason, Governance, ProposedCall,
     RunState,
 };
-use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::llm::{LlmClient, NotesTools};
 use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
 use rig::completion::CompletionModel;
 use std::collections::BTreeSet;
@@ -928,12 +928,14 @@ pub async fn prompt_agent_with_tools(
     preamble: &str,
     user_message: &str,
     status_tx: Option<mpsc::UnboundedSender<ToolEvent>>,
+    notes_tools: NotesTools,
 ) -> Result<String, crate::application::error::LlmError> {
     crate::application::chat_surface::prompt_chat_agent(
         llm,
         preamble,
         user_message,
         status_tx,
+        notes_tools,
     )
     .await
 }

--- a/src/application/tools/search.rs
+++ b/src/application/tools/search.rs
@@ -11,11 +11,25 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct SearchNotes {
     pub llm: Arc<LlmClient>,
+    /// The notes this run is allowed to see. `None` is a global chat; `Some(ids)`
+    /// is a folder, a thread or an `@mention`.
+    ///
+    /// The tool used to search the whole corpus unconditionally, so a scoped chat
+    /// leaked: the first retrieval respected the folder, then the agent's own
+    /// re-search did not, and the extra notes reached the answer while the sources
+    /// panel - built from the first retrieval only - never showed them.
+    pub allowed_note_ids: Option<Arc<[String]>>,
 }
 
 impl SearchNotes {
-    pub fn new(llm: Arc<LlmClient>) -> Self {
-        Self { llm }
+    pub fn new(
+        llm: Arc<LlmClient>,
+        allowed_note_ids: Option<Arc<[String]>>,
+    ) -> Self {
+        Self {
+            llm,
+            allowed_note_ids,
+        }
     }
 }
 
@@ -80,7 +94,12 @@ impl Tool for SearchNotes {
         // matches (a search for "Jean" returned nothing, so the agent declared "no relevant note"
         // while the note was in its initial context). The agent judges relevance from the content.
         let results = store
-            .hybrid_search(&args.query, vector, top_k, None)
+            .hybrid_search(
+                &args.query,
+                vector,
+                top_k,
+                self.allowed_note_ids.as_deref(),
+            )
             .await
             .map_err(|e| ToolFailure(format!("vectordb search: {e}")))?;
         Ok(results

--- a/src/infrastructure/llm.rs
+++ b/src/infrastructure/llm.rs
@@ -47,6 +47,43 @@ impl FromStr for Provider {
     }
 }
 
+/// Whether an agent run gets the local notes tools, and what those tools may see.
+///
+/// This replaced a bare `bool`. The boolean said "mount the tools" and said nothing
+/// about scope, so `search_notes` searched the whole corpus even inside a folder or
+/// thread chat - the one place the user had explicitly narrowed. Making the scope
+/// part of the same value means a caller cannot mount the tools without deciding it.
+#[derive(Clone, Default)]
+pub enum NotesTools {
+    /// No local notes tools on this run.
+    #[default]
+    None,
+    /// Mounted over every note.
+    Global,
+    /// Mounted over these notes only (folder, thread, or `@mention`).
+    Scoped(Arc<[String]>),
+}
+
+impl NotesTools {
+    /// `None` = do not mount. `Some(scope)` = mount, `scope` being the id filter
+    /// handed to the search tool.
+    pub fn scope(&self) -> Option<Option<Arc<[String]>>> {
+        match self {
+            NotesTools::None => None,
+            NotesTools::Global => Some(None),
+            NotesTools::Scoped(ids) => Some(Some(ids.clone())),
+        }
+    }
+
+    /// Mount over `ids` when the chat is scoped, over everything when it is not.
+    pub fn from_allowed(ids: Option<&[String]>) -> Self {
+        match ids {
+            Some(ids) => NotesTools::Scoped(Arc::from(ids)),
+            None => NotesTools::Global,
+        }
+    }
+}
+
 pub struct LlmClient {
     openai: openai::Client,
     provider: Provider,
@@ -192,13 +229,16 @@ impl LlmClient {
     /// subset over its server sink - the caller keeps the registry alive across the await
     /// so the sink stays valid. The `hook` always applies: enforcing when the caller
     /// attached a contract, observe-only otherwise. Nothing else in the app mounts tools.
+    ///
+    /// The note ids inside `NotesTools` are carried, never interpreted: resolving a
+    /// folder or a thread into ids stays in `application`.
     #[allow(clippy::too_many_arguments)]
     pub async fn run_agent(
         self: &Arc<Self>,
         openai_model: &str,
         preamble: &str,
         user_message: &str,
-        notes_tools: bool,
+        notes_tools: NotesTools,
         mcp: Option<(Vec<rmcp::model::Tool>, rmcp::service::ServerSink)>,
         hook: ContractHook,
         temperature: f64,
@@ -224,20 +264,20 @@ impl LlmClient {
                     .agent(openai_model)
                     .preamble(preamble)
                     .temperature(temperature);
-                match (notes_tools, mcp) {
-                    (true, Some((tools, peer))) => run!(base
-                        .tool(SearchNotes::new(self.clone()))
+                match (notes_tools.scope(), mcp) {
+                    (Some(scope), Some((tools, peer))) => run!(base
+                        .tool(SearchNotes::new(self.clone(), scope))
                         .tool(CreateNote::new())
                         .tool(SummarizeFolder::new(self.clone()))
                         .rmcp_tools(tools, peer)),
-                    (true, None) => run!(base
-                        .tool(SearchNotes::new(self.clone()))
+                    (Some(scope), None) => run!(base
+                        .tool(SearchNotes::new(self.clone(), scope))
                         .tool(CreateNote::new())
                         .tool(SummarizeFolder::new(self.clone()))),
-                    (false, Some((tools, peer))) => {
+                    (None, Some((tools, peer))) => {
                         run!(base.rmcp_tools(tools, peer))
                     }
-                    (false, None) => run!(base),
+                    (None, None) => run!(base),
                 }
             }
             Provider::Anthropic => {
@@ -251,20 +291,20 @@ impl LlmClient {
                     .preamble(preamble)
                     .temperature(temperature)
                     .max_tokens(ANTHROPIC_MAX_TOKENS);
-                match (notes_tools, mcp) {
-                    (true, Some((tools, peer))) => run!(base
-                        .tool(SearchNotes::new(self.clone()))
+                match (notes_tools.scope(), mcp) {
+                    (Some(scope), Some((tools, peer))) => run!(base
+                        .tool(SearchNotes::new(self.clone(), scope))
                         .tool(CreateNote::new())
                         .tool(SummarizeFolder::new(self.clone()))
                         .rmcp_tools(tools, peer)),
-                    (true, None) => run!(base
-                        .tool(SearchNotes::new(self.clone()))
+                    (Some(scope), None) => run!(base
+                        .tool(SearchNotes::new(self.clone(), scope))
                         .tool(CreateNote::new())
                         .tool(SummarizeFolder::new(self.clone()))),
-                    (false, Some((tools, peer))) => {
+                    (None, Some((tools, peer))) => {
                         run!(base.rmcp_tools(tools, peer))
                     }
-                    (false, None) => run!(base),
+                    (None, None) => run!(base),
                 }
             }
         }

--- a/src/ui/notes/note_actions.rs
+++ b/src/ui/notes/note_actions.rs
@@ -109,6 +109,7 @@ pub fn NoteActions(
                                         NOTE_ACTION_PROMPT,
                                         &c,
                                         None,
+                                        crate::infrastructure::llm::NotesTools::Global,
                                     )
                                     .await
                                     .map_err(|e| e.to_string())

--- a/tests/provider_integration_test.rs
+++ b/tests/provider_integration_test.rs
@@ -101,6 +101,7 @@ async fn test_anthropic_agent_with_tools_real() {
             "Tu es un assistant qui répond brièvement en français.",
             "Bonjour, peux-tu juste dire 'pong' ?",
             None,
+            flowflow::infrastructure::llm::NotesTools::Global,
         )
         .await
         .expect("anthropic agent prompt should succeed");

--- a/tests/rag_scope_test.rs
+++ b/tests/rag_scope_test.rs
@@ -1,0 +1,44 @@
+use flowflow::infrastructure::llm::NotesTools;
+
+/// A scoped chat must stay scoped, including when the agent searches on its own.
+///
+/// `search_notes` used to pass `None` as its id filter, so the first retrieval
+/// respected the folder or thread and the agent's own re-search did not. The extra
+/// notes reached the answer while the sources panel - built from the first
+/// retrieval only - never showed them, which made the leak invisible.
+#[test]
+fn a_scoped_run_carries_its_ids_to_the_tools() {
+    let ids = vec!["note-a".to_string(), "note-b".to_string()];
+    let mounted = NotesTools::from_allowed(Some(&ids))
+        .scope()
+        .expect("scoped run mounts the notes tools");
+    let carried = mounted.expect("a scoped run carries an id filter");
+    assert_eq!(&*carried, ids.as_slice());
+}
+
+#[test]
+fn a_global_run_carries_no_filter() {
+    let mounted = NotesTools::from_allowed(None)
+        .scope()
+        .expect("global run mounts the notes tools");
+    assert!(mounted.is_none(), "a global run must not narrow anything");
+}
+
+#[test]
+fn a_run_without_notes_tools_mounts_nothing() {
+    assert!(
+        NotesTools::None.scope().is_none(),
+        "None means the notes tools are not mounted at all"
+    );
+}
+
+/// An empty scope is not the same as no scope: it means "these zero notes", and
+/// must never widen back to the whole corpus.
+#[test]
+fn an_empty_scope_stays_empty_rather_than_becoming_global() {
+    let mounted = NotesTools::from_allowed(Some(&[]))
+        .scope()
+        .expect("still mounts");
+    let carried = mounted.expect("an empty scope is still a filter");
+    assert!(carried.is_empty());
+}

--- a/tests/rag_temporal_test.rs
+++ b/tests/rag_temporal_test.rs
@@ -1,0 +1,138 @@
+use chrono::{Datelike, Local, NaiveDate};
+use flowflow::application::rag::{
+    apply_date_filter, detect_temporal_regex, DateRange,
+};
+use flowflow::infrastructure::vectordb::{SearchResult, SourceType};
+
+/// Words that merely CONTAIN a month name are not a date intent.
+///
+/// "mai" hides inside some of the most ordinary French words there are, and the
+/// month test used a bare substring check. A query holding "mais" was read as
+/// "the month of May", every note outside May was dropped, and the chat answered
+/// "no relevant note" over an empty set. Nothing on screen said a date filter had
+/// run.
+#[test]
+fn a_word_that_merely_contains_a_month_is_not_a_date() {
+    let false_positives = [
+        "j'ai noté un truc mais je ne sais plus où",
+        "demain je dois envoyer le dossier",
+        "je n'ai jamais écrit ça",
+        "qu'est-ce que je fais maintenant",
+        "retrouve le mail de la banque",
+        "mes notes sur la maison",
+        "quel est mon domaine d'expertise",
+        "je n'aimais pas cette idée",
+    ];
+    for q in false_positives {
+        assert_eq!(
+            detect_temporal_regex(q),
+            None,
+            "no date intent in {q:?}, yet one was detected"
+        );
+    }
+}
+
+#[test]
+fn a_real_month_is_still_detected() {
+    let range = detect_temporal_regex("mes notes de mai").expect("mai");
+    assert_eq!(range.from.month(), 5);
+    assert_eq!(range.from.day(), 1);
+    assert_eq!(range.to.month(), 5);
+    assert_eq!(range.to.day(), 31);
+
+    let range =
+        detect_temporal_regex("ce que j'ai fait en mars").expect("mars");
+    assert_eq!(range.from.month(), 3);
+    assert_eq!(range.to.day(), 31);
+
+    // Punctuation is a word boundary too.
+    assert!(detect_temporal_regex("et en juin, quoi ?").is_some());
+}
+
+#[test]
+fn every_month_name_is_reachable() {
+    let months = [
+        ("janvier", 1),
+        ("février", 2),
+        ("fevrier", 2),
+        ("mars", 3),
+        ("avril", 4),
+        ("mai", 5),
+        ("juin", 6),
+        ("juillet", 7),
+        ("août", 8),
+        ("aout", 8),
+        ("septembre", 9),
+        ("octobre", 10),
+        ("novembre", 11),
+        ("décembre", 12),
+        ("decembre", 12),
+    ];
+    for (name, month) in months {
+        let q = format!("mes notes de {name}");
+        let range = detect_temporal_regex(&q)
+            .unwrap_or_else(|| panic!("{name} not detected"));
+        assert_eq!(range.from.month(), month, "wrong month for {name}");
+    }
+}
+
+/// The relative-period guards run before the month table and must keep working:
+/// "cette semaine" is a date intent even though "semaine" alone is not.
+#[test]
+fn relative_period_guards_still_fire() {
+    let today = Local::now().date_naive();
+
+    let range = detect_temporal_regex("mes notes de cette semaine")
+        .expect("cette semaine");
+    assert_eq!(range.to, today);
+    assert!(range.from <= today);
+
+    let range = detect_temporal_regex("ce que j'ai noté hier").expect("hier");
+    assert_eq!(range.from, today - chrono::Duration::days(1));
+    assert_eq!(range.to, range.from);
+
+    assert!(detect_temporal_regex("le mois dernier").is_some());
+    assert!(detect_temporal_regex("ce mois-ci").is_some());
+    assert!(detect_temporal_regex("aujourd'hui").is_some());
+}
+
+#[test]
+fn a_question_with_no_date_yields_none() {
+    assert_eq!(detect_temporal_regex("de quoi parlait la réunion"), None);
+    assert_eq!(detect_temporal_regex(""), None);
+}
+
+fn result_created(id: &str, created_at: &str) -> SearchResult {
+    SearchResult {
+        note_id: id.to_string(),
+        title: id.to_string(),
+        chunk_text: String::new(),
+        distance: 0.0,
+        relevance: 1.0,
+        created_at: created_at.to_string(),
+        source_type: SourceType::Local,
+        url: None,
+    }
+}
+
+#[test]
+fn the_date_filter_keeps_only_what_falls_inside_the_range() {
+    let range = DateRange {
+        from: NaiveDate::from_ymd_opt(2026, 5, 1).expect("date"),
+        to: NaiveDate::from_ymd_opt(2026, 5, 31).expect("date"),
+    };
+    let kept = apply_date_filter(
+        vec![
+            result_created("before", "2026-04-30T10:00:00Z"),
+            result_created("first-day", "2026-05-01T00:00:00Z"),
+            result_created("inside", "2026-05-15T12:00:00Z"),
+            result_created("last-day", "2026-05-31T23:59:00Z"),
+            result_created("after", "2026-06-01T09:00:00Z"),
+        ],
+        &range,
+    );
+    assert_eq!(
+        kept.iter().map(|r| r.note_id.as_str()).collect::<Vec<_>>(),
+        ["first-day", "inside", "last-day"]
+    );
+}

--- a/tests/tools_integration_test.rs
+++ b/tests/tools_integration_test.rs
@@ -186,7 +186,7 @@ async fn test_search_notes_real() {
     use std::sync::Arc;
 
     let llm = Arc::new(LlmClient::from_env().expect("OPENAI_API_KEY required"));
-    let tool = SearchNotes::new(llm);
+    let tool = SearchNotes::new(llm, None);
     let args = SearchNotesArgs {
         query: "réunion projet".to_string(),
         top_k: Some(3),
@@ -261,6 +261,7 @@ async fn test_agent_with_tools_e2e() {
         "Tu es un assistant qui répond brièvement en français.",
         "Bonjour, peux-tu juste dire 'pong' ?",
         None,
+        flowflow::infrastructure::llm::NotesTools::Global,
     )
     .await
     .expect("agent prompt should succeed");


### PR DESCRIPTION
Two live RAG bugs, both found by walking the code path end to end rather than by
inference, and both now pinned by tests that fail on the old behaviour.

Starting point was `docs/research/rag-chat-notes-audit/`. Its worst finding - the
cosine floor pruning candidates before the relevance judge, which is what made the
"Jean" note unreachable - is **already fixed**: `floor_filter` now only decides the
abstain go/no-go and no longer prunes. These two survived.

## 1. A month name was matched as a bare substring

`temporal.rs` tested `q.contains("mai")` with no word boundary. "mai" hides inside
some of the most ordinary French words there are:

**mais**, demain, semaine, jamais, maintenant, mail, maison, domaine, aimais.

Any question holding one was read as "the month of May". `apply_date_filter` then
dropped every note outside May, the candidate set went empty, and the chat
abstained with "no relevant note" - over notes it had just retrieved and discarded
itself. Nothing in the UI said a date filter had run at all.

Measured before the fix: `"j'ai noté un truc mais je ne sais plus où"` produced the
range `2026-05-01..2026-05-31`.

The chain, verified line by line:

1. `mod.rs:183-190` - on a first message `retrieval_q` is the raw question and
   `date_range` is `None`.
2. `mod.rs:212-213` - the regex therefore runs on the raw question, before the LLM
   fallback can correct it.
3. `temporal.rs:15-63` - the relative-period guards test exact multi-word phrases,
   so a bare "semaine" reaches the month table.
4. `temporal.rs:82-83` - bare `contains`, and `("mai", 5)` is in the list.
5. `temporal.rs:138-148` - the filter **drops**, with no fallback.
6. `mod.rs:366-376` - empty set, web off, no explicit intent, so: abstain.

**Fix.** Month names are matched on word boundaries, using the same
`OnceLock` + `\b(?:...)\b` shape `hesitations.rs` already uses. `\b` is
Unicode-aware, so "j'aimais" stays one word. The relative-period guards are
untouched: "cette semaine" is still a date intent even though "semaine" is not.

**Plus a safety net.** A date range can legitimately match nothing, and dropping
everything made that look like "found nothing at all". A range that empties a
non-empty candidate set is now waived, and the agent is told the period was empty
so the answer says so rather than passing off-period notes as on-period ones.

## 2. The agent's own search escaped the chat's scope

`tools/search.rs` passed `None` as `hybrid_search`'s id filter. In a folder,
thread or `@mention` chat the initial retrieval respected the perimeter and the
agent's re-search did not - and `constants.rs:123` explicitly invites that
re-search whenever the context looks thin. The extra notes reached the answer,
while the sources panel is built from the initial retrieval only (`mod.rs:449`),
so nothing on screen revealed the leak.

The comment above that call explains why the tool applies no score floor (the
"Jean" case). It says nothing about the perimeter: the `None` was an oversight.

**Fix.** `run_agent` took `notes_tools: bool`, which could say "mount the tools"
but not "over what", so no call site was ever asked the question. It now takes a
`NotesTools`: `None`, `Global`, or `Scoped(ids)`. `llm.rs` only forwards the ids -
resolving a folder or thread into note ids stays in `application`. An empty scope
stays empty rather than widening back to the whole corpus, which the tests pin.

## Verification

- **657 tests pass**, 0 failures. `make check` clean, `cargo fmt` applied.
- `cargo check --target aarch64-apple-ios --features mobile` clean.
- `tests/rag_temporal_test.rs`: eight false-positive phrases, every month still
  reachable, the guards still fire, and the filter's range semantics.
- `tests/rag_scope_test.rs`: a scoped run carries its ids, a global run carries no
  filter, an empty scope does not widen.
- Built with `make all` and installed on the iPhone.

## Manual check

In the chat, ask: **"J'ai noté un truc mais je ne sais plus où"**.
Before: "no relevant note". After: the notes come back.

## Not addressed here

The audit lists other findings I checked but did not fix (scope filtering applied
after `limit` in `vectordb.rs`, dedup collapsing a note with its attachment,
reranking on a 200-character preview). They belong in their own change.
