### PR TITLE
feat(account): Profile pane with per-field visibility + avatar photo

### DIFF
--- a/account/src/components/Avatar.astro
+++ b/account/src/components/Avatar.astro
@@ -2,15 +2,29 @@
 interface Props {
   name: string;
   size: number;
+  // when true, try the profile photo first; the inline onerror falls back to
+  // the monogram, so a missing avatar (404) never leaves a broken image.
+  photo?: boolean;
 }
 
-const { name, size } = Astro.props;
+const { name, size, photo = false } = Astro.props;
 const initial = (name.trim()[0] ?? "?").toUpperCase();
 const fontSize = Math.round(size * 0.44);
 ---
 
 <span
   class="b-av me acct-av"
-  style={`width:${size}px;height:${size}px;font-size:${fontSize}px`}
-  >{initial}</span
+  style={`position:relative;width:${size}px;height:${size}px;font-size:${fontSize}px`}
 >
+  {initial}
+  {
+    photo && (
+      <img
+        src="/v1/me/profile/avatar"
+        alt=""
+        onerror="this.remove()"
+        style="position:absolute;inset:0"
+      />
+    )
+  }
+</span>

--- a/account/src/components/Dashboard.astro
+++ b/account/src/components/Dashboard.astro
@@ -4,31 +4,35 @@ import {
   fmtDate,
   fmtDateTime,
   type Me,
+  type ProfileData,
   shortId,
 } from "../lib/api";
 import { useTranslations } from "../lib/i18n";
 import Avatar from "./Avatar.astro";
 import BrandIcon from "./BrandIcon.astro";
+import Profile from "./Profile.astro";
 
 interface Props {
   lang: string;
   me: Me;
   data: AccountData;
+  profile: ProfileData;
 }
 
-const { lang, me, data } = Astro.props;
+const { lang, me, data, profile } = Astro.props;
 const t = useTranslations(lang, "account");
 const n = t<Record<string, string>>("nav");
 
 const panes = [
   { key: "overview", label: n.overview },
+  { key: "profile", label: n.profile },
   { key: "devices", label: n.devices },
   { key: "services", label: n.services },
   { key: "billing", label: n.billing },
   { key: "security", label: n.security },
 ] as const;
 
-const meName = me.display_name ?? me.email;
+const meName = profile.display_name?.value ?? me.display_name ?? me.email;
 const plan = data.plans[0] ?? null;
 const planLabel = plan
   ? plan.plan.charAt(0).toUpperCase() + plan.plan.slice(1)
@@ -55,7 +59,7 @@ const freeSlots = Math.max(0, DEVICE_CAP - data.devices.length);
     {
       panes.map((p, i) => (
         <>
-          {p.key === "devices" && <div class="grp">{n.groupAccount}</div>}
+          {p.key === "profile" && <div class="grp">{n.groupAccount}</div>}
           {p.key === "billing" && <div class="grp">{n.groupSettings}</div>}
           <button
             class={`b-item${i === 0 ? " on" : ""}`}
@@ -68,7 +72,7 @@ const freeSlots = Math.max(0, DEVICE_CAP - data.devices.length);
       ))
     }
     <div class="me">
-      <Avatar name={meName} size={34} />
+      <Avatar name={meName} size={34} photo={true} />
       <div><b>{meName}</b><small>{me.email}</small></div>
     </div>
   </aside>
@@ -168,6 +172,11 @@ const freeSlots = Math.max(0, DEVICE_CAP - data.devices.length);
       }
     </div>
 
+    <div class="b-pane" data-pane="profile">
+      <div class="b-ph"><h3>{n.profile}</h3></div>
+      <Profile lang={lang} me={me} profile={profile} />
+    </div>
+
     <div class="b-pane" data-pane="devices">
       <div class="b-ph">
         <h3>{n.devices}</h3>
