### PR TITLE
feat(notes): open a note action menu at the finger, straight from the list

### DIFF
--- a/src/application/i18n/locales/en.ftl
+++ b/src/application/i18n/locales/en.ftl
@@ -323,6 +323,8 @@ folder-menu-delete-warning = Notes in this theme are not deleted.
 note-menu-import = Import a document
 note-menu-import-audio = Import an audio
 note-menu-delete = Delete note
+note-menu-copy = Copy text
+note-menu-no-folder = No folder
 
 audio-transcribing = Transcribing
 audio-transcription-failed = Transcription failed

--- a/src/application/i18n/locales/fr.ftl
+++ b/src/application/i18n/locales/fr.ftl
@@ -323,6 +323,8 @@ folder-menu-delete-warning = Les notes du thème ne seront pas supprimées.
 note-menu-import = Importer un document
 note-menu-import-audio = Importer un audio
 note-menu-delete = Supprimer la note
+note-menu-copy = Copier le texte
+note-menu-no-folder = Aucun dossier
 
 audio-transcribing = Transcription en cours
 audio-transcription-failed = Échec de la transcription

--- a/src/application/note_persistence.rs
+++ b/src/application/note_persistence.rs
@@ -33,6 +33,19 @@ pub fn create_note(
     Some((created, audio_id))
 }
 
