### PR TITLE
feat(embeddings): profile provenance + effective trace models

### DIFF
--- a/src/application/constants.rs
+++ b/src/application/constants.rs
@@ -54,6 +54,7 @@ pub const WHISPER_CATALOG: &[WhisperCatalogEntry] = &[
     },
 ];
 pub const EMBEDDING_MODEL: &str = "text-embedding-3-small";
+pub const EMBEDDING_PROFILE: &str = "openai:text-embedding-3-small:1536";
 pub const CHAT_MODEL: &str = "gpt-5.4-mini";
 pub const CHATGPT_CHAT_MODEL: &str = "gpt-5.6-terra";
 pub const CHATGPT_CHAT_MODEL_NAME: &str = "GPT-5.6 Terra";

--- a/src/application/embed/chunk_store.rs
+++ b/src/application/embed/chunk_store.rs
@@ -73,6 +73,8 @@ pub(crate) fn persist_chunk_blobs(
             owner_id: owner_id.to_string(),
             owner_kind: owner_kind.to_string(),
             chunk_index: c.chunk_index,
+            embed_profile: crate::application::constants::EMBEDDING_PROFILE
+                .to_string(),
             vector: c.vector.clone(),
             content_hash: content_hash(&c.chunk_text),
             chunk_text: c.chunk_text.clone(),

--- a/src/application/embed/mod.rs
+++ b/src/application/embed/mod.rs
@@ -154,10 +154,68 @@ pub fn embed_note(
     });
 }
 
