### PR TITLE
feat(chat): title conversations with the LLM instead of truncating to 50 chars

### DIFF
--- a/src/application/titling.rs
+++ b/src/application/titling.rs
@@ -1,6 +1,7 @@
 use crate::application::constants::{CHEAP_MODEL, TITLE_SYSTEM_PROMPT};
 use crate::application::error::LlmError;
 use crate::infrastructure::llm::LlmClient;
+use crate::infrastructure::persistence::Database;
 
 pub async fn generate_title(
     client: &LlmClient,
@@ -19,4 +20,31 @@ pub async fn generate_title(
         return Err(LlmError::Completion("Empty title".into()));
     }
     Ok(title)
+}
+
+/// Replace a conversation's placeholder title with a real one once the first
+/// answer lands. Returns the new title, or `None` when nothing was written.
+///
+/// The stored title must still equal `placeholder`: anything else means the
+/// user renamed the conversation by hand, and a manual rename is final.
+pub async fn retitle_conversation(
+    db: &Database,
+    conv_id: &str,
+    placeholder: &str,
+    content: &str,
+    lang: &str,
+) -> Option<String> {
+    let current = db
+        .list_conversations()
+        .ok()?
+        .into_iter()
+        .find(|c| c.id == conv_id)?
+        .title;
+    if current != placeholder {
+        return None;
+    }
+    let client = LlmClient::from_db(db).ok()?;
+    let title = generate_title(&client, content, lang).await.ok()?;
+    db.update_conversation_title(conv_id, &title).ok()?;
+    Some(title)
 }

--- a/src/ui/chat/actions.rs
+++ b/src/ui/chat/actions.rs
@@ -8,6 +8,7 @@ use crate::infrastructure::persistence::Database;
 use crate::ui::chat::models::{
     tool_label, ChatMsg, ChatSource, ProposalStatus,
 };
+use crate::ui::AppState;
 use dioxus::prelude::*;
 use std::sync::Arc;
 
@@ -234,6 +235,7 @@ pub fn send_question(
     web: bool,
     mention_ids: Vec<String>,
     lang: String,
+    app: AppState,
 ) {
     // Snapshot the recent turns BEFORE pushing the new question: this is the conversation
     // context rag::query rewrites follow-ups against ("et lui ?" -> the referent's name).
@@ -258,6 +260,10 @@ pub fn send_question(
             })
             .collect()
     };
+
+    // Only the opening turn carries the placeholder title the LLM refines later.
+    let first_turn = history.is_empty();
+    let placeholder: String = question.chars().take(50).collect();
 
     messages.write().push(ChatMsg::User(question.clone()));
     loading.set(true);
@@ -409,11 +415,32 @@ pub fn send_question(
                     }
                 }
 
+                let title_source =
+                    first_turn.then(|| format!("{question}\n\n{}", r.answer));
+
                 msgs.write().push(ChatMsg::Bot {
                     text: r.answer,
                     sources,
                     trace: r.trace,
                 });
+
+                if let (Some(source), Some(cid)) = (title_source, conv_signal())
+                {
+                    let titled =
+                        crate::application::titling::retitle_conversation(
+                            &db(),
+                            &cid,
+                            &placeholder,
+                            &source,
+                            &lang,
+                        )
+                        .await;
+                    if titled.is_some() {
+                        // The drawer stays mounted: the Chats list only re-reads on this bump.
+                        let mut app = app;
+                        app.invalidate_data();
+                    }
+                }
             }
             Err(e) => {
                 let err_msg = chat_error_message(&lang, &e);

--- a/src/ui/chat/view.rs
+++ b/src/ui/chat/view.rs
@@ -260,7 +260,7 @@ pub fn ChatView() -> Element {
                 let mention_ids: Vec<String> =
                     mentions().iter().map(|m| m.note_id.clone()).collect();
                 let lang = (app.current_lang)();
-                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, scope, web, mention_ids, lang);
+                send_question(q, &mut messages, &mut loading, &mut tool_status, conversation_id, db, scope, web, mention_ids, lang, app);
                 mentions.set(Vec::new());
             },
         }


### PR DESCRIPTION
## What

A conversation was titled with the first 50 characters of the first message,
truncated mid-word, and never revisited. Notes already get a real LLM title;
the chat generated one only for the note it saves from an answer, never for
itself.

The truncated title stays as the immediate placeholder. Once the first answer
lands, `retitle_conversation` generates a real title from the question plus
the answer and writes it, then the drawer's Chats list is invalidated so it
re-reads.

## How

- `application/titling.rs` — `retitle_conversation`: reads the stored title,
  bails out unless it still equals the placeholder, generates via the existing
  `generate_title` on `CHEAP_MODEL`, writes through `update_conversation_title`.
  A manual rename is final: anything other than the placeholder means the user
  named it, and nothing is written.
- `ui/chat/actions.rs` — `send_question` takes the `AppState` and, on the
  opening turn only (`history.is_empty()`), retitles after the bot message is
  pushed, then calls `invalidate_data()`.
- `ui/chat/view.rs` — passes `app` at the call site.

Cost: one cheap-model call per conversation, once, after the first answer.
It runs on the same task as the answer, so it never blocks the reply.

## Verification

`cargo check --features mobile` clean, `make check` clean, 680 tests pass.

On device: start a chat, the sidebar shows the truncated placeholder at once,
then it refines into a real title after the first answer. Renaming it by hand
sticks across further turns.

Closes #110

https://claude.ai/code/session_01A8tSXuyKrYC2guUc6dSESd
