### PR TITLE
refactor(ui): one delete-confirmation block, shared by the five row menus

### DIFF
--- a/src/ui/chat/menu.rs
+++ b/src/ui/chat/menu.rs
@@ -1,6 +1,7 @@
 use crate::application::i18n::t;
 use crate::infrastructure::persistence::Database;
 use crate::ui::chat::models::ChatSource;
+use crate::ui::delete_confirm::DeleteConfirm;
 use crate::ui::icons::*;
 use crate::ui::kit;
 use crate::ui::state::View;
@@ -99,44 +100,36 @@ pub fn ChatMenu(props: ChatMenuProps) -> Element {
                     }
                 }
             } else if confirm_delete() {
-                div { class: "px-3 py-2.5",
-                    p { class: "text-sm font-semibold text-stone-900 mb-0.5", {t(&lang, "chat-menu-delete-title")} }
-                    p { class: "text-xs text-stone-500 mb-3", {t(&lang, "chat-menu-delete-warning")} }
-                    div { class: "flex gap-2",
-                        button {
-                            class: kit::CONFIRM_BTN_GHOST,
-                            onclick: move |_| {
-                                confirm_delete.set(false);
-                                app.show_chat_menu.set(false);
-                            },
-                            {t(&lang, "chat-menu-cancel")}
+                DeleteConfirm {
+                    title: t(&lang, "chat-menu-delete-title"),
+                    warning: t(&lang, "chat-menu-delete-warning"),
+                    cancel_label: t(&lang, "chat-menu-cancel"),
+                    confirm_label: t(&lang, "chat-menu-delete"),
+                    on_cancel: move |_| {
+                        confirm_delete.set(false);
+                        app.show_chat_menu.set(false);
+                    },
+                    on_confirm: move |_| {
+                        if let Some(ref cid) = conversation_id() {
+                            let _ = db().delete_conversation(cid);
                         }
-                        button {
-                            class: kit::CONFIRM_BTN_DANGER,
-                            onclick: move |_| {
-                                if let Some(ref cid) = conversation_id() {
-                                    let _ = db().delete_conversation(cid);
-                                }
-                                // The drawer's conversation list stays mounted on mobile (the swipe
-                                // panel never unmounts) and only re-reads on this version: without
-                                // the bump the deleted chat ghosts in the list.
-                                app.invalidate_data();
-                                confirm_delete.set(false);
-                                app.show_chat_menu.set(false);
-                                app.sliding_out.set(true);
-                                // spawn_forever, NOT spawn: show_chat_menu=false unmounts THIS menu in
-                                // the same click, which cancels a scope-bound task mid-delay - leaving
-                                // sliding_out stuck true (whole screen pointer-events-none) and the
-                                // view never set. The freeze-after-delete bug.
-                                dioxus::core::spawn_forever(async move {
-                                    futures_timer::Delay::new(std::time::Duration::from_millis(150)).await;
-                                    app.sliding_out.set(false);
-                                    app.view.set(View::NotesList);
-                                });
-                            },
-                            {t(&lang, "chat-menu-delete")}
-                        }
-                    }
+                        // The drawer's conversation list stays mounted on mobile (the swipe
+                        // panel never unmounts) and only re-reads on this version: without
+                        // the bump the deleted chat ghosts in the list.
+                        app.invalidate_data();
+                        confirm_delete.set(false);
+                        app.show_chat_menu.set(false);
+                        app.sliding_out.set(true);
+                        // spawn_forever, NOT spawn: show_chat_menu=false unmounts THIS menu in
+                        // the same click, which cancels a scope-bound task mid-delay - leaving
+                        // sliding_out stuck true (whole screen pointer-events-none) and the
+                        // view never set. The freeze-after-delete bug.
+                        dioxus::core::spawn_forever(async move {
+                            futures_timer::Delay::new(std::time::Duration::from_millis(150)).await;
+                            app.sliding_out.set(false);
+                            app.view.set(View::NotesList);
+                        });
+                    },
                 }
             } else {
                 button {

--- a/src/ui/delete_confirm.rs
+++ b/src/ui/delete_confirm.rs
@@ -1,0 +1,31 @@
+use crate::ui::kit;
+use dioxus::prelude::*;
+
+#[component]
+pub fn DeleteConfirm(
+    title: String,
+    warning: String,
+    cancel_label: String,
+    confirm_label: String,
+    on_cancel: EventHandler<MouseEvent>,
+    on_confirm: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
+        div { class: "px-3 py-2.5",
+            p { class: "text-sm font-semibold text-stone-900 mb-0.5", "{title}" }
+            p { class: "text-xs text-stone-500 mb-3", "{warning}" }
+            div { class: "flex gap-2",
+                button {
+                    class: kit::CONFIRM_BTN_GHOST,
+                    onclick: move |e| on_cancel.call(e),
+                    "{cancel_label}"
+                }
+                button {
+                    class: kit::CONFIRM_BTN_DANGER,
+                    onclick: move |e| on_confirm.call(e),
+                    "{confirm_label}"
+                }
+            }
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod app;
 mod chat;
 mod clipboard;
+pub(crate) mod delete_confirm;
 pub mod hooks;
 pub mod icons;
 mod keyboard;

--- a/src/ui/notes/menu.rs
+++ b/src/ui/notes/menu.rs
@@ -1,4 +1,5 @@
 use crate::application::i18n::t;
+use crate::ui::delete_confirm::DeleteConfirm;
 use crate::ui::icons::*;
 use crate::ui::kit;
 use crate::ui::AppState;
@@ -149,37 +150,25 @@ pub fn NoteMenu(
         }
         div { class: "absolute right-4 top-1 {kit::MENU_PANEL}",
             if confirm_delete() {
-                div { class: "px-3 py-2.5",
-                    p { class: "text-sm font-semibold text-stone-900 mb-0.5",
-                        {t(&lang, "note-menu-delete-title")}
-                    }
-                    p { class: "text-xs text-stone-500 mb-3",
-                        {t(&lang, "note-menu-delete-warning")}
-                    }
-                    div { class: "flex gap-2",
-                        button {
-                            class: kit::CONFIRM_BTN_GHOST,
-                            onclick: move |_| {
-                                confirm_delete.set(false);
-                                app.show_note_menu.set(false);
-                            },
-                            {t(&lang, "chat-menu-cancel")}
+                DeleteConfirm {
+                    title: t(&lang, "note-menu-delete-title"),
+                    warning: t(&lang, "note-menu-delete-warning"),
+                    cancel_label: t(&lang, "chat-menu-cancel"),
+                    confirm_label: t(&lang, "chat-menu-delete"),
+                    on_cancel: move |_| {
+                        confirm_delete.set(false);
+                        app.show_note_menu.set(false);
+                    },
+                    on_confirm: {
+                        let note_id = note_id.clone();
+                        move |_| {
+                            app.show_note_menu.set(false);
+                            deleted.set(true);
+                            crate::application::note_persistence::delete_note(&db(), &note_id);
+                            engine.peek().schedule_debounced();
+                            app.current_note_id.set(None);
                         }
-                        button {
-                            class: kit::CONFIRM_BTN_DANGER,
-                            onclick: {
-                                let note_id = note_id.clone();
-                                move |_| {
-                                    app.show_note_menu.set(false);
-                                    deleted.set(true);
-                                    crate::application::note_persistence::delete_note(&db(), &note_id);
-                                    engine.peek().schedule_debounced();
-                                    app.current_note_id.set(None);
-                                }
-                            },
-                            {t(&lang, "chat-menu-delete")}
-                        }
-                    }
+                    },
                 }
             } else {
                 button {

--- a/src/ui/sidebar/conversations.rs
+++ b/src/ui/sidebar/conversations.rs
@@ -1,5 +1,6 @@
 use crate::application::i18n::t;
 use crate::infrastructure::persistence::Database;
+use crate::ui::delete_confirm::DeleteConfirm;
 use crate::ui::icons::*;
 use crate::ui::kit;
 use crate::ui::{AppState, RowMenu, View};
@@ -185,39 +186,27 @@ fn ConversationItem(
                 if menu_open {
                     div { class: "absolute right-2 top-full {kit::MENU_PANEL}",
                         if confirm_delete() {
-                            div { class: "px-3 py-2.5",
-                                p { class: "text-sm font-semibold text-stone-900 mb-0.5",
-                                    {t(&lang, "chat-menu-delete-title")}
-                                }
-                                p { class: "text-xs text-stone-500 mb-3",
-                                    {t(&lang, "chat-menu-delete-warning")}
-                                }
-                                div { class: "flex gap-2",
-                                    button {
-                                        class: kit::CONFIRM_BTN_GHOST,
-                                        onclick: move |_| {
-                                            confirm_delete.set(false);
-                                            app.row_menu.set(None);
-                                        },
-                                        {t(&lang, "chat-menu-cancel")}
-                                    }
-                                    button {
-                                        class: kit::CONFIRM_BTN_DANGER,
-                                        onclick: move |_| {
-                                            // Close the menu THIS render pass, delete on the next
-                                            // task: the row must never be torn down in the same
-                                            // patch as its own open menu (orphaned-node freeze).
-                                            confirm_delete.set(false);
-                                            app.row_menu.set(None);
-                                            let cid = conv_id_del.clone();
-                                            spawn(async move {
-                                                let _ = db().delete_conversation(&cid);
-                                                app.invalidate_data();
-                                            });
-                                        },
-                                        {t(&lang, "chat-menu-delete")}
-                                    }
-                                }
+                            DeleteConfirm {
+                                title: t(&lang, "chat-menu-delete-title"),
+                                warning: t(&lang, "chat-menu-delete-warning"),
+                                cancel_label: t(&lang, "chat-menu-cancel"),
+                                confirm_label: t(&lang, "chat-menu-delete"),
+                                on_cancel: move |_| {
+                                    confirm_delete.set(false);
+                                    app.row_menu.set(None);
+                                },
+                                on_confirm: move |_| {
+                                    // Close the menu THIS render pass, delete on the next
+                                    // task: the row must never be torn down in the same
+                                    // patch as its own open menu (orphaned-node freeze).
+                                    confirm_delete.set(false);
+                                    app.row_menu.set(None);
+                                    let cid = conv_id_del.clone();
+                                    spawn(async move {
+                                        let _ = db().delete_conversation(&cid);
+                                        app.invalidate_data();
+                                    });
+                                },
                             }
                         } else {
                             button {

--- a/src/ui/sidebar/folders.rs
+++ b/src/ui/sidebar/folders.rs
@@ -3,6 +3,7 @@ use crate::domain::{
     flatten_tree, subtree_ids, Folder, NewFolder, UpdateFolder,
 };
 use crate::infrastructure::persistence::Database;
+use crate::ui::delete_confirm::DeleteConfirm;
 use crate::ui::icons::*;
 use crate::ui::kit;
 use crate::ui::{AppState, RowMenu, View};
@@ -330,42 +331,30 @@ fn FolderItem(folder: Folder, depth: u32) -> Element {
                                     }
                                 }
                             } else if confirm_delete() {
-                                div { class: "px-3 py-2.5",
-                                    p { class: "text-sm font-semibold text-stone-900 mb-0.5",
-                                        {t(&lang, "folder-menu-delete-title")}
-                                    }
-                                    p { class: "text-xs text-stone-500 mb-3",
-                                        {t(&lang, "folder-menu-delete-warning")}
-                                    }
-                                    div { class: "flex gap-2",
-                                        button {
-                                            class: kit::CONFIRM_BTN_GHOST,
-                                            onclick: move |_| {
-                                                confirm_delete.set(false);
-                                                app.row_menu.set(None);
-                                            },
-                                            {t(&lang, "chat-menu-cancel")}
-                                        }
-                                        button {
-                                            class: kit::CONFIRM_BTN_DANGER,
-                                            onclick: move |_| {
-                                                // Close the menu THIS render pass, delete on the next
-                                                // task: the row must never be torn down in the same
-                                                // patch as its own open menu (orphaned-node freeze).
-                                                confirm_delete.set(false);
-                                                app.row_menu.set(None);
-                                                let fid = folder_id_for_delete.clone();
-                                                spawn(async move {
-                                                    let _ = db().delete_folder(&fid);
-                                                    if (app.selected_folder_id)().as_deref() == Some(fid.as_str()) {
-                                                        app.selected_folder_id.set(None);
-                                                    }
-                                                    app.folders_version.set((app.folders_version)() + 1);
-                                                });
-                                            },
-                                            {t(&lang, "chat-menu-delete")}
-                                        }
-                                    }
+                                DeleteConfirm {
+                                    title: t(&lang, "folder-menu-delete-title"),
+                                    warning: t(&lang, "folder-menu-delete-warning"),
+                                    cancel_label: t(&lang, "chat-menu-cancel"),
+                                    confirm_label: t(&lang, "chat-menu-delete"),
+                                    on_cancel: move |_| {
+                                        confirm_delete.set(false);
+                                        app.row_menu.set(None);
+                                    },
+                                    on_confirm: move |_| {
+                                        // Close the menu THIS render pass, delete on the next
+                                        // task: the row must never be torn down in the same
+                                        // patch as its own open menu (orphaned-node freeze).
+                                        confirm_delete.set(false);
+                                        app.row_menu.set(None);
+                                        let fid = folder_id_for_delete.clone();
+                                        spawn(async move {
+                                            let _ = db().delete_folder(&fid);
+                                            if (app.selected_folder_id)().as_deref() == Some(fid.as_str()) {
+                                                app.selected_folder_id.set(None);
+                                            }
+                                            app.folders_version.set((app.folders_version)() + 1);
+                                        });
+                                    },
                                 }
                             } else {
                                 button {

--- a/src/ui/thread/header_menu.rs
+++ b/src/ui/thread/header_menu.rs
@@ -1,6 +1,7 @@
 use crate::application::i18n::t;
 use crate::domain::UpdateThread;
 use crate::infrastructure::persistence::Database;
+use crate::ui::delete_confirm::DeleteConfirm;
 use crate::ui::icons::*;
 use crate::ui::kit;
 use crate::ui::{AppState, View};
@@ -114,29 +115,21 @@ pub fn ThreadHeaderMenu(thread_id: String) -> Element {
                     }
                 }
             } else if confirm_delete() {
-                div { class: "px-3 py-2.5",
-                    p { class: "text-sm font-semibold text-stone-900 mb-0.5", {t(&lang, "thread-menu-delete-title")} }
-                    p { class: "text-xs text-stone-500 mb-3", {t(&lang, "thread-menu-delete-warning")} }
-                    div { class: "flex gap-2",
-                        button {
-                            class: kit::CONFIRM_BTN_GHOST,
-                            onclick: move |_| app.show_thread_menu.set(false),
-                            {t(&lang, "thread-menu-cancel")}
+                DeleteConfirm {
+                    title: t(&lang, "thread-menu-delete-title"),
+                    warning: t(&lang, "thread-menu-delete-warning"),
+                    cancel_label: t(&lang, "thread-menu-cancel"),
+                    confirm_label: t(&lang, "thread-menu-delete"),
+                    on_cancel: move |_| app.show_thread_menu.set(false),
+                    on_confirm: {
+                        let tid = thread_id.clone();
+                        move |_| {
+                            let _ = db().delete_thread(&tid);
+                            app.notes_version.set((app.notes_version)() + 1);
+                            app.show_thread_menu.set(false);
+                            app.view.set(View::NotesList);
                         }
-                        button {
-                            class: kit::CONFIRM_BTN_DANGER,
-                            onclick: {
-                                let tid = thread_id.clone();
-                                move |_| {
-                                    let _ = db().delete_thread(&tid);
-                                    app.notes_version.set((app.notes_version)() + 1);
-                                    app.show_thread_menu.set(false);
-                                    app.view.set(View::NotesList);
-                                }
-                            },
-                            {t(&lang, "thread-menu-delete")}
-                        }
-                    }
+                    },
                 }
             } else {
                 button {


### PR DESCRIPTION
Closes #113 (option B only).

## What

The "title / warning / Cancel / Delete" confirmation block was written out
five times, once per row menu, with the same markup and the same
`kit::CONFIRM_BTN_*` classes. It now lives in a single presentational
component, `src/ui/delete_confirm.rs`.

Call sites migrated:

- `src/ui/chat/menu.rs`
- `src/ui/notes/menu.rs`
- `src/ui/thread/header_menu.rs`
- `src/ui/sidebar/conversations.rs`
- `src/ui/sidebar/folders.rs`

## What this deliberately does NOT do

Option B only. No unified `RowMenu` component: the thread header carries an
extra theme state and the note menu has no rename, so one component for all
five would be config-heavy for no gain. The bottom-sheet shell and the two
empty states named in the issue are left alone as well.

## Behavior

Behavior-preserving, zero visual change. Each call site keeps its own i18n
keys and its own handlers verbatim, including the two deliberate
teardown-order workarounds: the deferred `spawn` in the sidebar rows (the row
must not be torn down in the same patch as its own open menu) and the
`spawn_forever` slide delay in the chat menu.

## Verification

- `make check` clean (only the pre-existing `rag/mod.rs` warning)
- 688 tests pass, unchanged count
- Built and installed on iPhone via `make all`; the delete confirmation was
  exercised from all five surfaces