+pub fn purge_stale_embeddings(
+    db: &crate::infrastructure::persistence::Database,
+) -> Result<usize, String> {
+    db.delete_chunks_not_matching_profile(
+        crate::application::constants::EMBEDDING_PROFILE,
+    )
+}
+
+async fn embed_attachment_core(
+    store: &VectorStore,
+    ai: &LlmClient,
+    attachment_id: &str,
+    parent_note_id: &str,
+    filename: &str,
+    content: &str,
+) -> Result<usize, String> {
+    let chunks_text = chunk_text(content);
+    let now = crate::infrastructure::persistence::now_iso();
+    let mut entries = Vec::with_capacity(chunks_text.len());
+    for (i, text) in chunks_text.iter().enumerate() {
+        let vector = ai
+            .embed(text)
+            .await
+            .map_err(|e| format!("embed attachment chunk {i}: {e}"))?;
+        entries.push(Chunk {
+            id: format!("att:{attachment_id}:{i}"),
+            note_id: parent_note_id.to_string(),
+            chunk_text: text.clone(),
+            chunk_index: i as i32,
+            vector,
+            title: filename.to_string(),
+            tags: "[]".to_string(),
+            created_at: now.clone(),
+        });
+    }
+    let count = entries.len();
+    persist_chunk_blobs(attachment_id, "attachment", &entries);
+    store
+        .store_chunks(entries)
+        .await
+        .map_err(|e| format!("embed attachment store: {e}"))?;
+    Ok(count)
+}
+
 pub(crate) async fn embed_missing_notes(
     db: &crate::infrastructure::persistence::Database,
     store: &VectorStore,
 ) -> usize {
+    let purged = match purge_stale_embeddings(db) {
+        Ok(count) => count,
+        Err(e) => {
+            log(&format!("embed profile purge: {e}"));
+            return 0;
+        }
+    };
+    if purged > 0 {
+        log(&format!("embed profile purge: {purged} stale chunks"));
+        if let Err(e) = store.reset_table().await {
+            log(&format!("embed profile reset: {e}"));
+            return 0;
+        }
+    }
     if !ai_consent_granted() {
         return 0;
     }
@@ -174,38 +232,85 @@ pub(crate) async fn embed_missing_notes(
     };
     let mut embedded = 0usize;
     for note in &notes {
-        if too_short_to_embed(&note.content) {
-            continue;
+        if !too_short_to_embed(&note.content) {
+            match db.count_chunks_for_owner(&note.id, "note") {
+                Ok(0) => {
+                    let title = note.title.clone().unwrap_or_default();
+                    match embed_note_core(
+                        store,
+                        &ai,
+                        &note.id,
+                        &title,
+                        &note.content,
+                        &note.tags,
+                        &note.created_at,
+                    )
+                    .await
+                    {
+                        Ok(n) => {
+                            embedded += 1;
+                            log(&format!(
+                                "embed missing: {} (+{n} chunks)",
+                                note.id
+                            ));
+                        }
+                        Err(e) => {
+                            log(&format!("embed missing: {} {e}", note.id))
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => log(&format!("embed missing: count {} {e}", note.id)),
+            }
         }
-        match db.count_chunks_for_owner(&note.id, "note") {
-            Ok(0) => {}
-            Ok(_) => continue,
+        let attachments = match db.list_attachments_for_note(&note.id) {
+            Ok(items) => items,
             Err(e) => {
-                log(&format!("embed missing: count {} {e}", note.id));
+                log(&format!("embed missing: attachments {} {e}", note.id));
                 continue;
             }
-        }
-        let title = note.title.clone().unwrap_or_default();
-        match embed_note_core(
-            store,
-            &ai,
-            &note.id,
-            &title,
-            &note.content,
-            &note.tags,
-            &note.created_at,
-        )
-        .await
-        {
-            Ok(n) => {
-                embedded += 1;
-                log(&format!("embed missing: {} (+{n} chunks)", note.id));
+        };
+        for attachment in attachments {
+            if too_short_to_embed(&attachment.content_text) {
+                continue;
             }
-            Err(e) => log(&format!("embed missing: {} {e}", note.id)),
+            match db.count_chunks_for_owner(&attachment.id, "attachment") {
+                Ok(0) => {}
+                Ok(_) => continue,
+                Err(e) => {
+                    log(&format!(
+                        "embed missing: attachment count {} {e}",
+                        attachment.id
+                    ));
+                    continue;
+                }
+            }
+            match embed_attachment_core(
+                store,
+                &ai,
+                &attachment.id,
+                &attachment.note_id,
+                &attachment.filename,
+                &attachment.content_text,
+            )
+            .await
+            {
+                Ok(n) => {
+                    embedded += 1;
+                    log(&format!(
+                        "embed missing: attachment {} (+{n} chunks)",
+                        attachment.id
+                    ));
+                }
+                Err(e) => log(&format!(
+                    "embed missing: attachment {} {e}",
+                    attachment.id
+                )),
+            }
         }
     }
     if embedded > 0 {
-        log(&format!("embed missing: {embedded} notes embedded"));
+        log(&format!("embed missing: {embedded} owners embedded"));
     }
     embedded
 }
@@ -343,36 +448,20 @@ pub fn embed_attachment(
                     return;
                 }
             };
-            let chunks_text = chunk_text(&content);
-            log(&format!("embed attachment: {} chunks", chunks_text.len()));
-            let now = crate::infrastructure::persistence::now_iso();
-            let mut entries = Vec::new();
-            for (i, text) in chunks_text.iter().enumerate() {
-                match ai.embed(text).await {
-                    Ok(vector) => {
-                        entries.push(Chunk {
-                            id: format!("att:{attachment_id}:{i}"),
-                            note_id: parent_note_id.clone(),
-                            chunk_text: text.clone(),
-                            chunk_index: i as i32,
-                            vector,
-                            title: filename.clone(),
-                            tags: "[]".to_string(),
-                            created_at: now.clone(),
-                        });
-                    }
-                    Err(e) => {
-                        log(&format!("embed attachment chunk {i}: {e}"));
-                        return;
-                    }
-                }
-            }
-            persist_chunk_blobs(&attachment_id, "attachment", &entries);
-            match store.store_chunks(entries).await {
-                Ok(()) => {
-                    log(&format!("embed attachment done for {attachment_id}"))
-                }
-                Err(e) => log(&format!("embed attachment store: {e}")),
+            match embed_attachment_core(
+                &store,
+                &ai,
+                &attachment_id,
+                &parent_note_id,
+                &filename,
+                &content,
+            )
+            .await
+            {
+                Ok(n) => log(&format!(
+                    "embed attachment done for {attachment_id} ({n} chunks)"
+                )),
+                Err(e) => log(&format!("embed attachment: {e}")),
             }
         });
     });

--- a/src/application/rag/mod.rs
+++ b/src/application/rag/mod.rs
@@ -109,7 +109,8 @@ async fn select_relevant(
             .iter()
             .map(|c| estimate_tokens(&c.chunk_text))
             .sum::<u32>();
-    let timer = StepTimer::start("judge", Some(CHEAP_MODEL));
+    let timer =
+        StepTimer::start("judge", Some(ai.effective_model(CHEAP_MODEL)));
     let judged: HashSet<usize> =
         llm_relevance_filter(ai, question, &candidates, RAG_FINAL_K)
             .await
@@ -220,7 +221,8 @@ pub async fn query(
                 .iter()
                 .map(|t| estimate_tokens(&t.content))
                 .sum::<u32>();
-        let timer = StepTimer::start("prep", Some(CHEAP_MODEL));
+        let timer =
+            StepTimer::start("prep", Some(ai.effective_model(CHEAP_MODEL)));
         let (q, range) = prep_query(&ai, &history, question).await;
         timer.finish(
             &mut rag_trace,
@@ -267,7 +269,8 @@ pub async fn query(
         tokio::join!(temporal_fut, embed_fut);
     rag_trace.push(TraceStep {
         step: "temporal".to_string(),
-        model: needs_temporal_llm.then(|| CHEAP_MODEL.to_string()),
+        model: needs_temporal_llm
+            .then(|| ai.effective_model(CHEAP_MODEL).to_string()),
         tokens_in: needs_temporal_llm.then(|| estimate_tokens(retrieval_q)),
         tokens_out: None,
         approx: true,

--- a/src/infrastructure/llm.rs
+++ b/src/infrastructure/llm.rs
@@ -249,13 +249,19 @@ impl LlmClient {
         }
     }
 
-    /// Model id the chat/agent path actually uses under the configured provider.
-    pub fn chat_model_name(&self) -> &'static str {
+    /// Model actually executed when `openai_model` is requested: the OpenAI
+    /// path honors it; Anthropic and ChatGPT substitute their own model.
+    pub fn effective_model(&self, openai_model: &'static str) -> &'static str {
         match self.provider {
-            Provider::OpenAi => CHAT_MODEL,
+            Provider::OpenAi => openai_model,
             Provider::Anthropic => ANTHROPIC_CHAT_MODEL,
             Provider::ChatGpt => CHATGPT_CHAT_MODEL,
         }
+    }
+
+    /// Model id the chat/agent path actually uses under the configured provider.
+    pub fn chat_model_name(&self) -> &'static str {
+        self.effective_model(CHAT_MODEL)
     }
 
     async fn chatgpt_client(&self) -> Result<chatgpt::Client, LlmError> {

--- a/src/infrastructure/persistence/chunk_repo.rs
+++ b/src/infrastructure/persistence/chunk_repo.rs
@@ -5,6 +5,7 @@ pub struct ChunkRecord {
     pub owner_id: String,
     pub owner_kind: String,
     pub chunk_index: i32,
+    pub embed_profile: String,
     pub vector: Vec<f32>,
     pub content_hash: String,
     pub chunk_text: String,
@@ -74,8 +75,9 @@ impl Database {
             tx.execute(
                 "INSERT OR REPLACE INTO chunks
                  (id, owner_id, owner_kind, chunk_index, dim, vector,
-                  content_hash, chunk_text, title, tags, created_at)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
+                  content_hash, chunk_text, title, tags, created_at,
+                  embed_profile)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
                 rusqlite::params![
                     c.id,
                     c.owner_id,
@@ -88,6 +90,7 @@ impl Database {
                     c.title,
                     c.tags,
                     c.created_at,
+                    c.embed_profile,
                 ],
             )
             .map_err(|e| format!("Insert chunk: {e}"))?;
@@ -156,7 +159,8 @@ impl Database {
         let mut stmt = conn
             .prepare(
                 "SELECT id, owner_id, owner_kind, chunk_index, vector,
-                        content_hash, chunk_text, title, tags, created_at
+                        content_hash, chunk_text, title, tags, created_at,
+                        embed_profile
                  FROM chunks
                  WHERE owner_id = ?1 AND owner_kind = ?2
                  ORDER BY chunk_index ASC",
@@ -176,6 +180,7 @@ impl Database {
                     title: row.get(7)?,
                     tags: row.get(8)?,
                     created_at: row.get(9)?,
+                    embed_profile: row.get(10)?,
                 })
             })
             .map_err(|e| format!("Query chunks: {e}"))?;

--- a/src/infrastructure/persistence/chunk_repo.rs
+++ b/src/infrastructure/persistence/chunk_repo.rs
@@ -43,8 +43,19 @@ pub(crate) fn delete_chunks_for_owner(
         rusqlite::params![owner_id, owner_kind],
     )
 }
-
 impl Database {
+    pub fn delete_chunks_not_matching_profile(
+        &self,
+        embed_profile: &str,
+    ) -> Result<usize, String> {
+        self.conn()
+            .execute(
+                "DELETE FROM chunks WHERE embed_profile IS NOT ?1",
+                [embed_profile],
+            )
+            .map_err(|e| format!("Delete stale chunks: {e}"))
+    }
+
     pub fn delete_owner_chunks(
         &self,
         owner_id: &str,

--- a/src/infrastructure/persistence/schema.rs
+++ b/src/infrastructure/persistence/schema.rs
@@ -26,7 +26,13 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     (25, V25_SCHEMA),
     (26, V26_SCHEMA),
     (27, V27_SCHEMA),
+    (28, V28_SCHEMA),
 ];
+
+const V28_SCHEMA: &str = "
+ALTER TABLE chunks ADD COLUMN embed_profile TEXT NOT NULL
+    DEFAULT 'openai:text-embedding-3-small:1536';
+";
 
 // A note saved into a space folder is bound to its remote id and queued here
 // until the server has it; the queue is drained, bounded, at the head of every

--- a/src/infrastructure/sync/conflict.rs
+++ b/src/infrastructure/sync/conflict.rs
@@ -327,6 +327,8 @@ fn restore_chunks(db: &Database, note_id: &str, chunks: &[ArchivedChunk]) {
             owner_id: note_id.to_string(),
             owner_kind: "note".to_string(),
             chunk_index: c.chunk_index as i32,
+            embed_profile: crate::application::constants::EMBEDDING_PROFILE
+                .to_string(),
             vector: blob_to_vector(&blob),
             content_hash: c.content_hash.clone().unwrap_or_default(),
             chunk_text: c.chunk_text.clone().unwrap_or_default(),

--- a/src/infrastructure/sync/protocol/apply/entity.rs
+++ b/src/infrastructure/sync/protocol/apply/entity.rs
@@ -120,6 +120,17 @@ pub(super) fn replace_chunks_from_payload(
     )
     .map_err(|e| sql_err("clear chunks", e))?;
     for c in chunks {
+        let embed_profile = c
+            .embed_profile
+            .as_deref()
+            .unwrap_or(crate::application::constants::EMBEDDING_PROFILE);
+        if embed_profile != crate::application::constants::EMBEDDING_PROFILE {
+            log(&format!(
+                "skip foreign-profile chunk {} ({embed_profile})",
+                c.id
+            ));
+            continue;
+        }
         let blob = URL_SAFE_NO_PAD
             .decode(&c.vector_b64)
             .map_err(|e| proto_err(format!("decode chunk blob: {e}")))?;
@@ -136,8 +147,9 @@ pub(super) fn replace_chunks_from_payload(
         conn.execute(
             "INSERT OR REPLACE INTO chunks
                 (id, owner_id, owner_kind, chunk_index, dim, vector,
-                 content_hash, chunk_text, title, tags, created_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
+                 content_hash, chunk_text, title, tags, created_at,
+                 embed_profile)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
             rusqlite::params![
                 c.id,
                 owner_id,
@@ -150,6 +162,7 @@ pub(super) fn replace_chunks_from_payload(
                 c.title,
                 c.tags,
                 c.created_at,
+                embed_profile,
             ],
         )
         .map_err(|e| sql_err("insert chunk", e))?;

--- a/src/infrastructure/sync/protocol/apply/mod.rs
+++ b/src/infrastructure/sync/protocol/apply/mod.rs
@@ -23,6 +23,14 @@ pub(super) fn delete_entity_for_test(
 ) -> Result<(), SyncError> {
     entity::delete_entity(conn, spec, entity_id, None)
 }
+pub(super) fn replace_chunks_for_test(
+    conn: &Connection,
+    owner_id: &str,
+    owner_kind: &str,
+    chunks: &[super::wire::ChunkPayload],
+) -> Result<(), SyncError> {
+    entity::replace_chunks_from_payload(conn, owner_id, owner_kind, chunks)
+}
 
 mod hlc_guard;
 mod meta;

--- a/src/infrastructure/sync/protocol/collect.rs
+++ b/src/infrastructure/sync/protocol/collect.rs
@@ -55,7 +55,7 @@ pub(super) fn load_chunks(
     let mut stmt = conn
         .prepare(
             "SELECT id, chunk_index, vector, content_hash, chunk_text,
-                    title, tags, created_at
+                    title, tags, created_at, embed_profile
              FROM chunks WHERE owner_id = ?1 AND owner_kind = ?2
              ORDER BY chunk_index ASC",
         )
@@ -72,6 +72,7 @@ pub(super) fn load_chunks(
                 title: row.get(5)?,
                 tags: row.get(6)?,
                 created_at: row.get(7)?,
+                embed_profile: Some(row.get(8)?),
             })
         })
         .map_err(|e| sql_err("query chunks", e))?;

--- a/src/infrastructure/sync/protocol/mod.rs
+++ b/src/infrastructure/sync/protocol/mod.rs
@@ -31,6 +31,19 @@ pub fn apply_entity_delete_for_test(
         .ok_or_else(|| proto_err(format!("unknown kind {kind}")))?;
     apply::delete_entity_for_test(conn, spec, entity_id)
 }
+/// Apply serialized chunks through the production decoder and guards.
+/// This is a narrow integration-test seam for wire compatibility.
+#[doc(hidden)]
+pub fn apply_chunks_for_test(
+    conn: &rusqlite::Connection,
+    owner_id: &str,
+    owner_kind: &str,
+    chunks_json: &str,
+) -> Result<(), SyncError> {
+    let chunks: Vec<wire::ChunkPayload> = serde_json::from_str(chunks_json)
+        .map_err(|e| proto_err(format!("decode test chunks: {e}")))?;
+    apply::replace_chunks_for_test(conn, owner_id, owner_kind, &chunks)
+}
 
 // Catalog columns per entity kind, for the tests that guard what travels: a
 // column absent from the fixed `cols` list never reaches another device.

--- a/src/infrastructure/sync/protocol/wire.rs
+++ b/src/infrastructure/sync/protocol/wire.rs
@@ -92,6 +92,8 @@ pub(super) struct ChunkPayload {
     pub id: String,
     pub chunk_index: i64,
     pub vector_b64: String,
+    #[serde(default)]
+    pub embed_profile: Option<String>,
     pub content_hash: Option<String>,
     pub chunk_text: Option<String>,
     pub title: Option<String>,

--- a/src/infrastructure/sync/reconcile.rs
+++ b/src/infrastructure/sync/reconcile.rs
@@ -68,6 +68,13 @@ fn owner_note_id(
 }
 
 fn record_to_chunk(note_id: &str, r: ChunkRecord) -> Option<Chunk> {
+    if r.embed_profile != EMBEDDING_PROFILE {
+        eprintln!(
+            "[reconcile] skip foreign-profile chunk {} ({})",
+            r.id, r.embed_profile
+        );
+        return None;
+    }
     if r.vector.len() != EMBEDDING_DIMS {
         eprintln!(
             "[reconcile] skip malformed chunk {} (dim {} != {EMBEDDING_DIMS})",

--- a/src/infrastructure/sync/reconcile.rs
+++ b/src/infrastructure/sync/reconcile.rs
@@ -1,4 +1,4 @@
-use crate::application::constants::EMBEDDING_DIMS;
+use crate::application::constants::{EMBEDDING_DIMS, EMBEDDING_PROFILE};
 use crate::infrastructure::persistence::chunk_repo::{
     content_hash, ChunkRecord,
 };
@@ -42,6 +42,7 @@ fn row_to_record(
         owner_id: owner_id.to_string(),
         owner_kind: owner_kind.to_string(),
         chunk_index: row.chunk_index,
+        embed_profile: EMBEDDING_PROFILE.to_string(),
         vector: row.vector.clone(),
         content_hash: content_hash(&row.chunk_text),
         chunk_text: row.chunk_text.clone(),

--- a/src/infrastructure/vectordb.rs
+++ b/src/infrastructure/vectordb.rs
@@ -201,6 +201,14 @@ impl VectorStore {
         Ok(Self { db })
     }
 
+    pub async fn reset_table(&self) -> Result<(), String> {
+        match self.db.drop_table(VECTOR_TABLE_NAME, &[]).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.to_string().contains("was not found") => Ok(()),
+            Err(e) => Err(format!("VectorDB reset: {e}")),
+        }
+    }
+
     pub async fn store_chunks(&self, chunks: Vec<Chunk>) -> Result<(), String> {
         if chunks.is_empty() {
             return Ok(());

--- a/src/ui/chat/trace_accordion.rs
+++ b/src/ui/chat/trace_accordion.rs
@@ -32,7 +32,7 @@ pub fn TraceAccordion(trace: RagTrace) -> Element {
             if open() {
                 div { class: "mt-1 space-y-0.5",
                     for step in trace.steps.iter() {
-                        div { class: "flex items-baseline gap-2 text-xs font-mono",
+                        div { class: "flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xs font-mono",
                             span { class: "w-16 shrink-0 text-stone-600", "{step.step}" }
                             span {
                                 class: match step.outcome {
@@ -48,7 +48,7 @@ pub fn TraceAccordion(trace: RagTrace) -> Element {
                             }
                             span { class: "text-stone-500", "{step.latency_ms}ms" }
                             if let Some(ref model) = step.model {
-                                span { class: "text-stone-400 truncate", "{model}" }
+                                span { class: "text-stone-400 break-all", "{model}" }
                             }
                             if let Some(tin) = step.tokens_in {
                                 span { class: "text-stone-400", "~{tin}t in" }

--- a/tests/author_device_test.rs
+++ b/tests/author_device_test.rs
@@ -47,6 +47,7 @@ fn rewind_to_v22(db: &Database) {
          ALTER TABLE notes DROP COLUMN author_ref;
          DROP TABLE IF EXISTS spaces;
          DROP TABLE IF EXISTS pending_purge;
+         ALTER TABLE chunks DROP COLUMN embed_profile;
          DELETE FROM _migrations WHERE version >= 23;",
     )
     .unwrap();

--- a/tests/backup_restore_test.rs
+++ b/tests/backup_restore_test.rs
@@ -427,6 +427,8 @@ fn chunk_record(note_id: &str, text: &str) -> ChunkRecord {
         owner_id: note_id.to_string(),
         owner_kind: "note".to_string(),
         chunk_index: 0,
+        embed_profile: flowflow::application::constants::EMBEDDING_PROFILE
+            .to_string(),
         vector,
         content_hash: "h".to_string(),
         chunk_text: text.to_string(),

--- a/tests/chunk_blob_test.rs
+++ b/tests/chunk_blob_test.rs
@@ -18,6 +18,8 @@ fn rec(id: &str, owner: &str, kind: &str, idx: i32, dim: usize) -> ChunkRecord {
         owner_id: owner.to_string(),
         owner_kind: kind.to_string(),
         chunk_index: idx,
+        embed_profile: flowflow::application::constants::EMBEDDING_PROFILE
+            .to_string(),
         vector: vec![0.25_f32; dim],
         content_hash: "hash".to_string(),
         chunk_text: "text".to_string(),

--- a/tests/embedding_profile_test.rs
+++ b/tests/embedding_profile_test.rs
@@ -1,0 +1,196 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use flowflow::application::constants::{EMBEDDING_DIMS, EMBEDDING_PROFILE};
+use flowflow::application::embed::purge_stale_embeddings;
+use flowflow::domain::note::NewTextNote;
+use flowflow::infrastructure::persistence::chunk_repo::{
+    vector_to_blob, ChunkRecord,
+};
+use flowflow::infrastructure::persistence::Database;
+use flowflow::infrastructure::sync::{peers, protocol};
+use std::net::TcpListener;
+use std::sync::{Arc, Once};
+use tempfile::tempdir;
+
+static ADVERTISE: Once = Once::new();
+
+fn open_db() -> (Arc<Database>, tempfile::TempDir) {
+    let dir = tempdir().expect("db tempdir");
+    let db =
+        Database::open_at(dir.path().join("flowflow.db")).expect("open_at");
+    (Arc::new(db), dir)
+}
+
+fn chunk(id: &str, owner_id: &str, embed_profile: &str) -> ChunkRecord {
+    ChunkRecord {
+        id: id.to_string(),
+        owner_id: owner_id.to_string(),
+        owner_kind: "note".to_string(),
+        chunk_index: 0,
+        embed_profile: embed_profile.to_string(),
+        vector: vec![0.5; EMBEDDING_DIMS],
+        content_hash: "hash".to_string(),
+        chunk_text: "chunk text".to_string(),
+        title: "title".to_string(),
+        tags: "[]".to_string(),
+        created_at: "2026-09-02T00:00:00.000Z".to_string(),
+    }
+}
+
+fn make_note(db: &Database) -> String {
+    db.create_text_note(&NewTextNote {
+        title: Some("profile note".to_string()),
+        content: "content long enough to embed".to_string(),
+        tags: vec![],
+    })
+    .expect("create note")
+    .id
+}
+
+fn pair(db_a: &Arc<Database>, db_b: &Arc<Database>) -> String {
+    ADVERTISE.call_once(|| {
+        std::env::set_var("FLOWFLOW_SYNC_ADVERTISE_ADDR", "127.0.0.1");
+    });
+    let host = peers::start_pairing_host(db_a.clone()).expect("host");
+    let mut payload =
+        peers::decode_pairing_uri(&host.uri).expect("decode host uri");
+    payload.addr = "127.0.0.1".to_string();
+    let uri = peers::encode_pairing_uri(&payload).expect("re-encode uri");
+    let host_device_id = peers::join_pairing(db_b, &uri).expect("join");
+    for _ in 0..100 {
+        if host.status() != peers::PairingStatus::Waiting {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(matches!(host.status(), peers::PairingStatus::Paired { .. }));
+    host_device_id
+}
+
+fn sync_once(
+    db_host: &Arc<Database>,
+    db_client: &Arc<Database>,
+    host_device_id: &str,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let host_db = db_host.clone();
+    let server = std::thread::spawn(move || {
+        protocol::serve_sync_once(&host_db, &listener, 50, None)
+    });
+    protocol::sync_with_peer(db_client, host_device_id, "127.0.0.1", port, 50)
+        .expect("client sync");
+    server.join().expect("join").expect("server sync");
+}
+
+#[test]
+fn migration_and_repository_preserve_current_profile() {
+    let (db, _dir) = open_db();
+    let note_id = make_note(&db);
+    let record = chunk("note:current:0", &note_id, EMBEDDING_PROFILE);
+
+    db.replace_chunks(&note_id, "note", &[record])
+        .expect("replace chunks");
+
+    let rows = db.chunks_for_owner(&note_id, "note").expect("chunks");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].embed_profile, EMBEDDING_PROFILE);
+}
+
+#[test]
+fn purge_removes_only_foreign_profiles_and_is_idempotent() {
+    let (db, _dir) = open_db();
+    let current_owner = make_note(&db);
+    let foreign_owner = make_note(&db);
+    db.replace_chunks(
+        &current_owner,
+        "note",
+        &[chunk("note:current:0", &current_owner, EMBEDDING_PROFILE)],
+    )
+    .expect("current chunk");
+    db.replace_chunks(
+        &foreign_owner,
+        "note",
+        &[chunk("note:foreign:0", &foreign_owner, EMBEDDING_PROFILE)],
+    )
+    .expect("foreign seed");
+    db.conn()
+        .execute(
+            "UPDATE chunks SET embed_profile = ?1 WHERE id = ?2",
+            ["legacy:other-model:512", "note:foreign:0"],
+        )
+        .expect("force foreign profile");
+
+    assert_eq!(purge_stale_embeddings(&db).expect("purge"), 1);
+    assert_eq!(
+        db.count_chunks_for_owner(&current_owner, "note")
+            .expect("current count"),
+        1
+    );
+    assert_eq!(
+        db.count_chunks_for_owner(&foreign_owner, "note")
+            .expect("foreign count"),
+        0
+    );
+    assert_eq!(purge_stale_embeddings(&db).expect("second purge"), 0);
+}
+
+#[test]
+fn sync_applies_note_but_skips_foreign_profile_chunk() {
+    let (db_a, _dir_a) = open_db();
+    let (db_b, _dir_b) = open_db();
+    let host_device_id = pair(&db_a, &db_b);
+    let note_id = make_note(&db_a);
+    db_a.replace_chunks(
+        &note_id,
+        "note",
+        &[chunk(
+            "note:foreign-sync:0",
+            &note_id,
+            "legacy:other-model:512",
+        )],
+    )
+    .expect("foreign chunk");
+
+    sync_once(&db_a, &db_b, &host_device_id);
+
+    assert!(db_b.get_note(&note_id).expect("note query").is_some());
+    assert_eq!(
+        db_b.count_chunks_for_owner(&note_id, "note")
+            .expect("chunk count"),
+        0
+    );
+}
+
+#[test]
+fn legacy_payload_without_profile_uses_current_profile() {
+    let (db, _dir) = open_db();
+    let vector_b64 =
+        URL_SAFE_NO_PAD.encode(vector_to_blob(&vec![0.5; EMBEDDING_DIMS]));
+    let chunks = serde_json::json!([{
+        "id": "note:legacy:0",
+        "chunk_index": 0,
+        "vector_b64": vector_b64,
+        "content_hash": "hash",
+        "chunk_text": "legacy chunk",
+        "title": "title",
+        "tags": "[]",
+        "created_at": "2026-09-02T00:00:00.000Z"
+    }]);
+    let conn = db.conn();
+
+    protocol::apply_chunks_for_test(
+        &conn,
+        "legacy-owner",
+        "note",
+        &chunks.to_string(),
+    )
+    .expect("apply legacy payload");
+    drop(conn);
+
+    let rows = db
+        .chunks_for_owner("legacy-owner", "note")
+        .expect("legacy chunks");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].embed_profile, EMBEDDING_PROFILE);
+}

--- a/tests/llm_provider_test.rs
+++ b/tests/llm_provider_test.rs
@@ -1,3 +1,4 @@
+use flowflow::application::constants::CHEAP_MODEL;
 use flowflow::application::error::LlmError;
 use flowflow::infrastructure::persistence::Database;
 use flowflow::infrastructure::{LlmClient, Provider};
@@ -13,14 +14,18 @@ struct OpenAiEnv {
 }
 
 impl OpenAiEnv {
-    fn without_key() -> Self {
+    fn with_env(value: &str) -> Self {
         let lock = OPENAI_ENV_LOCK.lock().expect("OpenAI env lock");
         let previous = std::env::var_os("OPENAI_API_KEY");
-        std::env::set_var("OPENAI_API_KEY", "");
+        std::env::set_var("OPENAI_API_KEY", value);
         Self {
             previous,
             _lock: lock,
         }
+    }
+
+    fn without_key() -> Self {
+        Self::with_env("")
     }
 }
 
@@ -65,6 +70,7 @@ async fn chatgpt_mode_allows_chat_without_openai_key_but_not_embeddings() {
     let client = LlmClient::from_db(&db).expect("build ChatGPT client");
     assert_eq!(client.provider(), Provider::ChatGpt);
     assert_eq!(client.chat_model_name(), "gpt-5.6-terra");
+    assert_eq!(client.effective_model(CHEAP_MODEL), "gpt-5.6-terra");
 
     match client.embed("test").await {
         Err(LlmError::NotConfigured(message)) => {
@@ -87,4 +93,15 @@ fn openai_mode_still_requires_openai_key() {
         }
         _ => panic!("OpenAI mode must reject a missing key"),
     }
+}
+
+#[test]
+fn openai_mode_reports_requested_models_as_effective() {
+    let _env = OpenAiEnv::with_env("sk-test");
+    let (db, _dir) = open_test_db();
+
+    let client = LlmClient::from_db(&db).expect("build OpenAI client");
+    assert_eq!(client.provider(), Provider::OpenAi);
+    assert_eq!(client.effective_model(CHEAP_MODEL), "gpt-5.4-nano");
+    assert_eq!(client.chat_model_name(), "gpt-5.4-mini");
 }

--- a/tests/reconcile_test.rs
+++ b/tests/reconcile_test.rs
@@ -50,6 +50,8 @@ fn det_record(owner_id: &str, kind: &str, id: &str, idx: i32) -> ChunkRecord {
         owner_id: owner_id.to_string(),
         owner_kind: kind.to_string(),
         chunk_index: idx,
+        embed_profile: flowflow::application::constants::EMBEDDING_PROFILE
+            .to_string(),
         vector: vec_dims(idx as usize),
         content_hash: "h".to_string(),
         chunk_text: format!("text {idx}"),

--- a/tests/space_schema_test.rs
+++ b/tests/space_schema_test.rs
@@ -17,9 +17,10 @@ fn table_columns(db: &Database, table: &str) -> Vec<String> {
     rows.map(Result::unwrap).collect()
 }
 
-// Rewind to schema 25: drop the V26/V27 columns and tables, forget the record,
-// so the next open re-runs both against a realistic pre-upgrade file. Same shape as
-// the V23 rewind in author_device_test.
+// Rewind to schema 25: remove every later schema change and migration record.
+// The next open then runs all pending migrations against a real V25 shape.
+// Same pattern as the V22 rewind in author_device_test.
+
 fn rewind_to_v25(db: &Database) {
     let conn = db.conn();
     conn.execute_batch(
@@ -36,6 +37,7 @@ fn rewind_to_v25(db: &Database) {
          DROP TABLE spaces;
          DROP TABLE pending_purge;
          DROP TABLE space_publish_pending;
+         ALTER TABLE chunks DROP COLUMN embed_profile;
          DELETE FROM _migrations WHERE version >= 26;",
     )
     .unwrap();
@@ -79,7 +81,7 @@ fn v26_and_v27_apply_on_a_v25_file() {
         .conn()
         .query_row("SELECT MAX(version) FROM _migrations", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(head, 27);
+    assert_eq!(head, 28);
 }
 
 #[test]

--- a/tests/sync_conflict_test.rs
+++ b/tests/sync_conflict_test.rs
@@ -66,6 +66,8 @@ fn seed_chunks(db: &Database, note_id: &str, fill: f32) {
             owner_id: note_id.to_string(),
             owner_kind: "note".to_string(),
             chunk_index: i,
+            embed_profile: flowflow::application::constants::EMBEDDING_PROFILE
+                .to_string(),
             vector: vec![fill; 1536],
             content_hash: format!("hash-{fill}-{i}"),
             chunk_text: format!("chunk {fill} {i}"),

--- a/tests/sync_protocol_test.rs
+++ b/tests/sync_protocol_test.rs
@@ -230,6 +230,8 @@ fn seed_chunks(db: &Database, owner_id: &str, owner_kind: &str) {
             owner_id: owner_id.to_string(),
             owner_kind: owner_kind.to_string(),
             chunk_index: i,
+            embed_profile: flowflow::application::constants::EMBEDDING_PROFILE
+                .to_string(),
             vector: vec![0.5; 1536],
             content_hash: format!("hash-{i}"),
             chunk_text: format!("chunk text {i}"),


### PR DESCRIPTION
## Summary

- Persist an embedding profile (openai:text-embedding-3-small:1536) on
  every chunk (V28 migration) so vectors carry provenance.
- Sync guard: chunks from a foreign embedding profile are skipped on
  apply and reconcile instead of poisoning the local index.
- Startup purge: stale-profile chunks are deleted and their notes and
  attachments re-embedded automatically.
- RAG trace now records the model actually executed per step (ChatGPT
  subscription runs gpt-5.6-terra for prep/temporal/judge/agent), and
  the trace accordion no longer truncates long model ids.

## Testing

- make check clean (3 pre-existing warnings only).
- cargo test: 743 passed, 12 ignored (91 suites), incl. new
  embedding_profile_test (4 tests) and extended llm_provider_test.
- Installed on physical iPhone: migration, re-indexing, and per-step
  effective models verified in the debug trace by Mirko.