### PR TITLE
Note actions: mount the approval channel so a note can perform governed connector writes

### DIFF
--- a/src/ui/chat/approval_card.rs
+++ b/src/ui/chat/approval_card.rs
@@ -2,23 +2,24 @@ use crate::application::approvals::{
     self, ProposalView, UserDecision, APPROVAL_TIMEOUT,
 };
 use crate::application::i18n::t;
-use crate::ui::chat::actions::update_proposal_status;
-use crate::ui::chat::models::{ChatMsg, ProposalStatus};
+use crate::ui::chat::models::ProposalStatus;
 use crate::ui::icons::IconShieldCheck;
 use dioxus::prelude::*;
 use uuid::Uuid;
 
-// The in-chat approval card for a suspended connector write: payload rows, the TOCTOU caveat,
-// and Approuver / Modifier / Refuser. Modifier opens an inline editor over the value field;
+// The approval card for a suspended connector write: payload rows, the TOCTOU caveat, and
+// Approuver / Modifier / Refuser. Modifier opens an inline editor over the value field;
 // every action delegates to `approvals::decide`/`touch` - the card never touches the registry.
 // Once decided the buttons vanish and only a status pill remains. A decide that returns Expired
-// (the run already died) freezes the card locally, since no hook is left to emit the resolution.
+// (the run already died) has no hook left to emit the resolution, so the card asks its owner
+// to freeze it: `on_expired`. That handler is the card's only tie to where it is mounted, which
+// is why the same component serves the chat and a note action.
 #[component]
 pub fn ApprovalCard(
     view: ProposalView,
     status: ProposalStatus,
     edit_error: Option<String>,
-    messages: Signal<Vec<ChatMsg>>,
+    on_expired: EventHandler<()>,
     lang: String,
 ) -> Element {
     let mut editing = use_signal(|| false);
@@ -33,17 +34,10 @@ pub fn ApprovalCard(
     let pending = status == ProposalStatus::Pending;
     let card_id = Uuid::parse_str(&view.id).ok();
 
-    let approve = {
-        let id = view.id.clone();
-        move |_| {
-            if let Some(uuid) = card_id {
-                if approvals::decide(uuid, UserDecision::Approved).is_err() {
-                    update_proposal_status(
-                        &mut messages,
-                        &id,
-                        ProposalStatus::Expired,
-                    );
-                }
+    let approve = move |_| {
+        if let Some(uuid) = card_id {
+            if approvals::decide(uuid, UserDecision::Approved).is_err() {
+                on_expired.call(());
             }
         }
     };
@@ -55,23 +49,15 @@ pub fn ApprovalCard(
         editing.set(true);
     };
 
-    let reject = {
-        let id = view.id.clone();
-        move |_| {
-            if let Some(uuid) = card_id {
-                if approvals::decide(uuid, UserDecision::Rejected).is_err() {
-                    update_proposal_status(
-                        &mut messages,
-                        &id,
-                        ProposalStatus::Expired,
-                    );
-                }
+    let reject = move |_| {
+        if let Some(uuid) = card_id {
+            if approvals::decide(uuid, UserDecision::Rejected).is_err() {
+                on_expired.call(());
             }
         }
     };
 
     let submit_edit = {
-        let id = view.id.clone();
         let raw = view.raw_args.clone();
         move |_| {
             let mut args = raw.clone();
@@ -84,11 +70,7 @@ pub fn ApprovalCard(
             if let Some(uuid) = card_id {
                 if approvals::decide(uuid, UserDecision::Edited(args)).is_err()
                 {
-                    update_proposal_status(
-                        &mut messages,
-                        &id,
-                        ProposalStatus::Expired,
-                    );
+                    on_expired.call(());
                 }
             }
             editing.set(false);
@@ -148,7 +130,7 @@ pub fn ApprovalCard(
                     }
                     div { class: "mt-2 flex gap-2",
                         button {
-                            class: "flex-1 min-h-[44px] rounded-lg bg-ios-green/15 text-ios-green font-medium text-sm active:opacity-80",
+                            class: "flex-1 min-h-[44px] rounded-lg bg-ios-orange text-white font-medium text-sm active:opacity-80",
                             onclick: submit_edit,
                             {t(&lang, "approval-confirm")}
                         }
@@ -162,7 +144,7 @@ pub fn ApprovalCard(
             } else if pending {
                 div { class: "mt-3 flex gap-2",
                     button {
-                        class: "flex-1 min-h-[44px] rounded-lg bg-ios-green text-white font-medium text-sm active:opacity-80",
+                        class: "flex-1 min-h-[44px] rounded-lg bg-ios-orange text-white font-medium text-sm active:opacity-80",
                         onclick: approve,
                         {t(&lang, "approval-approve")}
                     }
@@ -216,8 +198,9 @@ fn pill_key(status: &ProposalStatus) -> &'static str {
 
 fn pill_class(status: &ProposalStatus) -> &'static str {
     match status {
-        ProposalStatus::Approved => "bg-ios-green/15 text-ios-green",
-        ProposalStatus::Edited => "bg-ios-orange/15 text-ios-orange-dark",
+        ProposalStatus::Approved | ProposalStatus::Edited => {
+            "bg-ios-orange-50 text-ios-orange-dark"
+        }
         ProposalStatus::Rejected => "bg-ios-red/10 text-ios-red",
         ProposalStatus::Pending | ProposalStatus::Expired => {
             "bg-stone-100 text-stone-500"

--- a/src/ui/chat/mod.rs
+++ b/src/ui/chat/mod.rs
@@ -3,7 +3,7 @@ mod bot_bubble;
 mod empty_state;
 mod mention_menu;
 mod menu;
-mod models;
+pub(crate) mod models;
 mod sources_accordion;
 mod tools_menu;
 mod trace_accordion;

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -1,14 +1,16 @@
 use crate::domain::ChatScope;
 use crate::infrastructure::audio::RecordingState;
 use crate::infrastructure::persistence::Database;
-use crate::ui::chat::actions::{load_messages_from_db, send_question};
+use crate::ui::chat::actions::{
+    load_messages_from_db, send_question, update_proposal_status,
+};
 use crate::ui::chat::approval_card::ApprovalCard;
 use crate::ui::chat::bot_bubble::BotBubble;
 use crate::ui::chat::chat_input::ChatInputBar;
 use crate::ui::chat::empty_state::ChatEmptyState;
 use crate::ui::chat::mention_menu::MentionedNote;
 use crate::ui::chat::menu::ChatMenu;
-use crate::ui::chat::models::ChatMsg;
+use crate::ui::chat::models::{ChatMsg, ProposalStatus};
 use crate::ui::chat::typing_indicator::TypingIndicator;
 use crate::ui::chat::user_bubble::UserBubble;
 use crate::ui::state::View;
@@ -203,14 +205,21 @@ pub fn ChatView() -> Element {
                                         }
                                     }
                                 },
-                                ChatMsg::Proposal { view, status, edit_error } => rsx! {
-                                    div { key: "{i}",
-                                        ApprovalCard {
-                                            view: view.clone(),
-                                            status: status.clone(),
-                                            edit_error: edit_error.clone(),
-                                            messages: messages,
-                                            lang: (app.current_lang)(),
+                                ChatMsg::Proposal { view, status, edit_error } => {
+                                    let id = view.id.clone();
+                                    rsx! {
+                                        div { key: "{i}",
+                                            ApprovalCard {
+                                                view: view.clone(),
+                                                status: status.clone(),
+                                                edit_error: edit_error.clone(),
+                                                on_expired: move |_| update_proposal_status(
+                                                    &mut messages,
+                                                    &id,
+                                                    ProposalStatus::Expired,
+                                                ),
+                                                lang: (app.current_lang)(),
+                                            }
                                         }
                                     }
                                 },

--- a/src/ui/notes/note_actions.rs
+++ b/src/ui/notes/note_actions.rs
@@ -1,22 +1,82 @@
+use crate::application::approvals::ProposalView;
 use crate::application::constants::NOTE_ACTION_PROMPT;
 use crate::application::i18n::t;
+use crate::application::tools::ToolEvent;
 use crate::domain::NewTextNote;
 use crate::infrastructure::backend::BackendClient;
 use crate::infrastructure::llm::LlmClient;
 use crate::infrastructure::persistence::Database;
 use crate::ui::chat::action_card::ActionResultCard;
+use crate::ui::chat::approval_card::ApprovalCard;
+use crate::ui::chat::models::{tool_label, ProposalStatus};
 use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
+use tokio::sync::mpsc;
 
 fn action_key(note_id: &str) -> String {
     format!("note_action:{note_id}")
 }
 
+// One approval card of the current run. The chat keeps its cards as conversation messages so
+// they survive a reload; a note has no message table, so a card lives only as long as its run
+// and an undecided proposal expires with it.
+#[derive(Clone, PartialEq)]
+struct Card {
+    view: ProposalView,
+    status: ProposalStatus,
+    edit_error: Option<String>,
+}
+
+fn set_status(cards: &mut Signal<Vec<Card>>, id: &str, status: ProposalStatus) {
+    if let Some(c) = cards.write().iter_mut().find(|c| c.view.id == id) {
+        c.status = status;
+        c.edit_error = None;
+    }
+}
+
+// Drain the run's tool events into the note's live UI state. Returns the sender the agent run
+// is given; the loop ends when the run drops it.
+fn drain_tool_events(
+    mut cards: Signal<Vec<Card>>,
+    mut tool_status: Signal<Option<String>>,
+    lang: String,
+) -> mpsc::UnboundedSender<ToolEvent> {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                ToolEvent::Started(name) => {
+                    tool_status.set(Some(tool_label(&lang, &name)))
+                }
+                ToolEvent::Finished(_) => tool_status.set(None),
+                ToolEvent::Proposal(view) => cards.write().push(Card {
+                    view,
+                    status: ProposalStatus::Pending,
+                    edit_error: None,
+                }),
+                ToolEvent::ProposalResolved { id, status } => {
+                    set_status(&mut cards, &id, status.into())
+                }
+                ToolEvent::EditRejected { id, reason } => {
+                    if let Some(c) =
+                        cards.write().iter_mut().find(|c| c.view.id == id)
+                    {
+                        c.edit_error = Some(reason);
+                    }
+                }
+            }
+        }
+    });
+    tx
+}
+
 // Run-this-note-as-an-action. The note text IS the instruction: it goes through the agent with the
 // connected tools (NOTE_ACTION_PROMPT keeps the reply to a one-line confirmation + resource link).
 // The result is cached per note so reopening the note shows what it produced instead of re-offering
-// a fresh run. Dark unless a backend connector is configured.
+// a fresh run. Dark unless a backend connector is configured. The run carries a live event
+// channel, so it gets the same governed surface as the chat: a connector write holds for the
+// approval card below the button instead of being dropped.
 #[component]
 pub fn NoteActions(
     mut local_note_id: Signal<String>,
@@ -33,6 +93,8 @@ pub fn NoteActions(
     let mut running = use_signal(|| false);
     let mut result: Signal<Option<String>> = use_signal(|| None);
     let mut error: Signal<Option<String>> = use_signal(|| None);
+    let mut cards: Signal<Vec<Card>> = use_signal(Vec::new);
+    let mut tool_status: Signal<Option<String>> = use_signal(|| None);
 
     // surface any previously cached result for this note (persistence across reopen)
     use_effect(move || {
@@ -65,6 +127,9 @@ pub fn NoteActions(
                         }
                         running.set(true);
                         error.set(None);
+                        cards.write().clear();
+                        tool_status.set(None);
+                        let tx = drain_tool_events(cards, tool_status, lang.clone());
                         let c = content();
                         let t_in = title();
                         let tg = tags();
@@ -99,8 +164,6 @@ pub fn NoteActions(
                                     cur
                                 }
                             };
-                            // No event channel here = no approval card can render, so this
-                            // path gets the notes-only surface (connector writes need chat).
                             let outcome = match LlmClient::from_db(&database) {
                                 Ok(ai) => {
                                     let ai = Arc::new(ai);
@@ -108,7 +171,7 @@ pub fn NoteActions(
                                         ai,
                                         NOTE_ACTION_PROMPT,
                                         &c,
-                                        None,
+                                        Some(tx),
                                         crate::infrastructure::llm::NotesTools::Global,
                                     )
                                     .await
@@ -123,15 +186,31 @@ pub fn NoteActions(
                                 }
                                 Err(e) => error.set(Some(e)),
                             }
+                            tool_status.set(None);
                             running.set(false);
                         });
                     },
                     if running() {
                         span { class: "inline-block w-3.5 h-3.5 border-2 border-ios-orange-dark border-t-transparent rounded-full animate-spin" }
-                        span { "{running_label}" }
+                        span { {tool_status().unwrap_or_else(|| running_label.clone())} }
                     } else {
                         span { "{run_label}" }
                     }
+                }
+                {
+                    cards().into_iter().enumerate().map(|(i, card)| {
+                        let id = card.view.id.clone();
+                        rsx! {
+                            ApprovalCard {
+                                key: "{i}",
+                                view: card.view,
+                                status: card.status,
+                                edit_error: card.edit_error,
+                                on_expired: move |_| set_status(&mut cards, &id, ProposalStatus::Expired),
+                                lang: lang.clone(),
+                            }
+                        }
+                    })
                 }
                 {
                     if let Some(answer) = result() {


### PR DESCRIPTION
Closes #108.

## Problem

A note that reads like an instruction could be run, but never performed a connector write: `NoteActions` called `prompt_chat_agent` with `status_tx: None`, which is the notes-only surface with an observe-only hook. The same sentence typed in chat went through governance and produced an approval card.

## Change

- `NoteActions` opens a `ToolEvent` channel and passes it as `status_tx`. Connector writes now hold for approval on this path too.
- `ApprovalCard` is mounted under the run button, and `ToolEvent::Started` replaces the mute spinner with the live tool label.
- `ApprovalCard`'s only tie to the chat was `messages: Signal<Vec<ChatMsg>>`, used to freeze a card whose run already died. It becomes `on_expired: EventHandler<()>`, so the same component serves the chat and a note without a note importing `ChatMsg`.
- The event loop lives in a free `drain_tool_events` rather than inline in the `onclick`, and the note keeps its own `Card` shape.

## Open question, decided

The issue asked whether a pending proposal should persist. It does not: a note has no message table, and the setting `note_action:<id>` only caches the final answer. An undecided proposal expires with the run, which is the fail-closed default everywhere else.

## Styling

Approve and Confirm move from `bg-ios-green` to the `bg-ios-orange` primary, and the approved/edited pills to `bg-ios-orange-50`. The green was outside the design system. Reject keeps the red.

## Verification

680 tests pass, clippy clean. Device-validated on iPhone: a note whose text triggers a connector write shows the card, approving performs the write, and the tool status is visible while the agent runs.