@@ -232,7 +241,7 @@ const freeSlots = Math.max(0, DEVICE_CAP - data.devices.length);
               <div class="b-row">
                 {brandFor(c.provider) ? (
                   <span class="b-svc">
-                    <BrandIcon name={brandFor(c.provider)} />
+                    <BrandIcon name={brandFor(c.provider)!} />
                   </span>
                 ) : (
                   <span class="b-dot" />

--- a/account/src/components/Profile.astro
+++ b/account/src/components/Profile.astro
@@ -1,0 +1,123 @@
+---
+import type { Me, ProfileData } from "../lib/api";
+import { useTranslations } from "../lib/i18n";
+import Avatar from "./Avatar.astro";
+
+interface Props {
+  lang: string;
+  me: Me;
+  profile: ProfileData;
+}
+
+const { lang, me, profile } = Astro.props;
+const t = useTranslations(lang, "account");
+const p = t<Record<string, string>>("profile");
+
+const meName = profile.display_name?.value ?? me.display_name ?? me.email;
+
+const FIELDS = [
+  "display_name",
+  "bio",
+  "public_email",
+  "website",
+  "x",
+  "linkedin",
+  "instagram",
+] as const;
+
+const VISIBILITIES = ["private", "groups", "public"] as const;
+
+const visibilityOf = (field: string): string =>
+  profile[field]?.visibility ?? "private";
+const valueOf = (field: string): string => profile[field]?.value ?? "";
+---
+
+<div class="b-cards">
+  <div class="b-c wide">
+    <div class="b-prof">
+      <button
+        class="b-shot"
+        type="button"
+        id="avatar-shot"
+        title={p.changePhoto}
+      >
+        <Avatar name={meName} size={72} photo={true} />
+        <span class="cam">
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#fff"
+            stroke-width="2.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><path
+              d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"
+            ></path><circle cx="12" cy="13" r="4"></circle></svg
+          >
+        </span>
+      </button>
+      <div class="id">
+        <b>{meName}</b>
+        <span>{me.email}</span>
+      </div>
+      <input
+        type="file"
+        id="avatar-file"
+        accept="image/jpeg,image/png,image/webp"
+        hidden
+      />
+    </div>
+    <div class="b-note">
+      <b>{p.tapHint}</b>
+      {p.photoSpec}
+    </div>
+    <div class="b-note err" id="avatar-error" hidden></div>
+  </div>
+
+  <div class="b-c wide">
+    <h4><span class="t">{p.identity}</span></h4>
+
+    {
+      FIELDS.map((field) => (
+        <div class="b-pfield" data-field={field}>
+          <span class="lb">{p[field]}</span>
+          <input
+            class="val"
+            type="text"
+            value={valueOf(field)}
+            placeholder={p.notSet}
+            data-field-input={field}
+          />
+          <span class="b-pills" data-visibility={visibilityOf(field)}>
+            {VISIBILITIES.map((v) => (
+              <button
+                class={`b-pill${v === "groups" ? " soon" : ""}${
+                  visibilityOf(field) === v ? " on" : ""
+                }`}
+                type="button"
+                data-vis={v}
+              >
+                {p[v]}
+                {v === "groups" && <span class="tag">{p.soon}</span>}
+              </button>
+            ))}
+          </span>
+        </div>
+      ))
+    }
+
+    <div class="b-save">
+      <span class="b-note err" id="profile-error" hidden></span>
+      <span class="b-note ok" id="profile-saved" hidden>{p.saved}</span>
+      <button class="b-btn pri" type="button" id="profile-save"
+        >{p.save}</button
+      >
+    </div>
+  </div>
+</div>
+
+<script>
+  import "../scripts/profile.ts";
+</script>

--- a/account/src/i18n/en/account.json
+++ b/account/src/i18n/en/account.json
@@ -2,6 +2,7 @@
   "nav": {
     "overview": "Overview",
     "groupAccount": "Account",
+    "profile": "Profile",
     "devices": "Devices",
     "services": "Services",
     "groupSettings": "Settings",
@@ -83,5 +84,25 @@
     "signin": "Sign-in",
     "register": "Registration",
     "none": "No sign-in recorded."
+  },
+  "profile": {
+    "identity": "Identity",
+    "display_name": "Display name",
+    "bio": "Bio",
+    "public_email": "Public email",
+    "website": "Website",
+    "x": "X",
+    "linkedin": "LinkedIn",
+    "instagram": "Instagram",
+    "private": "Private",
+    "groups": "Groups",
+    "public": "Public",
+    "soon": "soon",
+    "changePhoto": "Change photo",
+    "tapHint": "Tap the avatar to change the photo.",
+    "photoSpec": "JPEG, PNG or WebP · 256 KB max · shown with your name on shared notes.",
+    "notSet": "Not set",
+    "save": "Save changes",
+    "saved": "Saved."
   }
 }

--- a/account/src/i18n/fr/account.json
+++ b/account/src/i18n/fr/account.json
@@ -2,6 +2,7 @@
   "nav": {
     "overview": "Aperçu",
     "groupAccount": "Compte",
+    "profile": "Profil",
     "devices": "Appareils",
     "services": "Services",
     "groupSettings": "Réglages",
@@ -83,5 +84,25 @@
     "signin": "Connexion",
     "register": "Inscription",
     "none": "Aucune connexion enregistrée."
+  },
+  "profile": {
+    "identity": "Identité",
+    "display_name": "Nom d'affichage",
+    "bio": "Bio",
+    "public_email": "E-mail public",
+    "website": "Site web",
+    "x": "X",
+    "linkedin": "LinkedIn",
+    "instagram": "Instagram",
+    "private": "Privé",
+    "groups": "Groupes",
+    "public": "Public",
+    "soon": "bientôt",
+    "changePhoto": "Changer la photo",
+    "tapHint": "Touche l'avatar pour changer la photo.",
+    "photoSpec": "JPEG, PNG ou WebP · 256 Ko max · affichée avec ton nom sur les notes partagées.",
+    "notSet": "Non renseigné",
+    "save": "Enregistrer",
+    "saved": "Enregistré."
   }
 }