+/// Removes the note and everything only it owns: its audio files on disk and
+/// its vector chunks. Rows that cascade (attachments, reminders) are left to
+/// SQLite. Sync scheduling stays with the caller, which owns the session.
+pub fn delete_note(db: &Database, id: &str) {
+    for audio in db.list_audios(id).unwrap_or_default() {
+        let path =
+            crate::infrastructure::audio::resolve_audio_path(&audio.file_path);
+        let _ = std::fs::remove_file(path);
+    }
+    let _ = db.delete_note(id);
+    crate::application::embed::delete_note_embeddings(id.to_string());
+}
+
 pub fn update_note(
     db: &Database,
     id: &str,

--- a/src/ui/app/router.rs
+++ b/src/ui/app/router.rs
@@ -6,6 +6,7 @@ use crate::ui::chat::ChatView;
 use crate::ui::notes::attachment_modal::AttachmentModal;
 use crate::ui::notes::folder_picker;
 use crate::ui::notes::note_list::NotesList;
+use crate::ui::notes::row_menu::NoteRowMenu;
 use crate::ui::notes::NoteDetail;
 use crate::ui::settings::{SettingsSectionView, SettingsView};
 use crate::ui::sidebar::SidebarOverlay;
@@ -22,6 +23,7 @@ pub fn AppRouter(index_rebuilding: Signal<bool>) -> Element {
             SidebarOverlay {}
             RightNav {}
             AttachmentModal {}
+            NoteRowMenu {}
             div { class: "flex flex-col h-screen safe-pt lg:flex-1 lg:min-w-0",
                 TopBar {}
                 if index_rebuilding() {

--- a/src/ui/kit.rs
+++ b/src/ui/kit.rs
@@ -16,6 +16,8 @@ pub const PILL_GHOST: &str = "shrink-0 h-9 px-3 flex items-center justify-center
 
 pub const MENU_PANEL: &str = "z-50 min-w-[200px] bg-warm-white border border-stone-200 rounded-xl shadow-lg p-1 menu-pop";
 
+pub const MENU_PANEL_ANCHORED: &str = "z-50 w-60 bg-warm-white border border-stone-200 rounded-xl p-1 menu-anchor";
+
 pub const MENU_ITEM: &str = "w-full flex items-center gap-2.5 px-3 py-2.5 min-h-[40px] rounded-lg text-sm text-stone-800 text-left active:bg-stone-100 hover:bg-stone-100 transition-colors duration-150";
 
 pub const MENU_ITEM_DANGER: &str = "w-full flex items-center gap-2.5 px-3 py-2.5 min-h-[40px] rounded-lg text-sm text-ios-red-dark text-left active:bg-ios-red-50 hover:bg-ios-red-50 transition-colors duration-150";

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -1,4 +1,3 @@
-use crate::application::embed::delete_note_embeddings;
 use crate::application::i18n::t;
 use crate::ui::icons::*;
 use crate::ui::kit;
@@ -173,11 +172,7 @@ pub fn NoteMenu(
                                 move |_| {
                                     app.show_note_menu.set(false);
                                     deleted.set(true);
-                                    for a in db().list_audios(&note_id).unwrap_or_default() {
-                                        let _ = std::fs::remove_file(crate::infrastructure::audio::resolve_audio_path(&a.file_path));
-                                    }
-                                    let _ = db().delete_note(&note_id);
-                                    delete_note_embeddings(note_id.clone());
+                                    crate::application::note_persistence::delete_note(&db(), &note_id);
                                     engine.peek().schedule_debounced();
                                     app.current_note_id.set(None);
                                 }

--- a/src/ui/notes/mod.rs
+++ b/src/ui/notes/mod.rs
@@ -15,5 +15,6 @@ pub(crate) mod attachment_modal;
 pub(crate) mod folder_picker;
 pub(crate) mod note_card;
 pub(crate) mod note_list;
+pub(crate) mod row_menu;
 
 pub use detail::NoteDetail;

--- a/src/ui/notes/note_card.rs
+++ b/src/ui/notes/note_card.rs
@@ -2,9 +2,14 @@ use crate::application::i18n::t;
 use crate::domain::Note;
 use crate::infrastructure::persistence::Database;
 use crate::ui::icons::{IconArrowUpRight, IconBell};
-use crate::ui::{AppState, View};
+use crate::ui::{AppState, RowMenu, View};
 use dioxus::prelude::*;
 use std::sync::Arc;
+
+/// Finger travel, in CSS pixels, past which a press is a scroll, not a hold.
+const PRESS_SLOP: f64 = 10.0;
+/// How long a finger must stay down before the note action sheet opens.
+const LONG_PRESS_MS: u64 = 450;
 
 #[component]
 pub fn NoteCard(note: Note) -> Element {
@@ -12,6 +17,14 @@ pub fn NoteCard(note: Note) -> Element {
     let db: Signal<Arc<Database>> = use_context();
     let note_id = note.id.clone();
     let lang = (app.current_lang)();
+    // Same press bookkeeping as the related-notes rows (related.rs): a counter
+    // invalidates the pending timer when the finger lifts or the list scrolls.
+    let mut press_seq = use_signal(|| 0u32);
+    let mut pressed = use_signal(|| None::<u32>);
+    let mut press_origin = use_signal(|| (0.0f64, 0.0f64));
+    let mut suppress_click = use_signal(|| false);
+    let press_id = note.id.clone();
+    let menu_id = note.id.clone();
 
     let title = note
         .title
@@ -46,10 +59,66 @@ pub fn NoteCard(note: Note) -> Element {
         .ok()
         .and_then(|f| f.first().map(|f| f.name.clone()));
 
+    // The pressed card stays lit above the dimming veil the list draws.
+    let picked = (app.row_menu)() == Some(RowMenu::Note(note.id.clone()));
+
     rsx! {
         div {
             class: "bg-warm-white p-4 border border-stone-200 rounded-xl mb-2.5 lg:mb-0 lg:h-full cursor-pointer break-inside-avoid hover:border-stone-300 hover:shadow-sm transition-all duration-150",
+            // Sits between the veil and the menu: lit enough to read as selected,
+            // dimmer than the panel that owns the focus.
+            class: if picked { "relative z-20 shadow-xl border-stone-300 brightness-90" } else { "" },
+            onpointerdown: move |evt| {
+                let p = evt.client_coordinates();
+                press_origin.set((p.x, p.y));
+                let seq = press_seq() + 1;
+                press_seq.set(seq);
+                pressed.set(Some(seq));
+                let id = press_id.clone();
+                spawn(async move {
+                    futures_timer::Delay::new(
+                        std::time::Duration::from_millis(LONG_PRESS_MS),
+                    )
+                    .await;
+                    if pressed() == Some(seq) {
+                        pressed.set(None);
+                        suppress_click.set(true);
+                        app.row_menu_at.set(press_origin());
+                        app.row_menu.set(Some(RowMenu::Note(id)));
+                    }
+                });
+            },
+            // Desktop equivalent of the hold, per the platform convention.
+            oncontextmenu: move |evt| {
+                evt.prevent_default();
+                pressed.set(None);
+                let p = evt.client_coordinates();
+                app.row_menu_at.set((p.x, p.y));
+                app.row_menu.set(Some(RowMenu::Note(menu_id.clone())));
+            },
+            onpointerup: move |_| pressed.set(None),
+            onpointercancel: move |_| pressed.set(None),
+            onpointerleave: move |_| pressed.set(None),
+            // A finger always drifts a little; only real travel (a scroll) cancels.
+            onpointermove: move |evt| {
+                if pressed().is_none() {
+                    return;
+                }
+                let p = evt.client_coordinates();
+                let (ox, oy) = press_origin();
+                if (p.x - ox).abs() > PRESS_SLOP || (p.y - oy).abs() > PRESS_SLOP {
+                    pressed.set(None);
+                }
+            },
             onclick: move |_| {
+                if suppress_click() {
+                    suppress_click.set(false);
+                    return;
+                }
+                if (app.row_menu)().is_some() {
+                    app.row_menu.set(None);
+                    return;
+                }
                 app.show_folder_picker.set(false);
                 app.view.set(View::NoteDetail { note_id: note_id.clone() });
             },

--- a/src/ui/notes/note_list.rs
+++ b/src/ui/notes/note_list.rs
@@ -4,7 +4,7 @@ use crate::infrastructure::persistence::Database;
 use crate::ui::icons::*;
 use crate::ui::notes::note_card::NoteCard;
 use crate::ui::thread::ThreadCard;
-use crate::ui::AppState;
+use crate::ui::{AppState, RowMenu};
 use dioxus::prelude::*;
 use std::sync::Arc;
 
@@ -148,6 +148,12 @@ pub fn NotesList() -> Element {
                 }
             }
         } else {
+            // Dims the rest of the list while a note menu is open, so the pressed
+            // card reads as picked up. Visual only: the outside-click catcher is
+            // the global row-menu backdrop.
+            if matches!((app.row_menu)(), Some(RowMenu::Note(_))) {
+                div { class: "absolute inset-0 z-10 bg-black/35 pointer-events-none backdrop-fade" }
+            }
             div { class: "safe-pb-32 lg:grid lg:grid-cols-2 lg:gap-2.5",
                 for item in notes().into_iter().take(visible_count()) {
                     match item {

--- a/src/ui/notes/row_menu.rs
+++ b/src/ui/notes/row_menu.rs
@@ -1,0 +1,191 @@
+use crate::application::i18n::t;
+use crate::domain::flatten_tree;
+use crate::infrastructure::persistence::Database;
+use crate::infrastructure::sync::engine::SyncEngine;
+use crate::ui::icons::{IconCopy, IconFolder, IconTrash};
+use crate::ui::{kit, AppState, RowMenu};
+use dioxus::prelude::*;
+use std::sync::Arc;
+
+/// Panel width, mirroring `w-60` in `MENU_PANEL_ANCHORED`.
+const MENU_W: u32 = 240;
+/// Gap kept between the panel and the screen edge.
+const EDGE: u32 = 12;
+/// How much of the panel stays on screen when the press is near the bottom.
+const MIN_VISIBLE: u32 = 240;
+
+/// Applies a folder move off the render pass, so the card is never torn down
+/// in the same patch as the menu that triggered it.
+fn move_note(
+    mut app: AppState,
+    db: Signal<Arc<Database>>,
+    engine: Signal<Arc<SyncEngine>>,
+    note_id: String,
+    target: Option<String>,
+) {
+    app.row_menu.set(None);
+    spawn(async move {
+        let database = db();
+        for old in database.folders_for_note(&note_id).unwrap_or_default() {
+            let _ = database.remove_note_from_folder(&note_id, &old.id);
+        }
+        if let Some(fid) = target {
+            let _ = database.add_note_to_folder(&note_id, &fid);
+        }
+        engine.peek().schedule_debounced();
+        app.notes_version.set((app.notes_version)() + 1);
+    });
+}
+
+/// Long-press sheet for a note in the list. Mounted ONCE at the app root, not
+/// per card: `#notes-scroll` carries a `transform`, which would contain a
+/// `fixed` child, and a menu living in the row's subtree gets orphaned when
+/// the row is deleted (the frozen-taps bug).
+#[component]
+pub fn NoteRowMenu() -> Element {
+    let mut app: AppState = use_context();
+    let db: Signal<Arc<Database>> = use_context();
+    let engine: Signal<Arc<SyncEngine>> = use_context();
+    let mut confirm_delete = use_signal(|| false);
+    let mut moving = use_signal(|| false);
+    let lang = (app.current_lang)();
+
+    let Some(RowMenu::Note(note_id)) = (app.row_menu)() else {
+        return rsx! {};
+    };
+
+    let _ = (app.notes_version)();
+    let _ = (app.folders_version)();
+    let Ok(Some(note)) = db().get_note(&note_id) else {
+        return rsx! {};
+    };
+    let folders = flatten_tree(&db().list_all_folders().unwrap_or_default());
+    let current_folder = db()
+        .folders_for_note(&note_id)
+        .ok()
+        .and_then(|f| f.first().map(|f| f.id.clone()));
+
+    let title = note
+        .title
+        .clone()
+        .unwrap_or_else(|| t(&lang, "note-card-untitled"));
+    let copy_payload = format!("{title}\n\n{}", note.content);
+    let id_root = note_id.clone();
+    let id_delete = note_id.clone();
+
+    // Anchored to the press point, clamped in pure CSS: `min()` keeps the panel
+    // on screen near the right or bottom edge without measuring the viewport
+    // from Rust, and the height follows from the same clamped top.
+    let (x, y) = (app.row_menu_at)();
+    let anchor = format!(
+        "--mx: min({x}px, calc(100vw - {MENU_W}px - {EDGE}px)); \
+         --my: min({y}px, calc(100vh - {MIN_VISIBLE}px)); \
+         left: var(--mx); top: var(--my); \
+         max-height: calc(100vh - var(--my) - {EDGE}px);"
+    );
+
+    rsx! {
+        div {
+            class: "fixed overflow-y-auto {kit::MENU_PANEL_ANCHORED}",
+            style: "{anchor}",
+            if moving() {
+                button {
+                    class: kit::MENU_ITEM,
+                    onclick: {
+                        let id = id_root.clone();
+                        move |_| {
+                            moving.set(false);
+                            move_note(app, db, engine, id.clone(), None);
+                        }
+                    },
+                    IconFolder { size: 16 }
+                    {t(&lang, "note-menu-no-folder")}
+                }
+                for (folder, depth) in folders.into_iter() {
+                    {
+                        let fid = folder.id.clone();
+                        let nid = note_id.clone();
+                        let is_current = current_folder.as_deref() == Some(fid.as_str());
+                        let indent = format!("padding-left: {}px", 12 + depth * 14);
+                        rsx! {
+                            button {
+                                key: "{folder.id}",
+                                class: "{kit::MENU_ITEM}",
+                                class: if is_current { "text-ios-orange-dark font-medium" } else { "" },
+                                style: "{indent}",
+                                onclick: move |_| {
+                                    moving.set(false);
+                                    move_note(app, db, engine, nid.clone(), Some(fid.clone()));
+                                },
+                                IconFolder { size: 16 }
+                                span { class: "truncate", "{folder.name}" }
+                            }
+                        }
+                    }
+                }
+            } else if confirm_delete() {
+                div { class: "px-3 py-2.5",
+                    p { class: "text-sm font-semibold text-stone-900 mb-0.5",
+                        {t(&lang, "note-menu-delete-title")}
+                    }
+                    p { class: "text-xs text-stone-500 mb-3",
+                        {t(&lang, "note-menu-delete-warning")}
+                    }
+                    div { class: "flex gap-2",
+                        button {
+                            class: kit::CONFIRM_BTN_GHOST,
+                            onclick: move |_| {
+                                confirm_delete.set(false);
+                                app.row_menu.set(None);
+                            },
+                            {t(&lang, "chat-menu-cancel")}
+                        }
+                        button {
+                            class: kit::CONFIRM_BTN_DANGER,
+                            onclick: move |_| {
+                                // Close this render pass, delete on the next task: the card
+                                // must never be torn down in the same patch as its own menu.
+                                let id = id_delete.clone();
+                                confirm_delete.set(false);
+                                app.row_menu.set(None);
+                                spawn(async move {
+                                    crate::application::note_persistence::delete_note(&db(), &id);
+                                    engine.peek().schedule_debounced();
+                                    app.notes_version.set((app.notes_version)() + 1);
+                                });
+                            },
+                            {t(&lang, "chat-menu-delete")}
+                        }
+                    }
+                }
+            } else {
+                p { class: "px-3 pt-1.5 pb-2 text-xs text-stone-400 truncate", "{title}" }
+                button {
+                    class: kit::MENU_ITEM,
+                    onclick: move |_| moving.set(true),
+                    IconFolder { size: 16 }
+                    {t(&lang, "folder-menu-move")}
+                }
+                button {
+                    class: kit::MENU_ITEM,
+                    onclick: {
+                        let payload = copy_payload.clone();
+                        move |_| {
+                            crate::ui::clipboard::copy_text(&payload);
+                            app.row_menu.set(None);
+                        }
+                    },
+                    IconCopy { size: 16 }
+                    {t(&lang, "note-menu-copy")}
+                }
+                div { class: kit::MENU_SEP }
+                button {
+                    class: kit::MENU_ITEM_DANGER,
+                    onclick: move |_| confirm_delete.set(true),
+                    IconTrash { size: 16 }
+                    {t(&lang, "note-menu-delete")}
+                }
+            }
+        }
+    }
+}

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -48,6 +48,7 @@ impl SettingsSection {
 pub enum RowMenu {
     Conversation(String),
     Folder(String),
+    Note(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -107,6 +108,9 @@ pub struct AppState {
     pub audio_import_requested: Signal<bool>,
     pub sync_data_version: Signal<u64>,
     pub row_menu: Signal<Option<RowMenu>>,
+    // Where the finger was when the row menu opened, in client pixels. The menu
+    // grows out of that point instead of a fixed corner.
+    pub row_menu_at: Signal<(f64, f64)>,
     pub view_history: Signal<Vec<View>>,
     pub view_future: Signal<Vec<View>>,
     pub history_nav: Signal<bool>,
@@ -160,6 +164,7 @@ impl AppState {
             audio_import_requested: Signal::new(false),
             sync_data_version: Signal::new(0),
             row_menu: Signal::new(None),
+            row_menu_at: Signal::new((0.0, 0.0)),
             view_history: Signal::new(Vec::new()),
             view_future: Signal::new(Vec::new()),
             history_nav: Signal::new(false),

--- a/tailwind.css
+++ b/tailwind.css
@@ -58,6 +58,26 @@
     transform-origin: top right;
 }
 
+/* Note action menu: opens at the finger, so it grows out of the press point
+   instead of a fixed corner, with a deeper shadow to lift it off the cards. */
+.menu-anchor {
+    animation: popAnchor 0.19s cubic-bezier(0.2, 0.9, 0.25, 1.15);
+    transform-origin: top left;
+    box-shadow:
+        0 18px 40px -12px rgba(28, 25, 23, 0.28),
+        0 4px 10px -4px rgba(28, 25, 23, 0.14);
+}
+@keyframes popAnchor {
+    from {
+        opacity: 0;
+        transform: scale(0.86);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
 /* Composer "+" menu: bottom-sheet springs up on mobile, popover pops above the
    button on desktop, backdrop and tooltip fade. */
 .sheet-pop {


### PR DESCRIPTION
Closes #111.

## What

Press and hold a note in the list (or right-click it on desktop) and an
action menu opens at the finger: move to a folder, copy the text, delete
with confirmation. Short tap still opens the note. Nothing here is new
capability — every action already existed behind opening the note first.

## How

- `RowMenu::Note`, the third variant of the global row-menu slot already
  used by sidebar conversations and folders. The outside-click backdrop
  (`sidebar/mod.rs`) needs no change: it already lives outside any row
  subtree and outside the transformed list container.
- `ui/notes/row_menu.rs` renders the panel **once**, at the app root.
  `#notes-scroll` carries a `transform`, which would contain a `fixed`
  child, and a menu mounted inside a card gets orphaned when the card is
  deleted — the frozen-taps regression this pattern exists to prevent.
- The panel is anchored to the press point and clamped with CSS `min()`
  and `calc()`, so it stays on screen near an edge without measuring the
  viewport from Rust.
- The rest of the list dims to `bg-black/35` (the drawer's grey) while
  the menu is open; the pressed card stays lit above the veil at 90%
  brightness, between the veil and the panel.
- Long press reuses the press bookkeeping already proven in
  `notes/related.rs`: a sequence counter invalidates the pending timer,
  450 ms, cancelled past 10 px of travel so scrolling never triggers it.
  Pure Rust pointer events, no new `.ts`.

## Refactor folded in

The full delete-a-note sequence (audio files on disk, row, vector chunks)
was inlined in `NoteMenu`. It moves to
`application::note_persistence::delete_note`, next to `create_note` and
`update_note`, and both the detail menu and the new list menu call it.
Sync scheduling stays with the callers, which own the session.

## Design

Three directions were mocked up and reviewed; this is the one picked:
the iOS 14 menu that opens next to the tap rather than a fixed-corner
panel or a bottom sheet. New style hook `.menu-anchor` (transform-origin
at the press point, deeper shadow) and `kit::MENU_PANEL_ANCHORED`.
`folder-menu-move`, `note-menu-delete*`, `chat-menu-cancel/delete` are
reused as-is; two new keys, `note-menu-copy` and `note-menu-no-folder`,
in both locales.

Sharing was left out: `platform/ios/share.rs` is file-only, and sharing
text would need new objc2 FFI for a shortcut this size.

## Verified on device

iPhone and the Mac app, both built and installed from this branch:
long press and right-click, short tap still navigates, scroll never
triggers the menu, move/copy/delete, tap-outside dismiss, and the
orphan-backdrop regression check (delete from the list, then tap another
note, open the drawer, tap a folder). Deleting from the detail menu — the
second caller of the extracted use case — still removes the audio files.