--- a/account/src/lib/api.ts
+++ b/account/src/lib/api.ts
@@ -93,6 +93,28 @@ export async function fetchMe(cookie: string): Promise<Me | null> {
   return backendJson<Me>("/v1/auth/me", cookie);
 }
 
+// Profile KV (proposal 0001): field -> value + per-field visibility.
+export interface ProfileField {
+  value: string;
+  visibility: "private" | "groups" | "public";
+}
+
+export type ProfileData = Record<string, ProfileField>;
+
+export async function fetchProfile(cookie: string): Promise<ProfileData> {
+  if (PREVIEW) {
+    return {
+      display_name: { value: "Mirko Bozzetto", visibility: "public" },
+      bio: {
+        value: "Full-stack developer, Brussels. Rust, voice notes, local-first.",
+        visibility: "groups",
+      },
+      website: { value: "https://mirkobozzetto.com", visibility: "public" },
+    };
+  }
+  return (await backendJson<ProfileData>("/v1/me/profile", cookie)) ?? {};
+}
+
 export async function fetchAccountData(cookie: string): Promise<AccountData> {
   if (PREVIEW) return previewData();
   const [devices, entitlements, connections, requests, loginEvents] =

--- a/account/src/lib/proxy.ts
+++ b/account/src/lib/proxy.ts
@@ -34,7 +34,16 @@ export async function forward(
     init.body = await request.arrayBuffer();
   }
 
-  const res = await fetch(target, init);
+  // An unreachable backend must answer 502, never crash the SSR route.
+  let res: Response;
+  try {
+    res = await fetch(target, init);
+  } catch {
+    return new Response(JSON.stringify({ error: "backend unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
 
   const out = new Headers();
   const contentType = res.headers.get("content-type");

--- a/account/src/pages/fr/index.astro
+++ b/account/src/pages/fr/index.astro
@@ -1,7 +1,7 @@
 ---
 import Dashboard from "../../components/Dashboard.astro";
 import Layout from "../../layouts/Layout.astro";
-import { fetchAccountData, fetchMe } from "../../lib/api";
+import { fetchAccountData, fetchMe, fetchProfile } from "../../lib/api";
 
 export const prerender = false;
 
@@ -9,10 +9,11 @@ const cookie = Astro.request.headers.get("cookie") ?? "";
 const me = await fetchMe(cookie);
 if (!me) return Astro.redirect("/fr/login");
 const data = await fetchAccountData(cookie);
+const profile = await fetchProfile(cookie);
 ---
 
 <Layout lang="fr">
   <main class="container py-10">
-    <Dashboard lang="fr" me={me} data={data} />
+    <Dashboard lang="fr" me={me} data={data} profile={profile} />
   </main>
 </Layout>

--- a/account/src/pages/index.astro
+++ b/account/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Dashboard from "../components/Dashboard.astro";
 import Layout from "../layouts/Layout.astro";
-import { fetchAccountData, fetchMe } from "../lib/api";
+import { fetchAccountData, fetchMe, fetchProfile } from "../lib/api";
 
 export const prerender = false;
 
@@ -9,10 +9,11 @@ const cookie = Astro.request.headers.get("cookie") ?? "";
 const me = await fetchMe(cookie);
 if (!me) return Astro.redirect("/login");
 const data = await fetchAccountData(cookie);
+const profile = await fetchProfile(cookie);
 ---
 
 <Layout lang="en">
   <main class="container py-10">
-    <Dashboard lang="en" me={me} data={data} />
+    <Dashboard lang="en" me={me} data={data} profile={profile} />
   </main>
 </Layout>

--- a/account/src/scripts/profile.ts
+++ b/account/src/scripts/profile.ts
@@ -1,0 +1,144 @@
+// Profile pane behavior (proposal 0001 T10/T11): visibility pills, field save
+// through PUT /v1/me/profile (csrf from /v1/auth/me), and the tap-to-change
+// avatar upload (bounded client-side, re-checked server-side).
+
+const MAX_AVATAR_BYTES = 256 * 1024;
+
+async function csrf(): Promise<string | null> {
+  const me = await fetch("/v1/auth/me").then((r) =>
+    r.ok ? (r.json() as Promise<{ csrf: string }>) : null,
+  );
+  return me?.csrf ?? null;
+}
+
+function show(el: HTMLElement | null, message?: string): void {
+  if (!el) return;
+  if (message !== undefined) el.textContent = message;
+  el.hidden = false;
+}
+
+function initPills(): void {
+  for (const pill of document.querySelectorAll<HTMLButtonElement>(
+    ".b-pfield .b-pill",
+  )) {
+    pill.addEventListener("click", () => {
+      // Groups is visible but inert in v1: it lights up with shared folders.
+      if (pill.classList.contains("soon")) return;
+      const group = pill.closest<HTMLElement>(".b-pills");
+      if (!group) return;
+      for (const other of group.querySelectorAll(".b-pill")) {
+        other.classList.toggle("on", other === pill);
+      }
+      group.dataset.visibility = pill.dataset.vis;
+    });
+  }
+}
+
+function initSave(): void {
+  const btn = document.getElementById("profile-save");
+  const err = document.getElementById("profile-error");
+  const ok = document.getElementById("profile-saved");
+  btn?.addEventListener("click", () => {
+    void (async () => {
+      if (err) err.hidden = true;
+      if (ok) ok.hidden = true;
+      const body: Record<string, { value: string; visibility: string }> = {};
+      for (const row of document.querySelectorAll<HTMLElement>(".b-pfield")) {
+        const field = row.dataset.field;
+        const input = row.querySelector<HTMLInputElement>("input.val");
+        const pills = row.querySelector<HTMLElement>(".b-pills");
+        if (!field || !input || !pills) continue;
+        body[field] = {
+          value: input.value.trim(),
+          visibility: pills.dataset.visibility ?? "private",
+        };
+      }
+      const token = await csrf();
+      if (!token) {
+        show(err, "Session expired - reload the page.");
+        return;
+      }
+      const res = await fetch("/v1/me/profile", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "x-csrf-token": token,
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const detail = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        show(err, detail?.error ?? `Error ${res.status}`);
+        return;
+      }
+      show(ok);
+    })();
+  });
+}
+
+function initAvatar(): void {
+  const shot = document.getElementById("avatar-shot");
+  const file = document.getElementById("avatar-file") as HTMLInputElement | null;
+  const err = document.getElementById("avatar-error");
+  if (!shot || !file) return;
+
+  shot.addEventListener("click", () => file.click());
+  file.addEventListener("change", () => {
+    void (async () => {
+      if (err) err.hidden = true;
+      const picked = file.files?.[0];
+      file.value = "";
+      if (!picked) return;
+      if (picked.size > MAX_AVATAR_BYTES) {
+        show(err, "256 KB max.");
+        return;
+      }
+      const data = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const url = reader.result as string;
+          resolve(url.slice(url.indexOf(",") + 1));
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(picked);
+      });
+      const token = await csrf();
+      if (!token) {
+        show(err, "Session expired - reload the page.");
+        return;
+      }
+      const res = await fetch("/v1/me/profile/avatar", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "x-csrf-token": token,
+        },
+        body: JSON.stringify({ data_base64: data, mime: picked.type }),
+      });
+      if (!res.ok) {
+        const detail = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        show(err, detail?.error ?? `Error ${res.status}`);
+        return;
+      }
+      location.reload();
+    })();
+  });
+}
+
+function initProfile(): void {
+  initPills();
+  initSave();
+  initAvatar();
+}
+
+if (document.readyState !== "loading") {
+  initProfile();
+} else {
+  addEventListener("DOMContentLoaded", initProfile);
+}
+
+export {};

--- a/account/src/styles/beta.css
+++ b/account/src/styles/beta.css
@@ -853,6 +853,137 @@
   background: linear-gradient(180deg, var(--orange-bright), var(--orange));
 }
 
+/* ---------- pane Profile (proposal 0001) ---------- */
+button.b-shot {
+  border: 0;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.b-pfield {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px 18px;
+  padding: 15px 0;
+  border-bottom: 1px solid var(--stone-200);
+  align-items: center;
+}
+
+.b-pfield:last-of-type {
+  border-bottom: 0;
+}
+
+.b-pfield .lb {
+  grid-column: 1 / -1;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--stone-400);
+}
+
+.b-pfield input.val {
+  width: 100%;
+  min-width: 0;
+  padding: 10px 13px;
+  border: 1px solid var(--stone-200);
+  border-radius: 11px;
+  background: var(--warm-white);
+  font-family: inherit;
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.b-pfield input.val::placeholder {
+  color: var(--stone-400);
+  font-weight: 400;
+}
+
+.b-pfield input.val:focus {
+  outline: none;
+  border-color: var(--stone-300);
+}
+
+.b-pills {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--stone-200);
+  border-radius: 99px;
+  background: var(--warm-white);
+}
+
+.b-pill {
+  padding: 5px 12px;
+  border: 0;
+  border-radius: 99px;
+  background: none;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--stone-500);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.b-pill.on {
+  background: var(--orange-50);
+  color: var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-100);
+}
+
+.b-pill.soon {
+  color: var(--stone-300);
+  cursor: default;
+}
+
+.b-pill.soon.on {
+  background: var(--stone-100);
+  color: var(--stone-400);
+  box-shadow: inset 0 0 0 1px var(--stone-200);
+}
+
+.b-pill.soon .tag {
+  margin-left: 5px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--stone-400);
+}
+
+.b-note {
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--stone-500);
+}
+
+.b-note b {
+  color: var(--stone-700);
+}
+
+.b-note.err {
+  color: var(--orange-dark);
+}
+
+.b-note.ok {
+  color: var(--stone-700);
+}
+
+.b-save {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.b-save .b-note {
+  margin-top: 0;
+}
+
 /* ---------- chapitre sombre ---------- */
 .b-dark {
   position: relative;


### PR DESCRIPTION
Site half of proposal 0001 (person profiles, issue #86). App changes stay local until device validation.

## Profile pane (account.flowflow.be)
- New 6th pane in the Account group, per the validated T01 mockup: identity fields (display name, bio, public email, website, X, LinkedIn, Instagram), each with its visibility pill row - private / groups (visible, inert "soon") / public.
- Avatar: tap the photo (camera badge) to change it; JPEG/PNG/WebP, 256 KB client cap, uploaded as base64 JSON; server re-encodes and strips EXIF. Photo renders from GET /v1/me/profile/avatar with an inline-onerror monogram fallback, in the pane and the sidebar chip.
- Save = partial upsert PUT /v1/me/profile with the x-csrf-token header; empty value deletes the field.
- i18n EN/FR (account.json).

## Hardening
- lib/proxy.ts: an unreachable backend now answers 502 instead of crashing the SSR route (dev overlay / 500 in prod).

## Checks
- astro build + astro check green; visually validated against docs/proposals/0001 mockup in ACCOUNT_PREVIEW.

Requires mirkobozzetto/marketplace-flowflow#87 deployed for the pane to load real data (until then the pane renders empty and avatar falls back to the monogram).

https://claude.ai/code/session_01A8tSXuyKrYC2guUc6dSESd
